### PR TITLE
docs: soul inject guide + updated CLI and integration docs

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,5 +1,6 @@
-<!-- Covers: CLI installation, all 8 commands (init, birth, inspect, status, export, migrate, retire, list)
+<!-- Covers: CLI installation, all 9 commands (init, birth, inject, inspect, status, export, migrate, retire, list)
      with usage examples, options tables, and output descriptions.
+     Updated: 2026-03-13 — Added soul inject command for fast context injection into agent configs.
      Updated: 2026-03-02 — Removed dashboard/open commands, enhanced inspect with TUI panels. -->
 
 # CLI Reference
@@ -23,6 +24,8 @@ soul --version
 ### `soul init`
 
 Initialize a `.soul/` folder in the current directory. This is the recommended way to start using Soul Protocol in a project -- like `git init` for identity.
+
+> **Tip:** After `soul init`, run `soul inject claude-code` (or your platform) to push soul context directly into your agent's config file. See [`soul inject`](#soul-inject) below.
 
 ```bash
 # Interactive -- prompts for name
@@ -79,6 +82,78 @@ soul inspect .soul/
 soul status .soul/
 soul export .soul/ -o aria.soul
 ```
+
+---
+
+### `soul inject`
+
+Inject soul context (identity, core memory, state, recent memories) directly into an agent platform's config file. This is the fast, CLI-based alternative to running an MCP server -- ~50ms vs ~500ms per operation, no server process needed, works offline.
+
+The injected block is idempotent: running `soul inject` again replaces the existing section without duplicating content.
+
+```bash
+# Inject into Claude Code's CLAUDE.md
+soul inject claude-code
+
+# Inject a specific soul into Cursor's config
+soul inject cursor --soul guardian
+
+# Include more memories (default: 10)
+soul inject vscode --memories 20
+
+# Custom soul directory
+soul inject windsurf --dir ~/my-project/.soul
+
+# Quiet mode (no console output)
+soul inject cline --quiet
+```
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `TARGET` | Yes | Platform to inject into. One of: `claude-code`, `cursor`, `vscode`, `windsurf`, `cline`, `continue`. |
+
+**Options:**
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--soul TEXT` | | Soul name to inject. Default: first soul found in the directory. |
+| `--dir PATH` | `-d` | Soul directory path. Default: `.soul/` in the current working directory. |
+| `--memories INT` | `-m` | Number of recent memories to include. Default: 10. |
+| `--quiet` | `-q` | Suppress console output. |
+
+**Target config files:**
+
+| Target | Config file |
+|--------|-------------|
+| `claude-code` | `.claude/CLAUDE.md` |
+| `cursor` | `.cursorrules` |
+| `vscode` | `.github/copilot-instructions.md` |
+| `windsurf` | `.windsurfrules` |
+| `cline` | `.clinerules` |
+| `continue` | `.continuerules` |
+
+**What gets injected:**
+
+The command writes a markdown block between `<!-- SOUL-CONTEXT-START -->` and `<!-- SOUL-CONTEXT-END -->` markers containing:
+
+- Soul identity (name, archetype, DID, core values)
+- Current state (mood, energy, lifecycle stage)
+- Core memory (persona definition, knowledge about the human)
+- Recent episodic memories (configurable count, truncated at 120 chars)
+- Injection timestamp
+
+**When to use inject vs MCP:**
+
+| Use `soul inject` when... | Use MCP when... |
+|---------------------------|-----------------|
+| You want fast, static context | You need real-time memory updates during conversation |
+| MCP server keeps disconnecting | The agent needs to call `soul_observe` or `soul_remember` |
+| You're scripting or automating | You're using Claude Desktop (no CLI integration) |
+| You want to version-control the context | You want the soul to evolve during the session |
+
+Both approaches work together. Use `soul inject` for baseline context and MCP for live memory operations.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,6 @@
-<!-- Covers: Installation, optional extras, soul init quickstart, first soul walkthrough,
+<!-- Covers: Installation, optional extras, soul init quickstart, soul inject, first soul walkthrough,
      observe() pipeline explanation, next steps.
+     Updated: 2026-03-13 — Added soul inject section for fast agent integration.
      Updated: 2026-03-02 — Removed dashboard section (replaced by TUI in inspect/status). -->
 
 # Getting Started
@@ -54,6 +55,16 @@ The `.soul/` folder is human-readable (JSON + markdown), git-friendly, and cloud
 ```bash
 soul init --from-file colleague-shared-aria.soul
 ```
+
+To push your soul's context into your agent's config file:
+
+```bash
+soul inject claude-code    # writes to .claude/CLAUDE.md
+soul inject cursor         # writes to .cursorrules
+soul inject vscode         # writes to .github/copilot-instructions.md
+```
+
+This is the fastest way to give any AI agent your soul's identity, memories, and state -- no MCP server needed. Re-run it anytime to refresh the context.
 
 To export your `.soul/` folder as a portable archive:
 
@@ -225,4 +236,4 @@ See the [CognitiveEngine Guide](cognitive-engine.md) for details.
 - **[API Reference](api-reference.md)** -- Complete Soul class API, all types and models
 - **[MCP Server](mcp-server.md)** -- FastMCP server for agent integration
 - **[Integrations](integrations.md)** -- Give Claude Code, Cursor, or any agent a `.soul`
-- **[CLI Reference](cli-reference.md)** -- All 8 commands for soul management
+- **[CLI Reference](cli-reference.md)** -- All 9 commands including `soul inject` for fast agent integration

--- a/docs/guide-soul-inject.md
+++ b/docs/guide-soul-inject.md
@@ -1,0 +1,254 @@
+<!-- Guide: soul inject — fast context injection for AI agents.
+     Covers: why inject vs MCP, setup, usage for each platform, automation,
+     team workflows, CI/CD, and combining inject with MCP.
+     Created: 2026-03-13 -->
+
+# Guide: Fast Agent Integration with `soul inject`
+
+`soul inject` writes your soul's identity, memories, and state directly into your AI agent's config file. One command, ~50ms, no server needed.
+
+## Why `soul inject`?
+
+MCP servers are powerful but heavy. They need a running process, can disconnect, and add latency to every tool call. For many workflows, you just want the agent to *know who it is* when it starts up.
+
+`soul inject` gives you that:
+
+| | MCP Server | `soul inject` |
+|---|---|---|
+| Speed | ~500ms per call | ~50ms total |
+| Reliability | Can crash/disconnect | Always works |
+| Setup | Config JSON, env vars | One command |
+| Offline | Needs server process | Works offline |
+| Real-time memory | Yes | No (static snapshot) |
+| Memory updates mid-chat | Yes | No |
+
+**Use both together**: `soul inject` for baseline context on startup, MCP for live memory during conversation.
+
+## Quick Start
+
+```bash
+# 1. Create a soul (if you haven't already)
+soul init "Aria" --archetype "The Coding Expert"
+
+# 2. Inject into your agent's config
+soul inject claude-code
+```
+
+That's it. Your `.claude/CLAUDE.md` now contains Aria's identity, personality, current state, and recent memories.
+
+## What Gets Injected
+
+The command writes a markdown block like this into your config file:
+
+```markdown
+<!-- SOUL-CONTEXT-START -->
+## Soul: Aria
+
+**Identity**: Aria, The Coding Expert. DID: did:soul:aria-a3f2b1
+**Values**: precision, clarity, empathy
+**State**: curious, 95% energy, active
+
+### Core Memory
+**Persona**: I am Aria, a precise and clear-thinking coding assistant...
+**Human**: Prakash is a solo founder working on PocketPaw and Soul Protocol...
+
+### Recent Context (5 memories)
+- [episodic] User asked about FastAPI middleware patterns (importance: 7)
+- [episodic] Discussed async Python testing strategies (importance: 8)
+- [episodic] User prefers minimal dependencies (importance: 6)
+...
+
+_Injected by `soul inject` at 2026-03-13T12:00:00Z_
+<!-- SOUL-CONTEXT-END -->
+```
+
+The `<!-- SOUL-CONTEXT-START/END -->` markers make it idempotent. Running `soul inject` again replaces the block without duplicating it. Your existing config content is preserved.
+
+## Platform-by-Platform Setup
+
+### Claude Code
+
+```bash
+soul inject claude-code
+# Writes to: .claude/CLAUDE.md
+```
+
+If you already have a `CLAUDE.md` with project instructions, the soul context is appended (or replaces the previous injection). Your existing instructions stay untouched.
+
+### Cursor
+
+```bash
+soul inject cursor
+# Writes to: .cursorrules
+```
+
+### VS Code / GitHub Copilot
+
+```bash
+soul inject vscode
+# Writes to: .github/copilot-instructions.md
+```
+
+Creates the `.github/` directory if it doesn't exist.
+
+### Windsurf
+
+```bash
+soul inject windsurf
+# Writes to: .windsurfrules
+```
+
+### Cline
+
+```bash
+soul inject cline
+# Writes to: .clinerules
+```
+
+### Continue
+
+```bash
+soul inject continue
+# Writes to: .continuerules
+```
+
+## Options
+
+### Choose a specific soul
+
+If your `.soul/` directory contains multiple souls (e.g., `guardian/` and `pocketpaw.soul`):
+
+```bash
+soul inject claude-code --soul guardian
+soul inject cursor --soul pocketpaw
+```
+
+### Custom soul directory
+
+```bash
+soul inject claude-code --dir ~/projects/my-app/.soul
+soul inject cursor --dir /absolute/path/to/souls
+```
+
+### Control memory count
+
+```bash
+# Include 20 recent memories (default: 10)
+soul inject claude-code --memories 20
+
+# Minimal context (identity + state only, no memories)
+soul inject claude-code --memories 0
+```
+
+### Quiet mode
+
+```bash
+soul inject claude-code --quiet
+```
+
+Suppresses the "Injected soul context into..." confirmation message. Useful in scripts.
+
+## Workflows
+
+### Daily refresh
+
+Re-inject each morning to pick up memories from yesterday's sessions:
+
+```bash
+soul inject claude-code
+```
+
+If you used MCP during yesterday's session, the soul auto-saved new memories. Running `soul inject` today picks them up.
+
+### Multi-platform development
+
+Inject the same soul into every editor you use:
+
+```bash
+soul inject claude-code
+soul inject cursor
+soul inject vscode
+soul inject windsurf
+```
+
+All four editors now share the same soul context. When you switch editors, your agent already knows who you are and what you've been working on.
+
+### Team workflows
+
+Commit the `.soul/` directory to git. Each team member runs:
+
+```bash
+git pull
+soul inject claude-code
+```
+
+Everyone's agent starts with the same baseline identity and shared context. Individual sessions can still use MCP for personal memory.
+
+### CI/CD integration
+
+Add `soul inject` to your CI pipeline to ensure agents always have fresh context:
+
+```bash
+# In your CI script or Makefile
+soul inject claude-code --dir .soul --quiet
+```
+
+### Shell alias
+
+Add to your `.zshrc` or `.bashrc`:
+
+```bash
+alias si="soul inject claude-code"
+```
+
+Now just type `si` to refresh your agent's context.
+
+### Git hook
+
+Auto-inject after every `git checkout` or `git pull`:
+
+```bash
+# .git/hooks/post-checkout
+#!/bin/sh
+soul inject claude-code --quiet 2>/dev/null || true
+```
+
+## Combining with MCP
+
+The best setup uses both:
+
+1. **`soul inject`** at session start for fast baseline context
+2. **MCP server** running for live memory operations during the session
+
+```bash
+# Setup (one time)
+soul init "Aria" --setup claude-code
+
+# Each session
+soul inject claude-code   # fast context refresh
+# ... then Claude Code connects to MCP for soul_observe, soul_remember, etc.
+```
+
+The injected context gives the agent immediate awareness. MCP gives it the ability to learn and evolve during the conversation.
+
+## Troubleshooting
+
+### "Soul directory not found"
+
+Make sure you've run `soul init` first, or point `--dir` to where your soul lives:
+
+```bash
+soul inject claude-code --dir /path/to/.soul
+```
+
+### "No soul found in .soul/"
+
+The directory exists but doesn't contain a `soul.json` (directory format) or `.soul` file (ZIP format). Run `soul init` to create one.
+
+### Context looks stale
+
+The inject command reads from disk. If you used MCP during your last session, make sure the MCP server shut down cleanly (it auto-saves on exit). Then re-run `soul inject` to pick up the latest state.
+
+### Existing config content disappeared
+
+This shouldn't happen -- `soul inject` only replaces content between `<!-- SOUL-CONTEXT-START -->` and `<!-- SOUL-CONTEXT-END -->` markers. If your config file had no markers, the block is appended. If you accidentally deleted content, check git history.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,11 +1,12 @@
-<!-- Covers: Platform integration guide for Soul Protocol. Claude Code (MCP + CLAUDE.md template),
-     Claude Desktop, Cursor, Windsurf, custom Python agents, LangChain/LangGraph, CrewAI,
+<!-- Covers: Platform integration guide for Soul Protocol. CLI injection (soul inject), MCP server,
+     Claude Code, Claude Desktop, Cursor, Windsurf, custom Python agents, LangChain/LangGraph, CrewAI,
      integration tiers, portability patterns, and MCP tools reference table.
+     Updated: 2026-03-13 — Added Tier 1.5 (soul inject), multi-soul SOUL_DIR, updated tool count to 12.
      Updated: 2026-03-02 — Replaced dashboard references with inspect TUI. -->
 
 # Integrations
 
-Soul Protocol integrates with any AI agent through two paths: an MCP server that gives agents active memory and evolving identity, or system prompt injection for static personality. This guide covers both approaches across every major platform.
+Soul Protocol integrates with any AI agent through three paths: CLI injection for fast static context, an MCP server for active memory and evolving identity, or system prompt generation for manual injection. This guide covers all approaches across every major platform.
 
 
 ## Integration Tiers
@@ -24,9 +25,26 @@ prompt = soul.to_system_prompt()
 
 Best for: quick experiments, agents that don't support MCP, read-only personality injection.
 
+### Tier 1.5 -- CLI Injection (`soul inject`)
+
+One command injects soul context (identity, state, core memory, recent memories) directly into your agent's config file. No server, no MCP, no manual copy-paste. Runs in ~50ms.
+
+```bash
+soul inject claude-code              # writes to .claude/CLAUDE.md
+soul inject cursor --soul guardian   # specific soul into .cursorrules
+soul inject vscode --memories 20     # include 20 recent memories
+soul inject windsurf --dir ~/project/.soul
+```
+
+The injected block is idempotent -- re-running replaces the existing section. Supports 6 platforms: Claude Code, Cursor, VS Code/Copilot, Windsurf, Cline, Continue.
+
+Best for: projects that want persistent context without running a server, CI/CD pipelines, scripting, teams sharing soul context via git.
+
+See the [CLI Reference](cli-reference.md#soul-inject) for full options.
+
 ### Tier 2 -- MCP Server (Active)
 
-Run the Soul Protocol MCP server alongside your agent. The agent actively calls soul tools to recall memories, observe interactions, reflect on patterns, and evolve over time. Full bidirectional integration.
+Run the Soul Protocol MCP server alongside your agent. The agent actively calls soul tools to recall memories, observe interactions, reflect on patterns, and evolve over time. Full bidirectional integration. Supports multiple souls via `SOUL_DIR`.
 
 Best for: production agents, persistent companions, any platform with MCP support.
 
@@ -81,13 +99,19 @@ Add the soul MCP server to `.claude/settings.local.json` in your project root:
 
 `SOUL_PATH` can be a `.soul/` directory or a `.soul` archive file. Must be an absolute path. The server loads the soul on startup and keeps it in memory across tool calls.
 
-### Step 3: Add CLAUDE.md Instructions
+### Step 3: Inject Context (Fast Path)
 
-Create or update your project's `CLAUDE.md` to teach the agent how to use its soul. Add the template below.
+The quickest way to give Claude Code soul context is the `inject` command:
 
-### CLAUDE.md Template
+```bash
+soul inject claude-code
+```
 
-Copy this block into your `CLAUDE.md`:
+This writes identity, core memory, state, and recent memories directly into `.claude/CLAUDE.md`. Re-run it anytime to refresh. Done -- skip to Step 4.
+
+### Step 3 (Alternative): Manual CLAUDE.md Instructions
+
+If you prefer manual control, or want to combine `soul inject` with custom instructions, add this template to your `CLAUDE.md`:
 
 ```markdown
 ## Soul Protocol -- Persistent Identity
@@ -187,7 +211,14 @@ Cursor supports MCP servers through its settings. Run `soul init "MyAssistant"` 
 }
 ```
 
-Then add instructions to `.cursorrules` so the agent knows how to use its soul:
+Then inject soul context (or add it manually):
+
+```bash
+# Fast path: inject automatically
+soul inject cursor
+
+# Or add manual instructions to .cursorrules:
+```
 
 ```
 You have a persistent soul via the `soul` MCP server.
@@ -473,11 +504,13 @@ Roll back by loading an earlier snapshot. The soul picks up from that point with
 
 Quick reference for all tools, resources, and prompts exposed by the Soul Protocol MCP server. See the [MCP Server docs](mcp-server.md) for full parameter details.
 
-### Tools (10)
+### Tools (12)
 
 | Tool | Description |
 |------|-------------|
 | `soul_birth` | Create a new soul with name, archetype, and values |
+| `soul_list` | List all loaded souls with name, DID, memory count, and active status |
+| `soul_switch` | Set the active soul by name (case-insensitive) |
 | `soul_observe` | Process an interaction through the full psychology pipeline |
 | `soul_remember` | Store a memory directly (episodic, semantic, or procedural) |
 | `soul_recall` | Search memories by natural language query, ranked by ACT-R activation |
@@ -487,6 +520,8 @@ Quick reference for all tools, resources, and prompts exposed by the Soul Protoc
 | `soul_prompt` | Generate the complete system prompt for LLM injection |
 | `soul_save` | Persist the soul to disk |
 | `soul_export` | Export as a portable `.soul` file |
+
+All tools (except `soul_list` and `soul_switch`) accept an optional `soul` parameter to target a specific soul by name. If omitted, the active soul is used.
 
 ### Resources (3)
 
@@ -500,5 +535,5 @@ Quick reference for all tools, resources, and prompts exposed by the Soul Protoc
 
 | Name | Description |
 |------|-------------|
-| `soul_system_prompt` | Full system prompt combining DNA, identity, core memory, state, self-model |
+| `soul_system_prompt_template` | Full system prompt combining DNA, identity, core memory, state, self-model |
 | `soul_introduction` | First-person self-introduction for the soul |


### PR DESCRIPTION
## Summary

- New **guide-soul-inject.md** — full tutorial covering setup, all 6 platforms, workflows (daily refresh, multi-platform, team, CI/CD, git hooks), and how to combine inject with MCP
- Updated **cli-reference.md** — added `soul inject` command section with options table, target file mapping, and inject-vs-MCP comparison table
- Updated **integrations.md** — added Tier 1.5 (CLI injection), updated MCP tool count from 10 to 12 (soul_list, soul_switch), renamed prompt, added inject fast-path to Claude Code and Cursor sections
- Updated **getting-started.md** — added `soul inject` to the quick start flow after `soul init`

## Test plan

- [x] All doc links reference existing sections
- [x] CLI examples match actual command signatures
- [x] Tool count matches merged PR #82 (12 tools)
- [x] Prompt name updated to `soul_system_prompt_template`