### PR TITLE
Fix: resolve absolute path to uvx so GUI apps can spawn MCP server

### DIFF
--- a/src/soul_protocol/cli/setup.py
+++ b/src/soul_protocol/cli/setup.py
@@ -261,7 +261,7 @@ def _write_mcp_toml(config_path: Path, soul_path: Path) -> bool:
     """Write MCP config for Codex CLI (TOML format). Returns True if written."""
     # Use forward slashes (posix) for cross-platform TOML safety
     safe_path = soul_path.resolve().as_posix()
-    uvx_cmd = _resolve_uvx()
+    uvx_cmd = Path(_resolve_uvx()).as_posix()  # forward slashes for TOML safety
     toml_section = (
         f'\n[mcp_servers.soul]\n'
         f'command = "{uvx_cmd}"\n'

--- a/tests/test_cli/test_setup.py
+++ b/tests/test_cli/test_setup.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 from unittest.mock import patch
 
@@ -324,7 +325,6 @@ def test_resolve_uvx_returns_absolute_path():
     # On a dev machine with uv installed, should be absolute
     # On CI without uv, falls back to bare "uvx"
     assert result.endswith("uvx")
-    import shutil
     if shutil.which("uvx"):
         assert "/" in result or "\\" in result  # absolute path
 


### PR DESCRIPTION
## Summary
- GUI apps (Claude Desktop, VS Code, Cursor, Windsurf) don't inherit the user's shell PATH
- `soul init --setup` was writing bare `uvx` into MCP configs, which fails with "No such file or directory" on every GUI app
- Now uses `shutil.which("uvx")` at setup time to resolve the full absolute path (e.g. `/Library/Frameworks/Python.framework/Versions/3.12/bin/uvx`)
- Falls back to bare `uvx` if not found (CI, containers)
- Also fixes Continue idempotency check to match on args instead of command name

## Context
Every user who ran `soul init --setup` and then opened Claude Desktop (or any GUI-based coding agent) would see "MCP soul: Server disconnected" because the spawned process couldn't find `uvx` on the restricted GUI PATH.

## Test plan
- [x] `test_resolve_uvx_returns_absolute_path` — verifies resolution on dev machines
- [x] `test_resolve_uvx_fallback` — verifies bare `uvx` fallback when not on PATH
- [x] Existing 26 setup tests updated and passing
- [x] Full suite: 1028 tests pass