### PR TITLE
docs: sync README badge and header for v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 <!-- README.md — soul-protocol open standard -->
-<!-- Updated: 2026-04-06 — Added dream feature (offline batch consolidation).
+<!-- Updated: 2026-04-09 (v0.3.0) — bumped test count badge to 2105, noted the
+     four v0.3.0 features in this header block: dream cycle (offline batch
+     memory consolidation), smart recall (opt-in LLM reranking with prompt
+     injection defense and timeout), significance short-circuit (skip expensive
+     steps on trivial interactions), and soul remember --type flag fix.
+     Updated: 2026-04-06 — Added dream feature (offline batch consolidation).
      CLI: 37 → 38 commands. MCP: 23 → 24 tools.
      Updated: 2026-03-29 (v0.2.9) — bumped test count to 2010, version to 0.2.9.
      5 new features: skills decay, progressive recall, archival memory,
@@ -11,7 +16,7 @@
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests: 2010 passing](https://img.shields.io/badge/tests-2010%20passing-brightgreen)](https://github.com/qbtrix/soul-protocol)
+[![Tests: 2105 passing](https://img.shields.io/badge/tests-2105%20passing-brightgreen)](https://github.com/qbtrix/soul-protocol)
 
 ---
 
@@ -405,7 +410,7 @@ await soul.observe(Interaction(
 git clone https://github.com/qbtrix/soul-protocol.git
 cd soul-protocol
 pip install -e ".[dev]"
-pytest tests/   # 2010 tests
+pytest tests/   # 2105 tests
 ```
 
 ---


### PR DESCRIPTION
## What

Three tiny changes to `README.md`:

1. Test count badge: `tests-2010` → `tests-2105` (actual count from running the full suite locally on the current main)
2. Dev section snippet: `pytest tests/   # 2010 tests` → `pytest tests/   # 2105 tests`
3. Header comment block at the top of the file now has a v0.3.0 entry with the four features from this cycle (dream cycle, smart recall, significance short-circuit, `remember --type` fix)

## Why

The release commit bumped `pyproject.toml` and `__init__.py` to 0.3.0 and updated `CHANGELOG.md`, but the README badge and the header notes still referenced v0.2.9's test count. First-time visitors landing on the repo see a 2010 number that's nearly 100 tests behind reality, and the header block makes no mention of dream or smart recall even though both are the headline features of the release that's currently on PyPI.

## Scope

README only. Nothing else touched.