### PR TITLE
chore: add idocs/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ uv.lock
 
 # Soul files (don't commit user souls)
 *.soul
+
+# Internal docs (not for public repo)
+idocs/


### PR DESCRIPTION
## Summary
- Adds `idocs/` to `.gitignore` so internal documentation stays out of the public repo
- The `idocs/` folder contains preparation notes, technical deep-dives, and FAQ responses for internal use

## Test plan
- [x] Verify `idocs/` contents are not tracked by git