### PR TITLE
feat: Bond, Skills/XP, Reincarnation, dna.md unpacking

### DIFF
--- a/src/soul_protocol/__init__.py
+++ b/src/soul_protocol/__init__.py
@@ -1,5 +1,6 @@
 # __init__.py — Public API for the soul-protocol package
-# Updated: v0.3.2 — Added exception classes to public exports.
+# Updated: Added Bond, Skill, SkillRegistry exports for soul primitives.
+#   v0.3.2 — Added exception classes to public exports.
 #   v0.2.2 — Added SearchStrategy, TokenOverlapStrategy exports. Bumped version.
 #   v0.2.1 — Added CognitiveEngine, HeuristicEngine, ReflectionResult exports.
 #   v0.2.0 — Added psychology types (SomaticMarker, SignificanceScore,
@@ -7,6 +8,7 @@
 
 from __future__ import annotations
 
+from .bond import Bond
 from .cognitive.engine import CognitiveEngine, HeuristicEngine
 from .exceptions import (
     SoulCorruptError,
@@ -16,6 +18,7 @@ from .exceptions import (
     SoulRetireError,
 )
 from .memory.strategy import SearchStrategy, TokenOverlapStrategy
+from .skills import Skill, SkillRegistry
 from .soul import Soul
 from .types import (
     DNA,
@@ -44,6 +47,9 @@ from .types import (
 )
 
 __all__ = [
+    "Bond",
+    "Skill",
+    "SkillRegistry",
     "Soul",
     "CognitiveEngine",
     "HeuristicEngine",

--- a/src/soul_protocol/bond.py
+++ b/src/soul_protocol/bond.py
@@ -1,0 +1,27 @@
+# Engine-level module — opinionated bond mechanics. Not part of the core protocol.
+# bond.py — Human-Soul Bond model for tracking relationship strength
+# Created: 2026-03-06 — Implements Bond model with strengthen/weaken mechanics
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class Bond(BaseModel):
+    """The relationship between a human and their soul."""
+
+    bonded_to: str = ""  # Human's DID or identifier
+    bonded_at: datetime = Field(default_factory=datetime.now)
+    bond_strength: float = Field(default=50.0, ge=0, le=100)  # 0-100, evolves over time
+    interaction_count: int = 0
+
+    def strengthen(self, amount: float = 1.0) -> None:
+        """Strengthen the bond (called after positive interactions)."""
+        self.bond_strength = min(100.0, self.bond_strength + amount)
+        self.interaction_count += 1
+
+    def weaken(self, amount: float = 0.5) -> None:
+        """Weaken bond (time decay or negative interactions)."""
+        self.bond_strength = max(0.0, self.bond_strength - amount)

--- a/src/soul_protocol/export/unpack.py
+++ b/src/soul_protocol/export/unpack.py
@@ -1,5 +1,6 @@
 # export/unpack.py — Load a SoulConfig from a .soul zip archive.
-# Updated: v0.2.2 — Added general_events.json to memory tier extraction.
+# Updated: Added dna.md reading from archive into memory_data["dna_md"].
+#   v0.2.2 — Added general_events.json to memory tier extraction.
 #   v0.2.0 — Added self_model.json to memory tier extraction.
 #   Returns full memory data including self_model alongside the config.
 
@@ -52,6 +53,10 @@ async def unpack_soul(data: bytes) -> tuple[SoulConfig, dict]:
             mem_path = f"memory/{tier_name}.json"
             if mem_path in zf.namelist():
                 memory_data[tier_name] = json.loads(zf.read(mem_path))
+
+        # Read dna.md if present (human-readable personality snapshot)
+        if "dna.md" in zf.namelist():
+            memory_data["dna_md"] = zf.read("dna.md").decode("utf-8")
 
     config = SoulConfig.model_validate(payload)
     return config, memory_data

--- a/src/soul_protocol/skills.py
+++ b/src/soul_protocol/skills.py
@@ -1,0 +1,51 @@
+# Engine-level module — opinionated XP/leveling system. Not part of the core protocol.
+# skills.py — Skills/XP progression system for souls
+# Created: 2026-03-06 — Implements Skill and SkillRegistry with XP/leveling
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class Skill(BaseModel):
+    """A learned ability with XP progression."""
+
+    id: str
+    name: str
+    level: int = Field(default=1, ge=1, le=10)
+    xp: int = Field(default=0, ge=0)
+    xp_to_next: int = 100  # XP needed for next level
+    config: dict = Field(default_factory=dict)
+    last_used: datetime = Field(default_factory=datetime.now)
+
+    def add_xp(self, amount: int) -> bool:
+        """Add XP. Returns True if leveled up."""
+        self.xp += amount
+        self.last_used = datetime.now()
+        if self.xp >= self.xp_to_next and self.level < 10:
+            self.xp -= self.xp_to_next
+            self.level += 1
+            self.xp_to_next = int(self.xp_to_next * 1.5)  # Exponential scaling
+            return True
+        return False
+
+
+class SkillRegistry(BaseModel):
+    """Collection of skills for a soul."""
+
+    skills: list[Skill] = Field(default_factory=list)
+
+    def get(self, skill_id: str) -> Skill | None:
+        return next((s for s in self.skills if s.id == skill_id), None)
+
+    def add(self, skill: Skill) -> None:
+        if not self.get(skill.id):
+            self.skills.append(skill)
+
+    def grant_xp(self, skill_id: str, amount: int) -> bool:
+        skill = self.get(skill_id)
+        if skill:
+            return skill.add_xp(amount)
+        return False

--- a/src/soul_protocol/soul.py
+++ b/src/soul_protocol/soul.py
@@ -1,4 +1,6 @@
 # soul.py — The main Soul class: birth, awaken, observe, save, export
+# Updated: Added reincarnate() classmethod for lifecycle rebirth.
+#   Preserves memories, personality, and tracks incarnation lineage.
 # Updated: v0.3.2 — Added proper error handling for awaken(), export(), retire().
 #   Custom exceptions: SoulFileNotFoundError, SoulCorruptError, SoulExportError,
 #   SoulRetireError. retire() now fails before lifecycle change if save fails.
@@ -231,6 +233,67 @@ class Soul:
             engine=engine,
             **data,
         )
+
+    @classmethod
+    async def reincarnate(
+        cls,
+        old_soul: Soul,
+        *,
+        name: str | None = None,
+    ) -> Soul:
+        """Create a new Soul from an existing soul's essence.
+
+        Preserves memories, personality (DNA), and core values from the
+        previous life. Generates a new DID and increments the incarnation
+        counter. The old soul's DID is recorded in ``previous_lives``.
+
+        Args:
+            old_soul: The soul to reincarnate from.
+            name: Optional new name. Defaults to the old soul's name.
+
+        Returns:
+            A fresh Soul carrying forward the old soul's essence.
+        """
+        new_name = name or old_soul.name
+        old_identity = old_soul.identity
+
+        # Build lineage
+        previous_lives = list(old_identity.previous_lives)
+        previous_lives.append(old_soul.did)
+
+        # born intentionally reset — new incarnation begins fresh
+        identity = Identity(
+            did=generate_did(new_name),
+            name=new_name,
+            archetype=old_identity.archetype,
+            origin_story=old_identity.origin_story,
+            core_values=list(old_identity.core_values),
+            bonded_to=old_identity.bonded_to,
+            bond=old_identity.bond.model_copy(),
+            incarnation=old_identity.incarnation + 1,
+            previous_lives=previous_lives,
+        )
+
+        config = SoulConfig(
+            identity=identity,
+            dna=old_soul.dna.model_copy(deep=True),
+            core_memory=old_soul.get_core_memory().model_copy(),
+            evolution=old_soul._evolution.config.model_copy(deep=True),
+            lifecycle=LifecycleState.ACTIVE,
+        )
+
+        soul = cls(config)
+
+        # Carry forward memories from the old soul
+        memory_data = old_soul._memory.to_dict()
+        if memory_data:
+            soul._memory = MemoryManager.from_dict(
+                memory_data,
+                config.memory,
+                core_values=config.identity.core_values,
+            )
+
+        return soul
 
     @classmethod
     async def awaken(

--- a/src/soul_protocol/types.py
+++ b/src/soul_protocol/types.py
@@ -1,5 +1,6 @@
 # types.py — All Pydantic data models for the Digital Soul Protocol
-# Updated: v0.2.2 — Added superseded_by field to MemoryEntry for fact conflict resolution.
+# Updated: Added Bond, incarnation, previous_lives to Identity for soul primitives.
+#   v0.2.2 — Added superseded_by field to MemoryEntry for fact conflict resolution.
 #   v0.2.1 — Added ReflectionResult for CognitiveEngine reflection output.
 #   v0.2.0 — Added SomaticMarker, SignificanceScore, GeneralEvent, SelfImage
 #   for psychology-informed memory. Extended MemoryEntry with somatic markers,
@@ -11,6 +12,8 @@ from datetime import datetime
 from enum import StrEnum
 
 from pydantic import BaseModel, Field
+
+from .bond import Bond
 
 # ============ Identity ============
 
@@ -26,6 +29,9 @@ class Identity(BaseModel):
     origin_story: str = ""
     prime_directive: str = ""
     core_values: list[str] = Field(default_factory=list)
+    bond: Bond = Field(default_factory=Bond)
+    incarnation: int = 1
+    previous_lives: list[str] = Field(default_factory=list)
 
 
 # ============ DNA / Personality ============

--- a/tests/test_bond.py
+++ b/tests/test_bond.py
@@ -1,0 +1,103 @@
+# test_bond.py — Tests for the Human-Soul Bond model
+# Created: 2026-03-06 — Bond creation, strengthen, weaken, bounds checking
+
+from __future__ import annotations
+
+import pytest
+
+from soul_protocol.bond import Bond
+
+
+class TestBondCreation:
+    """Tests for Bond default construction."""
+
+    def test_default_bond(self):
+        bond = Bond()
+        assert bond.bonded_to == ""
+        assert bond.bond_strength == 50.0
+        assert bond.interaction_count == 0
+
+    def test_bond_with_identifier(self):
+        bond = Bond(bonded_to="did:key:user-123")
+        assert bond.bonded_to == "did:key:user-123"
+        assert bond.bond_strength == 50.0
+
+    def test_bond_with_custom_strength(self):
+        bond = Bond(bond_strength=75.0)
+        assert bond.bond_strength == 75.0
+
+    def test_bond_bonded_at_set(self):
+        bond = Bond()
+        assert bond.bonded_at is not None
+
+
+class TestStrengthen:
+    """Tests for Bond.strengthen()."""
+
+    def test_strengthen_default(self):
+        bond = Bond(bond_strength=50.0)
+        bond.strengthen()
+        assert bond.bond_strength == 51.0
+        assert bond.interaction_count == 1
+
+    def test_strengthen_custom_amount(self):
+        bond = Bond(bond_strength=50.0)
+        bond.strengthen(10.0)
+        assert bond.bond_strength == 60.0
+        assert bond.interaction_count == 1
+
+    def test_strengthen_increments_interaction_count(self):
+        bond = Bond(bond_strength=50.0)
+        bond.strengthen()
+        bond.strengthen()
+        bond.strengthen()
+        assert bond.interaction_count == 3
+
+    def test_strengthen_caps_at_100(self):
+        bond = Bond(bond_strength=99.5)
+        bond.strengthen(5.0)
+        assert bond.bond_strength == 100.0
+
+
+class TestWeaken:
+    """Tests for Bond.weaken()."""
+
+    def test_weaken_default(self):
+        bond = Bond(bond_strength=50.0)
+        bond.weaken()
+        assert bond.bond_strength == 49.5
+
+    def test_weaken_custom_amount(self):
+        bond = Bond(bond_strength=50.0)
+        bond.weaken(10.0)
+        assert bond.bond_strength == 40.0
+
+    def test_weaken_floors_at_zero(self):
+        bond = Bond(bond_strength=0.3)
+        bond.weaken(1.0)
+        assert bond.bond_strength == 0.0
+
+    def test_weaken_does_not_change_interaction_count(self):
+        bond = Bond(bond_strength=50.0, interaction_count=5)
+        bond.weaken()
+        assert bond.interaction_count == 5
+
+
+class TestBoundsValidation:
+    """Test Pydantic validation on bond_strength bounds."""
+
+    def test_bond_strength_too_high(self):
+        with pytest.raises(Exception):
+            Bond(bond_strength=101.0)
+
+    def test_bond_strength_too_low(self):
+        with pytest.raises(Exception):
+            Bond(bond_strength=-1.0)
+
+    def test_bond_strength_at_zero(self):
+        bond = Bond(bond_strength=0.0)
+        assert bond.bond_strength == 0.0
+
+    def test_bond_strength_at_100(self):
+        bond = Bond(bond_strength=100.0)
+        assert bond.bond_strength == 100.0

--- a/tests/test_e2e_new_primitives.py
+++ b/tests/test_e2e_new_primitives.py
@@ -1,0 +1,137 @@
+# test_e2e_new_primitives.py — End-to-end lifecycle test for new soul primitives
+# Created: 2026-03-06 — Full lifecycle: birth, bond, skills, retire, reincarnate
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+from soul_protocol.export.pack import pack_soul
+from soul_protocol.export.unpack import unpack_soul
+from soul_protocol.skills import Skill, SkillRegistry
+from soul_protocol.soul import Soul
+from soul_protocol.types import (
+    Interaction,
+    LifecycleState,
+    MemoryType,
+)
+
+
+async def test_full_lifecycle():
+    """Birth -> interact -> bond -> skills -> retire -> reincarnate -> verify."""
+
+    # === Phase 1: Birth ===
+    soul = await Soul.birth(
+        "Aria",
+        archetype="The Compassionate Creator",
+        values=["empathy", "creativity"],
+    )
+    assert soul.lifecycle == LifecycleState.ACTIVE
+    assert soul.identity.incarnation == 1
+
+    # === Phase 2: Bond ===
+    soul.identity.bond.bonded_to = "did:key:prakash-001"
+    soul.identity.bond.strengthen(10.0)
+    soul.identity.bond.strengthen(5.0)
+    assert soul.identity.bond.bond_strength == 65.0
+    assert soul.identity.bond.interaction_count == 2
+
+    # === Phase 3: Interact and remember ===
+    await soul.remember(
+        "User loves building AI companions",
+        type=MemoryType.SEMANTIC,
+        importance=9,
+    )
+
+    interaction = Interaction(
+        user_input="I've been working on soul-protocol all day",
+        agent_output="That sounds like meaningful work!",
+        channel="test",
+    )
+    await soul.observe(interaction)
+
+    # Verify memory is there
+    results = await soul.recall("AI companions")
+    assert any("AI companions" in r.content for r in results)
+
+    # === Phase 4: Skills ===
+    registry = SkillRegistry()
+    registry.add(Skill(id="empathy", name="Empathy"))
+    registry.add(Skill(id="coding", name="Coding"))
+
+    # Grant XP to empathy
+    registry.grant_xp("empathy", 50)
+    registry.grant_xp("coding", 100)  # Should level up
+
+    assert registry.get("empathy").xp == 50
+    assert registry.get("empathy").level == 1
+    assert registry.get("coding").level == 2
+
+    # === Phase 5: Export and verify dna.md ===
+    config = soul.serialize()
+    memory_data = soul._memory.to_dict()
+    packed = await pack_soul(config, memory_data=memory_data)
+
+    buf = io.BytesIO(packed)
+    with zipfile.ZipFile(buf, "r") as zf:
+        assert "dna.md" in zf.namelist()
+        dna_content = zf.read("dna.md").decode("utf-8")
+        assert "Aria" in dna_content
+        assert "Personality (OCEAN)" in dna_content
+
+    # Verify unpack reads dna.md
+    restored_config, restored_memory = await unpack_soul(packed)
+    assert "dna_md" in restored_memory
+    assert "Aria" in restored_memory["dna_md"]
+
+    # === Phase 6: Save original DID, then reincarnate ===
+    original_did = soul.did
+    original_bond_strength = soul.identity.bond.bond_strength
+
+    reborn = await Soul.reincarnate(soul, name="Aria Nova")
+
+    # === Phase 7: Verify reincarnation ===
+    assert reborn.name == "Aria Nova"
+    assert reborn.did != original_did
+    assert reborn.identity.incarnation == 2
+    assert original_did in reborn.identity.previous_lives
+    assert reborn.lifecycle == LifecycleState.ACTIVE
+
+    # Personality preserved
+    assert reborn.dna.personality.openness == soul.dna.personality.openness
+
+    # Core values preserved
+    assert reborn.identity.core_values == ["empathy", "creativity"]
+
+    # Bond preserved
+    assert reborn.identity.bond.bond_strength == original_bond_strength
+    assert reborn.identity.bond.bonded_to == "did:key:prakash-001"
+
+    # Memories preserved
+    results = await reborn.recall("AI companions")
+    assert any("AI companions" in r.content for r in results)
+
+
+async def test_dna_md_in_soul_archive(tmp_path):
+    """Verify dna.md is present and readable in .soul archives."""
+    soul = await Soul.birth(
+        "Mira",
+        archetype="The Seeker",
+        personality="Curious and methodical",
+    )
+
+    soul_path = tmp_path / "mira.soul"
+    await soul.export(str(soul_path))
+
+    # Read the archive
+    with zipfile.ZipFile(str(soul_path), "r") as zf:
+        assert "dna.md" in zf.namelist()
+        content = zf.read("dna.md").decode("utf-8")
+        assert "Mira" in content
+        assert "Personality (OCEAN)" in content
+
+    # Round-trip via unpack
+    packed_bytes = soul_path.read_bytes()
+    _, memory_data = await unpack_soul(packed_bytes)
+    assert "dna_md" in memory_data
+    assert "Mira" in memory_data["dna_md"]

--- a/tests/test_reincarnation.py
+++ b/tests/test_reincarnation.py
@@ -1,0 +1,112 @@
+# test_reincarnation.py — Tests for Soul.reincarnate() lifecycle
+# Created: 2026-03-06 — Reincarnation, memory preservation, incarnation counter
+
+from __future__ import annotations
+
+import pytest
+
+from soul_protocol.soul import Soul
+from soul_protocol.types import LifecycleState, MemoryType
+
+
+async def test_basic_reincarnation():
+    """Reincarnate creates a new soul with a new DID."""
+    original = await Soul.birth("Aria", archetype="The Creator")
+    reborn = await Soul.reincarnate(original)
+
+    assert reborn.name == "Aria"
+    assert reborn.did != original.did
+    assert reborn.did.startswith("did:soul:aria-")
+    assert reborn.lifecycle == LifecycleState.ACTIVE
+
+
+async def test_reincarnation_with_new_name():
+    """Reincarnate with a new name changes the soul's name."""
+    original = await Soul.birth("Aria", archetype="The Creator")
+    reborn = await Soul.reincarnate(original, name="Nova")
+
+    assert reborn.name == "Nova"
+    assert reborn.did.startswith("did:soul:nova-")
+
+
+async def test_incarnation_counter():
+    """Each reincarnation increments the incarnation counter."""
+    soul = await Soul.birth("Aria")
+    assert soul.identity.incarnation == 1
+
+    soul2 = await Soul.reincarnate(soul)
+    assert soul2.identity.incarnation == 2
+
+    soul3 = await Soul.reincarnate(soul2)
+    assert soul3.identity.incarnation == 3
+
+
+async def test_previous_lives_tracking():
+    """Previous lives list tracks old DIDs."""
+    soul = await Soul.birth("Aria")
+    original_did = soul.did
+
+    soul2 = await Soul.reincarnate(soul)
+    assert original_did in soul2.identity.previous_lives
+    assert len(soul2.identity.previous_lives) == 1
+
+    soul3 = await Soul.reincarnate(soul2)
+    assert original_did in soul3.identity.previous_lives
+    assert soul2.did in soul3.identity.previous_lives
+    assert len(soul3.identity.previous_lives) == 2
+
+
+async def test_personality_preserved():
+    """DNA personality traits carry over through reincarnation."""
+    original = await Soul.birth("Aria", archetype="The Creator")
+    # Modify DNA to verify it carries
+    original._dna.personality.openness = 0.9
+    original._dna.personality.neuroticism = 0.1
+
+    reborn = await Soul.reincarnate(original)
+
+    assert reborn.dna.personality.openness == pytest.approx(0.9)
+    assert reborn.dna.personality.neuroticism == pytest.approx(0.1)
+
+
+async def test_core_values_preserved():
+    """Core values carry over through reincarnation."""
+    original = await Soul.birth(
+        "Aria",
+        values=["empathy", "creativity", "honesty"],
+    )
+    reborn = await Soul.reincarnate(original)
+
+    assert reborn.identity.core_values == ["empathy", "creativity", "honesty"]
+
+
+async def test_memories_preserved():
+    """Memories carry over through reincarnation."""
+    original = await Soul.birth("Aria")
+    await original.remember(
+        "User loves Python programming",
+        type=MemoryType.SEMANTIC,
+        importance=8,
+    )
+
+    reborn = await Soul.reincarnate(original)
+    results = await reborn.recall("Python programming")
+    assert any("Python" in r.content for r in results)
+
+
+async def test_archetype_preserved():
+    """Archetype carries over through reincarnation."""
+    original = await Soul.birth("Aria", archetype="The Compassionate Creator")
+    reborn = await Soul.reincarnate(original)
+    assert reborn.archetype == "The Compassionate Creator"
+
+
+async def test_bond_preserved():
+    """Bond state carries over through reincarnation."""
+    original = await Soul.birth("Aria")
+    original.identity.bond.bonded_to = "did:key:user-123"
+    original.identity.bond.strengthen(20.0)
+
+    reborn = await Soul.reincarnate(original)
+    assert reborn.identity.bond.bonded_to == "did:key:user-123"
+    assert reborn.identity.bond.bond_strength == 70.0

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,129 @@
+# test_skills.py — Tests for the Skills/XP progression system
+# Created: 2026-03-06 — Skill creation, XP, leveling, level cap, registry
+
+from __future__ import annotations
+
+from soul_protocol.skills import Skill, SkillRegistry
+
+
+class TestSkillCreation:
+    """Tests for Skill default construction."""
+
+    def test_default_skill(self):
+        skill = Skill(id="coding", name="Coding")
+        assert skill.id == "coding"
+        assert skill.name == "Coding"
+        assert skill.level == 1
+        assert skill.xp == 0
+        assert skill.xp_to_next == 100
+
+    def test_skill_with_config(self):
+        skill = Skill(id="art", name="Art", config={"style": "watercolor"})
+        assert skill.config == {"style": "watercolor"}
+
+
+class TestSkillXP:
+    """Tests for Skill.add_xp()."""
+
+    def test_add_xp_no_levelup(self):
+        skill = Skill(id="coding", name="Coding")
+        leveled = skill.add_xp(50)
+        assert leveled is False
+        assert skill.xp == 50
+        assert skill.level == 1
+
+    def test_add_xp_triggers_levelup(self):
+        skill = Skill(id="coding", name="Coding")
+        leveled = skill.add_xp(100)
+        assert leveled is True
+        assert skill.level == 2
+        assert skill.xp == 0
+        assert skill.xp_to_next == 150  # 100 * 1.5
+
+    def test_add_xp_overflow_carries(self):
+        skill = Skill(id="coding", name="Coding")
+        leveled = skill.add_xp(130)
+        assert leveled is True
+        assert skill.level == 2
+        assert skill.xp == 30
+        assert skill.xp_to_next == 150
+
+    def test_xp_scaling_across_levels(self):
+        skill = Skill(id="coding", name="Coding")
+        # Level 1 -> 2: need 100 XP, next = 150
+        skill.add_xp(100)
+        assert skill.level == 2
+        assert skill.xp_to_next == 150
+
+        # Level 2 -> 3: need 150 XP, next = 225
+        skill.add_xp(150)
+        assert skill.level == 3
+        assert skill.xp_to_next == 225
+
+    def test_level_cap_at_10(self):
+        skill = Skill(id="coding", name="Coding", level=10, xp=0)
+        leveled = skill.add_xp(999)
+        assert leveled is False
+        assert skill.level == 10
+        assert skill.xp == 999  # XP still accumulates
+
+    def test_add_xp_updates_last_used(self):
+
+        skill = Skill(id="coding", name="Coding")
+        before = skill.last_used
+        skill.add_xp(10)
+        # last_used should be updated (at least not before the original)
+        assert skill.last_used >= before
+
+
+class TestSkillRegistry:
+    """Tests for SkillRegistry."""
+
+    def test_empty_registry(self):
+        registry = SkillRegistry()
+        assert len(registry.skills) == 0
+
+    def test_add_skill(self):
+        registry = SkillRegistry()
+        skill = Skill(id="coding", name="Coding")
+        registry.add(skill)
+        assert len(registry.skills) == 1
+        assert registry.get("coding") is not None
+
+    def test_add_duplicate_ignored(self):
+        registry = SkillRegistry()
+        registry.add(Skill(id="coding", name="Coding"))
+        registry.add(Skill(id="coding", name="Coding v2"))
+        assert len(registry.skills) == 1
+        assert registry.get("coding").name == "Coding"
+
+    def test_get_missing_returns_none(self):
+        registry = SkillRegistry()
+        assert registry.get("nonexistent") is None
+
+    def test_grant_xp_existing_skill(self):
+        registry = SkillRegistry()
+        registry.add(Skill(id="coding", name="Coding"))
+        leveled = registry.grant_xp("coding", 50)
+        assert leveled is False
+        assert registry.get("coding").xp == 50
+
+    def test_grant_xp_levelup(self):
+        registry = SkillRegistry()
+        registry.add(Skill(id="coding", name="Coding"))
+        leveled = registry.grant_xp("coding", 100)
+        assert leveled is True
+        assert registry.get("coding").level == 2
+
+    def test_grant_xp_missing_skill(self):
+        registry = SkillRegistry()
+        result = registry.grant_xp("nonexistent", 50)
+        assert result is False
+
+    def test_multiple_skills(self):
+        registry = SkillRegistry()
+        registry.add(Skill(id="coding", name="Coding"))
+        registry.add(Skill(id="art", name="Art"))
+        registry.add(Skill(id="music", name="Music"))
+        assert len(registry.skills) == 3
+        assert registry.get("art").name == "Art"


### PR DESCRIPTION
## Summary

Rebased version of #34 onto current main (4da5a96). The old branch diverged from a very early commit and would have reverted StrEnum, cognitive engine exports, self-model/general_events extraction, error handling, and CI pipeline changes.

This PR adds soul primitives on top of the full main codebase:

- **Bond model** (`bond.py`) — Human-Soul relationship tracking with strengthen/weaken mechanics, 0-100 bond strength, interaction counter
- **Skills/XP system** (`skills.py`) — Skill with level progression (1-10), exponential XP scaling, SkillRegistry collection
- **Reincarnation** (`soul.py`) — `Soul.reincarnate()` classmethod creates a new soul from existing essence, preserves memories/personality/bond, tracks incarnation count and previous lives via `Identity.previous_lives`
- **Identity fields** (`types.py`) — Added `bond: Bond`, `incarnation: int`, `previous_lives: list[str]` to Identity
- **dna.md unpacking** (`unpack.py`) — Now reads `dna.md` from .soul archives into `memory_data["dna_md"]`
- **Public exports** (`__init__.py`) — Added `Bond`, `Skill`, `SkillRegistry` to package API

Review fixes from #34 applied:
- Relative import for Bond in types.py (`from .bond import Bond`)
- Decision comment in reincarnate() explaining born reset
- Passes `core_values` to `MemoryManager.from_dict()` in reincarnate()

## Test plan
- [x] 16 bond tests (creation, strengthen, weaken, bounds validation)
- [x] 15 skill tests (XP, leveling, cap at 10, registry operations)
- [x] 9 reincarnation tests (lifecycle, memory/personality/bond preservation)
- [x] 2 E2E tests (full lifecycle + dna.md archive round-trip)
- [x] All 489 tests pass (43 new + 446 existing), zero regressions
- [x] Ruff lint clean