### PR TITLE
docs: update README stats, MCP server docs, memory architecture v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- README.md — soul-protocol open standard -->
-<!-- Updated: 2026-03-12 — updated test count to 996, added Soul Health Score section, updated line counts -->
+<!-- Updated: 2026-03-13 — updated test count to 1189, tool count to 12, CLI commands to 15 -->
 
 # Soul Protocol
 
@@ -7,7 +7,7 @@
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests: 996 passing](https://img.shields.io/badge/tests-996%20passing-brightgreen)](https://github.com/qbtrix/soul-protocol)
+[![Tests: 1189 passing](https://img.shields.io/badge/tests-1189%20passing-brightgreen)](https://github.com/qbtrix/soul-protocol)
 
 ---
 
@@ -63,8 +63,8 @@ Full methodology: [research/EVAL-FRAMEWORK.md](research/EVAL-FRAMEWORK.md)
 soul_protocol/
 ├── spec/      695 lines   The protocol. Portable, minimal, no opinions.
 ├── runtime/  9,693 lines  Reference implementation. Opinionated, batteries-included.
-├── cli/                    11-command CLI
-└── mcp/                    MCP server (10 tools, 3 resources)
+├── cli/                    15-command CLI
+└── mcp/                    MCP server (12 tools, 3 resources)
 ```
 
 **`spec/`** defines what any runtime must implement: Identity, MemoryStore, MemoryEntry, SoulContainer, `.soul` file format, EmbeddingProvider, EternalStorageProvider. Depends on Pydantic only.
@@ -91,8 +91,8 @@ Like HTTP and nginx. The spec defines the contract. The runtime is one implement
 | **Portability** | `.soul` ZIP archive. JSON inside. Rename to .zip and read it. |
 | **Integration** | Single `CognitiveEngine.think()` method. Plug in any LLM. |
 | **Cross-language** | JSON Schemas auto-generated from spec. Validate `.soul` files in any language. |
-| **CLI** | 11 commands. Rich TUI output. |
-| **MCP** | 10 tools + 3 resources for Claude Code, Cursor, or any MCP client |
+| **CLI** | 15 commands. Rich TUI output. |
+| **MCP** | 12 tools + 3 resources for Claude Code, Cursor, or any MCP client |
 
 ---
 
@@ -284,9 +284,13 @@ soul <command> [options]
 | `inspect` | Full TUI: identity, OCEAN bars, state, memory, self-model |
 | `status` | Quick check: mood, energy, memory count |
 | `export` | Export to .soul, .json, .yaml, or .md |
+| `inject` | Inject soul context into an agent platform's config file |
 | `migrate` | Convert SOUL.md to .soul format |
+| `recall` | Query a soul's memories |
+| `remember` | Store a memory in a soul |
 | `retire` | Retire a soul (preserves memories) |
 | `list` | List saved souls in ~/.soul/ |
+| `unpack` | Unpack a .soul file into a browsable directory |
 | `archive` | Archive to eternal storage tiers |
 | `recover` | Recover from eternal storage |
 | `eternal-status` | Show eternal storage references |
@@ -300,7 +304,7 @@ pip install soul-protocol[mcp]
 SOUL_PATH=aria.soul soul-mcp
 ```
 
-10 tools and 3 resources for Claude Code, Cursor, or any MCP-compatible client. See [integrations](docs/integrations.md).
+12 tools and 3 resources for Claude Code, Cursor, or any MCP-compatible client. See [integrations](docs/integrations.md).
 
 ---
 
@@ -355,7 +359,7 @@ await soul.observe(Interaction(
 git clone https://github.com/qbtrix/soul-protocol.git
 cd soul-protocol
 pip install -e ".[dev]"
-pytest tests/   # 996 tests
+pytest tests/   # 1189 tests
 ```
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 <!-- Covers: Documentation index, quick links to all guides (including integrations), version info, project links -->
+<!-- Updated: 2026-03-13 — added Tier 1.5 soul inject guide link -->
 
 # Soul Protocol Documentation
 
@@ -18,6 +19,7 @@ A soul remembers. A soul grows. A soul migrates.
 | [API Reference](api-reference.md) | Complete Soul class API, all types and models |
 | [MCP Server](mcp-server.md) | FastMCP server for agent integration -- tools, resources, prompts |
 | [Integrations](integrations.md) | Claude Code, Cursor, custom agents -- give any agent a .soul |
+| [Soul Inject Guide](guide-soul-inject.md) | Tier 1.5 integration -- inject soul context into agent platform configs with a single CLI command |
 | [CLI Reference](cli-reference.md) | Command-line interface for soul management |
 | [Architecture](architecture.md) | Design philosophy, psychology stack, module structure |
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,5 +1,7 @@
-<!-- Covers: MCP server setup, configuration for Claude Desktop/Cursor, all 10 tools with parameters,
-     3 resources, 2 prompts, programmatic usage, and design notes. -->
+<!-- Covers: MCP server setup, configuration for Claude Desktop/Cursor, all 12 tools with parameters,
+     3 resources, 2 prompts, programmatic usage, and design notes.
+     Updated: 2026-03-13 — added soul_list + soul_switch tools, SOUL_DIR env var, multi-soul registry notes,
+     renamed soul_system_prompt to soul_system_prompt_template, added optional soul parameter docs. -->
 
 # MCP Server
 
@@ -26,6 +28,8 @@ soul-mcp
 ```
 
 The server reads `SOUL_PATH` from the environment on startup. If set, it loads that soul file (`.soul`, `.json`, `.yaml`, or `.md`) before accepting connections. If not set, the server starts with no soul loaded -- clients must call `soul_birth` before using any other tool.
+
+You can also set `SOUL_DIR` to point to a directory containing multiple soul folders (e.g. `~/.soul/`). When `SOUL_DIR` is set, the server discovers all souls in that directory and loads them into the `SoulRegistry`. The first soul found becomes the active soul. Use `soul_list` and `soul_switch` to manage which soul is active at runtime. If both `SOUL_PATH` and `SOUL_DIR` are set, `SOUL_PATH` takes priority as the initially active soul.
 
 ## Configuration
 
@@ -65,9 +69,11 @@ Add to your MCP settings (`.cursor/mcp.json` or equivalent):
 
 Any client that speaks the Model Context Protocol over stdio can connect. The server uses FastMCP's default stdio transport.
 
-## Tools (10)
+## Tools (12)
 
 All tools are prefixed `soul_` to avoid name collisions when running alongside other MCP servers.
+
+**Multi-soul targeting:** When the server is running with `SOUL_DIR` and multiple souls are loaded, all tools accept an optional `soul` parameter (string) to target a specific soul by name or ID. If omitted, the tool operates on the currently active soul.
 
 ---
 
@@ -202,6 +208,30 @@ Export the soul as a portable `.soul` file (zip archive). Contains identity, DNA
 
 ---
 
+### `soul_list`
+
+List all souls known to the server. When running with `SOUL_DIR`, this returns every soul in the registry. When running with a single `SOUL_PATH`, it returns that one soul.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| (none) | | | |
+
+**Returns:** JSON with `souls` array. Each entry includes `name`, `did`, `active` (boolean), and `lifecycle`.
+
+---
+
+### `soul_switch`
+
+Switch the active soul. The newly active soul becomes the target for all subsequent tool calls that omit the `soul` parameter.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `soul` | `str` | required | Name or DID of the soul to activate |
+
+**Returns:** JSON with `status`, `name`, and `did` of the newly active soul. Returns an error if the soul is not found in the registry.
+
+---
+
 ## Resources (3)
 
 Resources provide read-only access to soul data. MCP clients can subscribe to these URIs for live state.
@@ -218,7 +248,7 @@ Prompts are pre-built text templates that MCP clients can request.
 
 | Name | Purpose |
 |------|---------|
-| `soul_system_prompt` | Complete system prompt for LLM context injection. Combines DNA, identity, core memory, state, and self-model into a single prompt string. |
+| `soul_system_prompt_template` | Complete system prompt template for LLM context injection. Combines DNA, identity, core memory, state, and self-model into a single prompt string. (Renamed from `soul_system_prompt` in v0.2.3.) |
 | `soul_introduction` | First-person self-introduction. Example: "I'm Aria, The Compassionate Creator. My core values are empathy, curiosity. I'm currently feeling curious with 85% energy." |
 
 ## Programmatic Usage
@@ -241,7 +271,7 @@ async with Client(mcp) as client:
 
 ## Design Notes
 
-- **One soul per server instance.** The server holds a single soul in a global variable. To manage multiple souls, run multiple server processes.
+- **Multi-soul via SoulRegistry.** When `SOUL_DIR` is set, the server loads all discovered souls into a `SoulRegistry` and exposes `soul_list` / `soul_switch` for runtime selection. One soul is active at a time; all tools default to it unless a `soul` parameter is provided. For single-soul setups (`SOUL_PATH` only), the registry holds one entry and `soul_switch` is a no-op.
 - **All tools are prefixed `soul_`.** This avoids name collisions when a client connects to several MCP servers simultaneously (e.g. soul + filesystem + database).
 - **Global state -- not thread-safe.** The server uses module-level state. Do not call `soul_observe` concurrently from multiple threads. Sequential tool calls from a single MCP client are fine.
 - **Stateful lifecycle.** The soul persists in memory across tool calls within a session. Call `soul_save` or `soul_export` to persist before the server shuts down.

--- a/docs/memory-architecture.md
+++ b/docs/memory-architecture.md
@@ -1,6 +1,9 @@
 <!-- Covers: The 5-tier memory system, psychology-informed observe() pipeline,
      ACT-R activation scoring, cross-store recall, pluggable retrieval,
-     reflection/consolidation, fact conflict resolution, and memory settings. -->
+     reflection/consolidation, fact conflict resolution, memory settings,
+     and v2 features: MemoryCategory, salience, L0/L1 content layers,
+     extraction taxonomy, dedup pipeline, abstract generation.
+     Updated: 2026-03-13 — added v2 memory features documentation. -->
 
 # Memory Architecture
 
@@ -365,6 +368,107 @@ Settings are passed at soul creation and persisted in the `.soul` file. They can
 - **Low-memory devices:** Reduce `episodic_max_entries` to 1,000 and `semantic_max_facts` to 200
 - **Long-running companions:** Increase limits and rely on eviction policies to keep quality high
 - **Testing:** Use small limits (100/50) for fast iteration
+
+
+## Memory Categories (v2)
+
+Every `MemoryEntry` can be assigned a `MemoryCategory` that classifies its semantic role. The `MemoryCategory` enum defines 7 values:
+
+| Category | Description | Example |
+|----------|-------------|---------|
+| `profile` | Identity facts about the user or soul | "User's name is Prakash" |
+| `preference` | Likes, dislikes, style choices | "User prefers dark mode" |
+| `entity` | Named things: people, places, organizations | "User works at Qbtrix" |
+| `event` | Time-bound happenings | "Deployed v0.2.2 on Tuesday" |
+| `case` | Problem/solution pairs, debugging sessions | "Fixed the OOM by reducing batch size" |
+| `pattern` | Recurring behaviors, workflows | "User always reviews PRs before merging" |
+| `skill` | Learned capabilities, domain knowledge | "User is proficient in async Python" |
+
+Categories are assigned automatically during fact extraction via the `classify_memory_category()` heuristic. The heuristic checks content against keyword patterns for each category and picks the best match. When no pattern matches, the default is `preference` for semantic memories and `event` for episodic memories.
+
+Categories power filtered recall: `soul.recall("Python", categories=[MemoryCategory.SKILL, MemoryCategory.PREFERENCE])`.
+
+
+## Salience (v2)
+
+Each `MemoryEntry` carries an optional `salience` field -- an additive boost applied during ACT-R activation scoring. The range is **-0.25 to +0.25**.
+
+```
+total = W_BASE * base + W_SPREAD * spread + W_EMOTION * emo + salience + noise
+```
+
+Salience lets the system (or an LLM judge) mark certain memories as more or less retrievable without changing their importance score. Use cases:
+
+- **Positive salience (+0.1 to +0.25):** Key architectural decisions, user corrections, safety-critical facts. These should surface even when activation would otherwise decay them.
+- **Negative salience (-0.1 to -0.25):** Stale preferences the user has moved past, superseded patterns. Soft-demoting without deletion.
+- **Zero (default):** No boost. Standard ACT-R decay applies.
+
+Salience is persisted in the `.soul` file and survives export/import round-trips.
+
+
+## Content Layers: L0 and L1 (v2)
+
+Long memories are expensive to inject into LLM context. Content layers provide progressive loading:
+
+- **L0 (abstract):** A compressed summary of the memory, roughly 100 tokens. Generated automatically when a memory is created. Used for listing and scanning large memory sets without blowing up context.
+- **L1 (overview):** A more detailed summary, roughly 1,000 tokens. Generated on demand or during reflection. Provides enough detail for most recall scenarios.
+- **Full content:** The original, uncompressed memory text. Loaded only when a client explicitly requests the full entry.
+
+Fields on `MemoryEntry`:
+
+| Field | Type | Size | When generated |
+|-------|------|------|----------------|
+| `content` | `str` | Full | Always (original text) |
+| `abstract` | `str` or `None` | ~100 tokens | On creation (first sentence, ~400 chars) |
+| `overview` | `str` or `None` | ~1K tokens | On demand or during reflection |
+
+Recall results include `abstract` by default. Clients can request `full=True` to get the complete content. This keeps context budgets manageable for souls with thousands of memories.
+
+### Abstract Generation
+
+Abstracts are generated using a simple heuristic: take the first sentence of the content, capped at approximately 400 characters. If the content is shorter than 400 characters, the abstract equals the full content. The heuristic splits on sentence boundaries (`.`, `!`, `?`) and picks the first complete sentence.
+
+With a `CognitiveEngine` attached, the LLM generates a more meaningful abstract that captures the key point rather than just the first sentence.
+
+
+## Extraction Taxonomy (v2)
+
+The `classify_memory_category()` function assigns a `MemoryCategory` to extracted facts. It runs as part of the fact extraction step in the psychology pipeline.
+
+**Heuristic classification rules (checked in order):**
+
+1. **profile** -- matches patterns like "name is", "I am a", "I'm from", "born in"
+2. **entity** -- matches patterns like "works at", "works for", capitalized proper nouns with relational context
+3. **skill** -- matches patterns like "proficient in", "experienced with", "knows how to", technology keywords
+4. **preference** -- matches patterns like "prefer", "like", "love", "hate", "dislike", "favorite"
+5. **event** -- matches temporal markers: "yesterday", "last week", "on Monday", date patterns
+6. **case** -- matches problem/solution language: "fixed", "solved", "debugged", "the issue was"
+7. **pattern** -- matches frequency language: "always", "usually", "every time", "tends to"
+
+If no rule matches, the fallback is `preference` for semantic entries and `event` for episodic entries.
+
+With a `CognitiveEngine`, the LLM classifies categories with richer context understanding, handling ambiguous cases that keyword matching misses.
+
+
+## Deduplication Pipeline (v2)
+
+The `reconcile_fact()` function runs before storing any new semantic fact. It prevents duplicates and handles updates to existing knowledge.
+
+**Algorithm:**
+
+1. Compute Jaccard token overlap between the new fact and every existing fact in semantic memory.
+2. Find the highest-overlap match.
+3. Apply thresholds:
+
+| Overlap | Action | Rationale |
+|---------|--------|-----------|
+| > 0.85 | **SKIP** | Near-duplicate. The existing fact already captures this knowledge. |
+| 0.6 -- 0.85 | **MERGE** | Partial overlap. Update the existing fact's content and bump its importance. The old content is preserved in `superseded_by` linkage. |
+| < 0.6 | **CREATE** | Sufficiently novel. Store as a new fact. |
+
+The merge operation combines the new information with the existing fact. If a `CognitiveEngine` is available, the LLM produces a merged statement. Otherwise, the newer fact replaces the older one (with `superseded_by` tracking).
+
+This three-tier approach (skip / merge / create) replaces the earlier binary dedup (overlap > 0.7 = skip, otherwise create) and reduces semantic memory bloat while preserving knowledge evolution history.
 
 
 ## Serialization


### PR DESCRIPTION
## Summary

Post-merge documentation audit covering PRs #82-86. Updates stale stats, adds missing docs for new features.

- **README.md** — test count (996 → 1189), tool count (10 → 12), CLI commands (11 → 15)
- **mcp-server.md** — 12 tools, soul_list/soul_switch docs, SOUL_DIR env var, multi-soul SoulRegistry, prompt rename
- **memory-architecture.md** — MemoryCategory enum, salience scoring, L0/L1 content layers, extraction taxonomy, dedup pipeline, abstract generation
- **index.md** — added Tier 1.5 (soul inject) link

## Test plan

- [x] Stats match actual counts (1189 tests, 12 tools, 15 CLI commands)
- [x] All new tool docs follow existing format
- [x] Memory v2 sections reference correct algorithms and thresholds