### PR TITLE
Auto-save on shutdown + directory-based soul format

### DIFF
--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -29,6 +29,11 @@ from rich.text import Text
 console = Console()
 
 
+def _safe_name(name: str) -> str:
+    """Sanitize a soul name for use in file paths (no traversal)."""
+    return Path(name.lower().replace(" ", "-")).name or "soul"
+
+
 def _ocean_bar(label: str, value: float) -> Text:
     """Render a single OCEAN trait as a labeled bar."""
     pct = int(value * 100)
@@ -166,7 +171,7 @@ def birth(
                     f"N={p.neuroticism:.1f}[/dim]"
                 )
 
-        out = output or f"./{soul.name.lower()}.soul"
+        out = output or f"./{_safe_name(soul.name)}.soul"
         await soul.export(out)
         console.print(f"[dim]Saved to {out}[/dim]")
 
@@ -431,7 +436,7 @@ def export_cmd(source, output, fmt):
         from soul_protocol.runtime.soul import Soul
 
         soul = await Soul.awaken(source)
-        out = output or f"{soul.name.lower().replace(' ', '-')}.{fmt}"
+        out = output or f"{_safe_name(soul.name)}.{fmt}"
 
         if fmt == "soul":
             await soul.export(out)
@@ -473,7 +478,7 @@ def unpack_cmd(source, soul_dir):
         from soul_protocol.runtime.soul import Soul
 
         soul = await Soul.awaken(source)
-        target = soul_dir or f".soul/{soul.name.lower().replace(' ', '-')}"
+        target = soul_dir or f".soul/{_safe_name(soul.name)}"
         await soul.save_local(target)
         console.print(f"[green]Unpacked[/green] {soul.name} → {target}/")
         console.print("[dim]Browse the folder in VS Code or any editor.[/dim]")

--- a/src/soul_protocol/mcp/server.py
+++ b/src/soul_protocol/mcp/server.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,30 @@ _soul: Soul | None = None
 _soul_path: str | None = None
 
 
+def _is_directory_path(p: Path) -> bool:
+    """Check if a path is (or should be) a directory soul store."""
+    if p.is_dir():
+        return True
+    # Non-existent path without a file extension → treat as directory
+    if not p.exists() and not p.suffix:
+        return True
+    return False
+
+
+async def _auto_save(soul: Soul, path: str | None) -> None:
+    """Save the soul to the appropriate format based on path type."""
+    if path:
+        p = Path(path)
+        if _is_directory_path(p):
+            await soul.save_local(str(p))
+        elif p.suffix == ".soul":
+            await soul.export(str(p))
+        else:
+            await soul.save_local(str(p))
+    else:
+        await soul.save()
+
+
 @asynccontextmanager
 async def _lifespan(server: FastMCP):
     """Load soul from SOUL_PATH on startup, cleanup on shutdown."""
@@ -40,8 +65,6 @@ async def _lifespan(server: FastMCP):
         try:
             _soul = await Soul.awaken(path)
         except (FileNotFoundError, ValueError, SoulProtocolError) as e:
-            import sys
-
             print(
                 f"soul-mcp: failed to load SOUL_PATH={path!r}: {e}",
                 file=sys.stderr,
@@ -58,26 +81,13 @@ async def _lifespan(server: FastMCP):
     # Auto-save on shutdown
     if _soul is not None:
         try:
-            if _soul_path:
-                p = Path(_soul_path)
-                if p.is_dir():
-                    await _soul.save_local(str(p))
-                elif p.suffix == ".soul":
-                    await _soul.export(str(p))
-                else:
-                    await _soul.save(_soul_path)
-            else:
-                await _soul.save()
-            import sys
-
+            await _auto_save(_soul, _soul_path)
             print(
                 f"soul-mcp: auto-saved to {_soul_path or '~/.soul/'}",
                 file=sys.stderr,
                 flush=True,
             )
         except Exception as e:
-            import sys
-
             print(
                 f"soul-mcp: auto-save failed: {e}",
                 file=sys.stderr,
@@ -345,17 +355,9 @@ async def soul_save(path: str | None = None) -> str:
     global _soul_path
     soul = await _get_soul()
     save_path = path or _soul_path
+    await _auto_save(soul, save_path)
     if save_path:
-        p = Path(save_path)
-        if p.is_dir():
-            await soul.save_local(str(p))
-        elif p.suffix == ".soul":
-            await soul.export(str(p))
-        else:
-            await soul.save(save_path)
         _soul_path = save_path
-    else:
-        await soul.save()
     default_path = str(Path.home() / ".soul" / soul.did)
     return json.dumps(
         {

--- a/tests/test_mcp/test_server.py
+++ b/tests/test_mcp/test_server.py
@@ -256,14 +256,10 @@ async def test_soul_save():
             )
             data = json.loads(result.data)
             assert data["status"] == "saved"
-            # save() creates <path>/<soul_id>/ directory structure
+            # save_local creates flat directory with soul.json directly inside
             save_dir = Path(path)
             assert save_dir.is_dir()
-            soul_dirs = list(save_dir.iterdir())
-            assert len(soul_dirs) >= 1
-            # Should contain soul.json inside the soul_id subdir
-            soul_files = list(save_dir.glob("*/soul.json"))
-            assert len(soul_files) == 1
+            assert (save_dir / "soul.json").exists()
 
 
 async def test_soul_export():


### PR DESCRIPTION
## Summary

- MCP server auto-saves the soul on shutdown — no more lost memories between sessions
- `SOUL_PATH` now supports both `.soul` ZIP files and directory paths
- New `soul unpack` CLI command extracts `.soul` archives into browsable folders
- `soul export --output` is now optional (defaults to `<name>.soul`)

## How it works

**Auto-save**: The lifespan teardown detects the format (directory vs ZIP) and saves accordingly. If the soul was born at runtime with no path, it falls back to `~/.soul/<did>/`.

**Directory format**: Point `SOUL_PATH` at a folder instead of a ZIP. The soul's state lives in readable JSON/YAML files you can browse in VS Code and diff with git:

```
.soul/guardian/
├── dna.md
├── memory/
│   ├── core.json
│   ├── episodic.json
│   ├── semantic.json
│   └── ...
├── soul.json
└── state.json
```

## Test plan

- [x] `test_autosave_to_soul_file` — memories persist after shutdown (ZIP)
- [x] `test_autosave_to_directory` — memories persist after shutdown (directory)
- [x] `test_lifespan_loads_from_directory` — SOUL_PATH directory loads correctly
- [x] `test_soul_save_updates_path` — soul_save tracks path for auto-save
- [x] Full suite: 1001 passed