### PR TITLE
ci: make lint job blocking now that errors are fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # CI — lint and test on every PR and push to main.
-# Updated: 2026-03-05 — Fix: install all extras so MCP tests can import fastmcp.
+# Updated: 2026-03-05 — Lint errors fixed, lint job now blocks PRs.
 name: CI
 
 on:
@@ -14,8 +14,6 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    # TODO: remove continue-on-error once pre-existing lint errors are fixed
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Removes continue-on-error from the lint job. All 523 lint errors were fixed in #30, so lint should now block PRs that introduce new violations.