### PR TITLE
fix: proper error handling for awaken(), export(), retire()

### DIFF
--- a/src/soul_protocol/__init__.py
+++ b/src/soul_protocol/__init__.py
@@ -1,5 +1,6 @@
 # __init__.py — Public API for the soul-protocol package
-# Updated: v0.2.2 — Added SearchStrategy, TokenOverlapStrategy exports. Bumped version.
+# Updated: v0.3.2 — Added exception classes to public exports.
+#   v0.2.2 — Added SearchStrategy, TokenOverlapStrategy exports. Bumped version.
 #   v0.2.1 — Added CognitiveEngine, HeuristicEngine, ReflectionResult exports.
 #   v0.2.0 — Added psychology types (SomaticMarker, SignificanceScore,
 #   GeneralEvent, SelfImage) to public exports.
@@ -7,6 +8,13 @@
 from __future__ import annotations
 
 from .cognitive.engine import CognitiveEngine, HeuristicEngine
+from .exceptions import (
+    SoulCorruptError,
+    SoulExportError,
+    SoulFileNotFoundError,
+    SoulProtocolError,
+    SoulRetireError,
+)
 from .memory.strategy import SearchStrategy, TokenOverlapStrategy
 from .soul import Soul
 from .types import (
@@ -39,6 +47,12 @@ __all__ = [
     "Soul",
     "CognitiveEngine",
     "HeuristicEngine",
+    # v0.3.2 exceptions
+    "SoulProtocolError",
+    "SoulFileNotFoundError",
+    "SoulCorruptError",
+    "SoulExportError",
+    "SoulRetireError",
     # v0.2.2 pluggable retrieval
     "SearchStrategy",
     "TokenOverlapStrategy",

--- a/src/soul_protocol/exceptions.py
+++ b/src/soul_protocol/exceptions.py
@@ -1,0 +1,45 @@
+# exceptions.py — Custom exception classes for soul-protocol.
+# Created: v0.3.2 — SoulFileNotFoundError, SoulCorruptError, SoulExportError,
+#   SoulRetireError for proper error handling in awaken(), export(), retire().
+
+from __future__ import annotations
+
+
+class SoulProtocolError(Exception):
+    """Base exception for all soul-protocol errors."""
+
+
+class SoulFileNotFoundError(SoulProtocolError):
+    """Raised when a soul file does not exist at the given path."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        super().__init__(f"No soul file at {path}")
+
+
+class SoulCorruptError(SoulProtocolError):
+    """Raised when a .soul archive is invalid or corrupted."""
+
+    def __init__(self, path: str, reason: str = "") -> None:
+        self.path = path
+        self.reason = reason
+        detail = f" — {reason}" if reason else ""
+        super().__init__(f"Invalid .soul archive at {path}{detail}")
+
+
+class SoulExportError(SoulProtocolError):
+    """Raised when exporting a soul fails (disk full, permissions, etc.)."""
+
+    def __init__(self, path: str, reason: str = "") -> None:
+        self.path = path
+        self.reason = reason
+        detail = f" — {reason}" if reason else ""
+        super().__init__(f"Failed to export soul to {path}{detail}")
+
+
+class SoulRetireError(SoulProtocolError):
+    """Raised when retiring a soul fails because memory preservation failed."""
+
+    def __init__(self, reason: str = "") -> None:
+        self.reason = reason
+        super().__init__(f"Cannot retire soul: failed to save memories — {reason}")

--- a/src/soul_protocol/soul.py
+++ b/src/soul_protocol/soul.py
@@ -1,4 +1,7 @@
 # soul.py — The main Soul class: birth, awaken, observe, save, export
+# Updated: v0.3.2 — Added proper error handling for awaken(), export(), retire().
+#   Custom exceptions: SoulFileNotFoundError, SoulCorruptError, SoulExportError,
+#   SoulRetireError. retire() now fails before lifecycle change if save fails.
 # Updated: v0.3.1 — Wired seed_domains through Soul.__init__() → MemoryManager
 #   → SelfModelManager. Custom seed domains now replace default bootstrapping.
 # Updated: v0.3.0 — Expanded birth() with ocean, communication, biorhythms,
@@ -249,31 +252,46 @@ class Soul:
             engine: Optional CognitiveEngine for LLM-enhanced cognition.
             search_strategy: Optional SearchStrategy for pluggable retrieval (v0.2.2).
         """
+        from .exceptions import SoulCorruptError, SoulFileNotFoundError
+
         memory_data: dict = {}
 
         if isinstance(source, bytes):
-            config, memory_data = await unpack_soul(source)
+            try:
+                config, memory_data = await unpack_soul(source)
+            except Exception as e:
+                raise SoulCorruptError("<bytes>", str(e)) from e
         else:
             path = Path(source)
-            if path.suffix == ".soul":
-                config, memory_data = await unpack_soul(path.read_bytes())
-            elif path.suffix == ".json":
-                config = SoulConfig.model_validate_json(path.read_text())
-            elif path.suffix in (".yaml", ".yml"):
-                import yaml
+            if not path.exists():
+                raise SoulFileNotFoundError(str(path))
+            try:
+                if path.suffix == ".soul":
+                    try:
+                        config, memory_data = await unpack_soul(path.read_bytes())
+                    except (KeyError, Exception) as e:
+                        raise SoulCorruptError(str(path), str(e)) from e
+                elif path.suffix == ".json":
+                    config = SoulConfig.model_validate_json(path.read_text())
+                elif path.suffix in (".yaml", ".yml"):
+                    import yaml
 
-                data = yaml.safe_load(path.read_text())
-                config = SoulConfig.model_validate(data)
-            elif path.suffix == ".md":
-                from .parsers.markdown import soul_from_md
+                    data = yaml.safe_load(path.read_text())
+                    config = SoulConfig.model_validate(data)
+                elif path.suffix == ".md":
+                    from .parsers.markdown import soul_from_md
 
-                return cls(
-                    await soul_from_md(path.read_text()),
-                    engine=engine,
-                    search_strategy=search_strategy,
-                )
-            else:
-                raise ValueError(f"Unknown soul format: {path.suffix}")
+                    return cls(
+                        await soul_from_md(path.read_text()),
+                        engine=engine,
+                        search_strategy=search_strategy,
+                    )
+                else:
+                    raise ValueError(f"Unknown soul format: {path.suffix}")
+            except (SoulFileNotFoundError, SoulCorruptError):
+                raise
+            except PermissionError as e:
+                raise SoulFileNotFoundError(str(path)) from e
 
         soul = cls(config, engine=engine, search_strategy=search_strategy)
         soul._lifecycle = LifecycleState.ACTIVE
@@ -546,16 +564,33 @@ class Soul:
 
     async def export(self, path: str | Path) -> None:
         """Export soul as a portable .soul file with full memory data."""
-        memory_data = self._memory.to_dict()
-        data = await pack_soul(self.serialize(), memory_data=memory_data)
-        Path(path).write_bytes(data)
+        from .exceptions import SoulExportError
+
+        try:
+            memory_data = self._memory.to_dict()
+            data = await pack_soul(self.serialize(), memory_data=memory_data)
+            Path(path).write_bytes(data)
+        except PermissionError as e:
+            raise SoulExportError(str(path), f"permission denied") from e
+        except OSError as e:
+            raise SoulExportError(str(path), str(e)) from e
 
     async def retire(
         self, *, farewell: bool = False, preserve_memories: bool = True
     ) -> None:
-        """Retire this soul with dignity."""
+        """Retire this soul with dignity.
+
+        If preserve_memories is True (default), saves all memories before
+        retiring. If the save fails, the soul remains in its current
+        lifecycle state and a SoulRetireError is raised.
+        """
         if preserve_memories:
-            await self.save()
+            from .exceptions import SoulRetireError
+
+            try:
+                await self.save()
+            except Exception as e:
+                raise SoulRetireError(str(e)) from e
 
         self._lifecycle = LifecycleState.RETIRED
         await self._memory.clear()

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,217 @@
+# test_error_handling.py — Tests for proper error handling in awaken(), export(), retire().
+# Created: v0.3.2 — Covers SoulFileNotFoundError, SoulCorruptError,
+#   SoulExportError, SoulRetireError.
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from soul_protocol import Soul
+from soul_protocol.exceptions import (
+    SoulCorruptError,
+    SoulExportError,
+    SoulFileNotFoundError,
+    SoulRetireError,
+)
+
+
+# ============ awaken() error handling ============
+
+
+class TestAwakenErrors:
+    """Test that awaken() raises descriptive errors instead of raw exceptions."""
+
+    @pytest.mark.asyncio
+    async def test_awaken_nonexistent_file_raises_soul_file_not_found(self):
+        with pytest.raises(SoulFileNotFoundError, match="No soul file at"):
+            await Soul.awaken("/tmp/does_not_exist_12345.soul")
+
+    @pytest.mark.asyncio
+    async def test_awaken_nonexistent_json_raises_soul_file_not_found(self):
+        with pytest.raises(SoulFileNotFoundError, match="No soul file at"):
+            await Soul.awaken("/tmp/does_not_exist_12345.json")
+
+    @pytest.mark.asyncio
+    async def test_awaken_corrupt_soul_file_raises_soul_corrupt(self):
+        """A .soul file with invalid content should raise SoulCorruptError."""
+        with tempfile.NamedTemporaryFile(suffix=".soul", delete=False) as f:
+            f.write(b"this is not a zip archive")
+            f.flush()
+            try:
+                with pytest.raises(SoulCorruptError, match="Invalid .soul archive"):
+                    await Soul.awaken(f.name)
+            finally:
+                os.unlink(f.name)
+
+    @pytest.mark.asyncio
+    async def test_awaken_corrupt_bytes_raises_soul_corrupt(self):
+        """Raw bytes that aren't a valid .soul archive should raise SoulCorruptError."""
+        with pytest.raises(SoulCorruptError):
+            await Soul.awaken(b"not a valid archive")
+
+    @pytest.mark.asyncio
+    async def test_awaken_error_includes_path(self):
+        """Error message should include the file path for debugging."""
+        path = "/tmp/nonexistent_soul_test.soul"
+        with pytest.raises(SoulFileNotFoundError) as exc_info:
+            await Soul.awaken(path)
+        assert path in str(exc_info.value)
+        assert exc_info.value.path == path
+
+    @pytest.mark.asyncio
+    async def test_awaken_unknown_format_still_raises_value_error(self):
+        """Unknown file extensions should still raise ValueError."""
+        with tempfile.NamedTemporaryFile(suffix=".xyz", delete=False) as f:
+            f.write(b"data")
+            f.flush()
+            try:
+                with pytest.raises(ValueError, match="Unknown soul format"):
+                    await Soul.awaken(f.name)
+            finally:
+                os.unlink(f.name)
+
+
+# ============ export() error handling ============
+
+
+class TestExportErrors:
+    """Test that export() raises SoulExportError on I/O failures."""
+
+    @pytest.mark.asyncio
+    async def test_export_to_readonly_dir_raises_soul_export_error(self):
+        """Exporting to a read-only directory should raise SoulExportError."""
+        soul = await Soul.birth(name="ExportTest")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chmod(tmpdir, 0o444)
+            try:
+                export_path = os.path.join(tmpdir, "test.soul")
+                with pytest.raises(SoulExportError, match="permission denied"):
+                    await soul.export(export_path)
+            finally:
+                os.chmod(tmpdir, 0o755)
+
+    @pytest.mark.asyncio
+    async def test_export_error_includes_path(self):
+        """SoulExportError should include the target path."""
+        soul = await Soul.birth(name="ExportTest")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chmod(tmpdir, 0o444)
+            try:
+                export_path = os.path.join(tmpdir, "test.soul")
+                with pytest.raises(SoulExportError) as exc_info:
+                    await soul.export(export_path)
+                assert export_path in str(exc_info.value)
+                assert exc_info.value.path == export_path
+            finally:
+                os.chmod(tmpdir, 0o755)
+
+    @pytest.mark.asyncio
+    async def test_export_success_still_works(self):
+        """Normal export should still work without errors."""
+        soul = await Soul.birth(name="ExportTest")
+        with tempfile.NamedTemporaryFile(suffix=".soul", delete=False) as f:
+            try:
+                await soul.export(f.name)
+                assert os.path.getsize(f.name) > 0
+            finally:
+                os.unlink(f.name)
+
+
+# ============ retire() error handling ============
+
+
+class TestRetireErrors:
+    """Test that retire() fails before lifecycle change if save fails."""
+
+    @pytest.mark.asyncio
+    async def test_retire_raises_if_save_fails(self):
+        """retire(preserve_memories=True) should raise SoulRetireError if save fails."""
+        soul = await Soul.birth(name="RetireTest")
+
+        with patch.object(soul, "save", new_callable=AsyncMock) as mock_save:
+            mock_save.side_effect = OSError("disk full")
+            with pytest.raises(SoulRetireError, match="disk full"):
+                await soul.retire(preserve_memories=True)
+
+    @pytest.mark.asyncio
+    async def test_retire_keeps_lifecycle_on_save_failure(self):
+        """If save fails, the soul should stay ACTIVE, not become RETIRED."""
+        soul = await Soul.birth(name="RetireTest")
+        from soul_protocol.types import LifecycleState
+
+        assert soul.lifecycle == LifecycleState.ACTIVE
+
+        with patch.object(soul, "save", new_callable=AsyncMock) as mock_save:
+            mock_save.side_effect = OSError("disk full")
+            with pytest.raises(SoulRetireError):
+                await soul.retire(preserve_memories=True)
+
+        # Soul should still be ACTIVE
+        assert soul.lifecycle == LifecycleState.ACTIVE
+
+    @pytest.mark.asyncio
+    async def test_retire_without_preserve_skips_save(self):
+        """retire(preserve_memories=False) should not attempt save."""
+        soul = await Soul.birth(name="RetireTest")
+        from soul_protocol.types import LifecycleState
+
+        with patch.object(soul, "save", new_callable=AsyncMock) as mock_save:
+            await soul.retire(preserve_memories=False)
+            mock_save.assert_not_called()
+
+        assert soul.lifecycle == LifecycleState.RETIRED
+
+    @pytest.mark.asyncio
+    async def test_retire_success_still_works(self):
+        """Normal retire with save should work."""
+        soul = await Soul.birth(name="RetireTest")
+        from soul_protocol.types import LifecycleState
+
+        with patch.object(soul, "save", new_callable=AsyncMock) as mock_save:
+            await soul.retire(preserve_memories=True)
+            mock_save.assert_called_once()
+
+        assert soul.lifecycle == LifecycleState.RETIRED
+
+
+# ============ Exception class tests ============
+
+
+class TestExceptionClasses:
+    """Test exception class attributes and inheritance."""
+
+    def test_soul_file_not_found_has_path(self):
+        e = SoulFileNotFoundError("/tmp/test.soul")
+        assert e.path == "/tmp/test.soul"
+        assert "No soul file" in str(e)
+
+    def test_soul_corrupt_has_path_and_reason(self):
+        e = SoulCorruptError("/tmp/test.soul", "missing soul.json")
+        assert e.path == "/tmp/test.soul"
+        assert e.reason == "missing soul.json"
+        assert "missing soul.json" in str(e)
+
+    def test_soul_export_has_path_and_reason(self):
+        e = SoulExportError("/tmp/test.soul", "permission denied")
+        assert e.path == "/tmp/test.soul"
+        assert "permission denied" in str(e)
+
+    def test_soul_retire_has_reason(self):
+        e = SoulRetireError("disk full")
+        assert e.reason == "disk full"
+        assert "disk full" in str(e)
+
+    def test_all_exceptions_inherit_from_base(self):
+        from soul_protocol.exceptions import SoulProtocolError
+
+        assert issubclass(SoulFileNotFoundError, SoulProtocolError)
+        assert issubclass(SoulCorruptError, SoulProtocolError)
+        assert issubclass(SoulExportError, SoulProtocolError)
+        assert issubclass(SoulRetireError, SoulProtocolError)


### PR DESCRIPTION
## Summary

- Custom exception classes for all file I/O operations — no more raw Python tracebacks
- `retire()` now fails before lifecycle change if memory save fails, preventing silent data loss
- 18 new tests covering all error paths

## What Changed

### New: `src/soul_protocol/exceptions.py`
- `SoulProtocolError` — base exception
- `SoulFileNotFoundError` — missing soul file (includes path in message)
- `SoulCorruptError` — invalid/corrupt .soul archive (includes path + reason)
- `SoulExportError` — export failure (includes path + reason)
- `SoulRetireError` — save failed during retire (includes reason)

### Fixed: `src/soul_protocol/soul.py`
- `awaken()`: checks file existence before reading, wraps archive parsing with SoulCorruptError
- `export()`: catches PermissionError/OSError, raises SoulExportError
- `retire()`: wraps save in try/except, raises SoulRetireError if save fails — soul stays ACTIVE

### Updated: `src/soul_protocol/__init__.py`
- All exception classes exported in public API

## Test Plan

- [x] 18 new tests in `tests/test_error_handling.py`
- [x] All 340 tests pass (existing + new)
- [x] Verified: awaken with missing file raises SoulFileNotFoundError
- [x] Verified: awaken with corrupt archive raises SoulCorruptError
- [x] Verified: export to read-only dir raises SoulExportError
- [x] Verified: retire keeps ACTIVE state if save fails

Closes #12, Closes #13