### PR TITLE
fix: MCP lifespan catches SoulProtocolError on bad SOUL_PATH

### DIFF
--- a/src/soul_protocol/mcp/server.py
+++ b/src/soul_protocol/mcp/server.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from fastmcp import FastMCP  # optional dep: pip install soul-protocol[mcp]
 
+from ..exceptions import SoulProtocolError
 from ..soul import Soul
 from ..types import Interaction, MemoryType, Mood
 
@@ -37,7 +38,7 @@ async def _lifespan(server: FastMCP):
         _soul_path = path
         try:
             _soul = await Soul.awaken(path)
-        except (FileNotFoundError, ValueError) as e:
+        except (FileNotFoundError, ValueError, SoulProtocolError) as e:
             import sys
             print(
                 f"soul-mcp: failed to load SOUL_PATH={path!r}: {e}",


### PR DESCRIPTION
## Summary

One-line fix: the MCP server lifespan caught `(FileNotFoundError, ValueError)` but PR #17 changed `awaken()` to raise `SoulFileNotFoundError` (inherits from `SoulProtocolError`, not `FileNotFoundError`). This caused the server to crash on startup with a bad `SOUL_PATH` instead of degrading gracefully.

## Fix

Added `SoulProtocolError` to the except clause in `_lifespan()`.

## Test Plan

- [x] `test_lifespan_handles_bad_path` passes
- [x] All 404 tests pass