### PR TITLE
fix: remove stale merge artifact causing IndentationError in MemoryManager

### DIFF
--- a/src/soul_protocol/runtime/memory/manager.py
+++ b/src/soul_protocol/runtime/memory/manager.py
@@ -1,4 +1,5 @@
 # memory/manager.py — MemoryManager facade orchestrating all memory subsystems.
+# Updated: fix stale duplicate promote-to-episodic block from merge artifact.
 # Updated: phase1-ablation-fixes — Pass token_count to significance gate, weaken
 #   promotion rule so trivial interactions with facts don't bypass the gate.
 # Updated: feat/dspy-integration — Accept optional dspy_processor param. When set,
@@ -451,11 +452,6 @@ class MemoryManager:
         if facts:
             logger.debug("Facts extracted and stored: count=%d", len(facts))
 
-        # --- 4b. v0.2.3 — Conditionally promote if facts were extracted ---
-        # Only promote to episodic when significance is at least half the
-        # threshold (0.25) AND facts were extracted.  This prevents trivial
-        # interactions from being promoted just because a fact was found.
-        if not significant and facts and sig_value >= 0.3:
         # --- 4b. Promote to episodic if facts were extracted ---
         if not significant and facts:
             significant = True


### PR DESCRIPTION
## Summary

- Removes a duplicate promote-to-episodic `if` block in `MemoryManager.observe()` that was left behind during the PR #55 merge
- The stale `if not significant and facts and sig_value >= 0.3:` had no body, causing an `IndentationError` on import
- All 981 tests pass after the fix

## Context

PR #55 (personality-modulated recall) was merged into dev alongside commits from the ablation-fixes and dspy-integration branches. The merge left a 5-line stale code block (comment + condition from ablation-fixes) immediately before the correct version of the same block. Since the stale `if` statement had no body (the next line was a comment at the same indent level), Python raised `IndentationError` when importing the module.

## Test plan

- [x] `uv run pytest tests/ -x -q` -- 981 passed, 0 failed