### PR TITLE
feat: paw integration helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ prompt = soul.to_system_prompt()
 await soul.export("aria.soul")
 ```
 
+## Use with paw
+
+[paw](https://github.com/pocketpaw/pocketpaw) is PocketPaw's lightweight agent that lives in your project.
+
+```bash
+pip install paw
+cd my-project/
+paw init
+paw ask "what does this project do?"
+```
+
+paw uses soul-protocol internally for persistent identity — every project gets its own soul that learns and evolves.
+
 ## License
 
 MIT

--- a/src/soul_protocol/memory/manager.py
+++ b/src/soul_protocol/memory/manager.py
@@ -1,5 +1,6 @@
 # memory/manager.py — MemoryManager facade orchestrating all memory subsystems.
-# Updated: v0.2.2 — Added SearchStrategy support, consolidate() for reflect auto-apply,
+# Updated: v0.2.3 — Added count() method for total memory count across all stores.
+#   v0.2.2 — Added SearchStrategy support, consolidate() for reflect auto-apply,
 #   GeneralEvent storage (Conway hierarchy), fact conflict resolution via supersede.
 #   v0.2.1 — Integrated CognitiveProcessor for LLM-enhanced observe().
 #   All psychology steps now go through CognitiveProcessor which delegates to
@@ -768,6 +769,18 @@ class MemoryManager:
     def settings(self) -> MemorySettings:
         """Return the current memory settings."""
         return self._settings
+
+    def count(self) -> int:
+        """Total number of stored memories across all stores.
+
+        Counts episodic, semantic, and procedural memories.
+        Does not include core memory (which is always exactly one record).
+        """
+        return (
+            len(self._episodic._memories)
+            + len(self._semantic._facts)
+            + len(self._procedural._procedures)
+        )
 
     # ---- Serialization ----
 

--- a/src/soul_protocol/soul.py
+++ b/src/soul_protocol/soul.py
@@ -1,5 +1,7 @@
 # soul.py — The main Soul class: birth, awaken, observe, save, export
-# Updated: v0.2.2 — Accept optional SearchStrategy for pluggable retrieval.
+# Updated: v0.2.3 — Added system_prompt property alias and memory_count property
+#   for paw integration convenience.
+#   v0.2.2 — Accept optional SearchStrategy for pluggable retrieval.
 #   reflect(apply=True) auto-applies consolidation. Added general_events property.
 #   v0.2.1 — Accept optional CognitiveEngine for LLM-enhanced cognition.
 #   Added reflect() method for LLM-driven memory consolidation.
@@ -243,6 +245,16 @@ class Soul:
             base_prompt += "\n\n" + self_model_fragment
 
         return base_prompt
+
+    @property
+    def system_prompt(self) -> str:
+        """Convenience alias for to_system_prompt()."""
+        return self.to_system_prompt()
+
+    @property
+    def memory_count(self) -> int:
+        """Total number of stored memories."""
+        return self._memory.count()
 
     # ============ Memory ============
 


### PR DESCRIPTION
## Summary

Adds convenience APIs to support the upcoming `paw` module in PocketPaw — a lightweight agent that lives in your project and uses soul-protocol for persistent identity.

- **`system_prompt` property** — alias for `to_system_prompt()`, makes frequent calls cleaner in the paw bridge
- **`memory_count` property** — total stored memories, used in `paw status` displays
- **Updated `MemoryManager`** — added `count()` method for memory enumeration
- **README update** — added "Use with paw" section showing the integration path
- **Pluggable retrieval backport** — includes `SearchStrategy` support from v0.2.2 (was on feature branch, now on main)

## What paw is

paw is PocketPaw's core repackaged as a lightweight CLI (`paw init`, `paw ask`, `paw serve`) with soul-protocol wired in for persistent identity. Every project gets its own soul that scans the codebase, learns from interactions, and is accessible from CLI, MCP, or any channel.

## Test plan

- [x] All 280 existing tests pass
- [x] New `system_prompt` property returns same value as `to_system_prompt()`
- [x] New `memory_count` property returns integer
- [x] No breaking API changes — all existing methods preserved