### PR TITLE
ci: auto-publish to PyPI on GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+# Publish to PyPI on GitHub release creation.
+# Requires PYPI_TOKEN secret set in repo settings.
+
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Build
+        run: uv build
+
+      - name: Publish
+        run: uv publish dist/*
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Adds a workflow that builds and publishes to PyPI whenever a GitHub release is created. Uses PYPI_TOKEN secret (already configured).