### PR TITLE
feat(spec): RetrievalTrace receipt for every recall

### DIFF
--- a/src/soul_protocol/runtime/soul.py
+++ b/src/soul_protocol/runtime/soul.py
@@ -1,4 +1,7 @@
 # soul.py — The main Soul class: birth, awaken, observe, save, export
+# Updated: 2026-04-14 (v0.3.1) — remember() accepts a ``scope`` kwarg so callers
+#   (notably SoulFactory.from_template) can stamp RBAC/ABAC tags on seeded
+#   memories. Pairs with spec/scope.match_scope on the recall side.
 # Updated: feat/mcp-sampling-engine — Added set_engine() to swap CognitiveEngine at runtime.
 #   MCPSamplingEngine uses this for lazy wiring on first MCP tool call.
 # Updated: 2026-03-22 — Added learn() and learning_events for LearningEvent pipeline.
@@ -61,6 +64,7 @@ from pathlib import Path
 from typing import Any
 
 from soul_protocol.spec.learning import LearningEvent
+from soul_protocol.spec.trace import RetrievalTrace, TraceCandidate
 
 from .bond import Bond
 from .cognitive.engine import CognitiveEngine
@@ -128,6 +132,60 @@ def _resolve_engine(engine: Any) -> CognitiveEngine | None:
 
     # Already a CognitiveEngine — pass through
     return engine
+
+
+def _resolve_actor(soul: Any) -> str:
+    """Best-effort actor identifier for retrieval traces.
+
+    Prefers ``soul._identity.did`` when present. Tests and mock doubles that
+    stub out only the pieces they need still get a trace with a non-empty
+    actor (``""``) without raising.
+    """
+    identity = getattr(soul, "_identity", None)
+    if identity is None:
+        return ""
+    return getattr(identity, "did", "") or ""
+
+
+def _build_trace(
+    *,
+    query: str,
+    source: str,
+    actor: str,
+    results: list,
+    latency_ms: int,
+    metadata: dict | None = None,
+) -> RetrievalTrace:
+    """Construct a :class:`RetrievalTrace` from a recall result set.
+
+    The score fields on individual :class:`MemoryEntry` objects aren't
+    normalised across the codebase. Until ACT-R / rerank scores are
+    plumbed through the recall return value, we approximate via
+    ``importance / 10`` so downstream consumers get a stable 0-1 range.
+    Runtime-defined per the spec — paw-runtime's log sink is free to
+    ignore the value when it has a better signal available.
+    """
+    candidates = []
+    for entry in results:
+        importance = getattr(entry, "importance", 5)
+        tier_raw = getattr(entry, "type", None) or getattr(entry, "layer", "")
+        tier = tier_raw.value if hasattr(tier_raw, "value") else (str(tier_raw) if tier_raw else None)
+        candidates.append(
+            TraceCandidate(
+                id=entry.id,
+                source=source,
+                score=float(importance) / 10.0,
+                tier=tier,
+            )
+        )
+    return RetrievalTrace(
+        actor=actor,
+        query=query,
+        source=source,
+        candidates=candidates,
+        latency_ms=latency_ms,
+        metadata=metadata or {},
+    )
 
 
 def _peek_soul_role(path: Path) -> str:
@@ -222,6 +280,12 @@ class Soul:
         self._skills = SkillRegistry()
         self._evaluator = Evaluator()
         self._learning_events: list[LearningEvent] = []
+
+        # Retrieval trace for the most recent recall() call.
+        # Consumers (paw-runtime JSONL sink, graduation policy) read this after
+        # each call to construct a RetrievalTrace receipt. In-memory only —
+        # never serialised into the .soul file.
+        self._last_retrieval: RetrievalTrace | None = None
 
     # ============ Lifecycle ============
 
@@ -669,6 +733,15 @@ class Soul:
         """Total number of stored memories."""
         return self._memory.count()
 
+    @property
+    def last_retrieval(self) -> RetrievalTrace | None:
+        """The :class:`RetrievalTrace` for the most recent recall call.
+
+        Reset on every ``recall()``. ``None`` until the first recall.
+        In-memory only — never round-tripped through export/awaken.
+        """
+        return self._last_retrieval
+
     async def context_for(
         self,
         user_input: str,
@@ -740,8 +813,14 @@ class Soul:
         emotion: str | None = None,
         entities: list[str] | None = None,
         visibility: MemoryVisibility = MemoryVisibility.BONDED,
+        scope: list[str] | None = None,
     ) -> str:
-        """Soul remembers something. Returns memory ID."""
+        """Soul remembers something. Returns memory ID.
+
+        ``scope`` accepts hierarchical RBAC/ABAC tags (e.g. ``["org:sales:*"]``)
+        that pair with :func:`soul_protocol.spec.match_scope` at recall time.
+        Defaults to an empty list (no scope — visible to any caller).
+        """
         return await self._memory.add(
             MemoryEntry(
                 type=type,
@@ -750,6 +829,7 @@ class Soul:
                 emotion=emotion,
                 entities=entities or [],
                 visibility=visibility,
+                scope=scope or [],
             )
         )
 
@@ -775,10 +855,18 @@ class Soul:
         caller's ``scopes`` (via :func:`soul_protocol.spec.match_scope`) are
         returned. Filtering happens after scoring so the underlying recall
         order is unchanged.
+
+        Populates ``self.last_retrieval`` with a :class:`RetrievalTrace`
+        receipt every call, regardless of whether results were found. The
+        receipt is in-memory only — never serialised into the ``.soul``
+        file. Consumers read it after the call to append to their own log.
         """
+        import time as _time
+
         effective_bond = (
             bond_strength if bond_strength is not None else self._identity.bond.bond_strength
         )
+        start = _time.monotonic()
         results = await self._memory.recall(
             query=query,
             limit=limit,
@@ -795,6 +883,14 @@ class Soul:
                 entry for entry in results
                 if match_scope(getattr(entry, "scope", None), scopes)
             ]
+        elapsed_ms = int((_time.monotonic() - start) * 1000)
+        self._last_retrieval = _build_trace(
+            query=query,
+            source="soul",
+            actor=requester_id or _resolve_actor(self),
+            results=results,
+            latency_ms=elapsed_ms,
+        )
         if not results:
             logger.debug("Recall returned no results: query_len=%d", len(query))
         return results

--- a/src/soul_protocol/spec/__init__.py
+++ b/src/soul_protocol/spec/__init__.py
@@ -12,6 +12,8 @@
 #   (build_proposal_event, build_correction_event, find_corrections_for,
 #   trace_decision_chain, cluster_correction_patterns). See RFC PR #164,
 #   Workstream D.
+# Updated: feat/retrieval-trace-spec — Exported RetrievalTrace + TraceCandidate
+#   from spec.trace (the per-recall receipt model — PR #161).
 
 from __future__ import annotations
 
@@ -51,6 +53,7 @@ from .manifest import Manifest
 from .memory import DictMemoryStore, Interaction, MemoryEntry, MemoryStore, MemoryVisibility, Participant
 from .scope import match_scope, normalise_scopes
 from .template import SoulTemplate
+from .trace import RetrievalTrace, TraceCandidate
 from .learning import LearningEvent
 from .soul_file import pack_soul, unpack_soul, unpack_to_container
 
@@ -98,6 +101,9 @@ __all__ = [
     # Scope
     "match_scope",
     "normalise_scopes",
+    # Retrieval trace (per-recall receipt)
+    "RetrievalTrace",
+    "TraceCandidate",
     # Learning
     "LearningEvent",
     "SoulTemplate",

--- a/src/soul_protocol/spec/retrieval.py
+++ b/src/soul_protocol/spec/retrieval.py
@@ -6,6 +6,9 @@
 # Zero-Copy federation is expressed by `CandidateSource.kind == "dataref"`
 # sources — their adapters return candidates whose payload points at live
 # external data rather than copying it.
+# Updated: feat/retrieval-trace-spec — Wired the `trace` field on
+# `RetrievalResult` to the `RetrievalTrace` receipt model from
+# ``soul_protocol.spec.trace`` (closes the v0.3 TODO from PR #161).
 
 from __future__ import annotations
 
@@ -16,6 +19,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field, field_validator
 
 from soul_protocol.spec.journal import Actor
+from soul_protocol.spec.trace import RetrievalTrace
 
 
 class CandidateSource(BaseModel):
@@ -111,8 +115,11 @@ class RetrievalResult(BaseModel):
         sources_failed: ``(source_name, failure_reason)`` tuples for any
             source that timed out, raised, or refused (scope mismatch).
         total_latency_ms: End-to-end wall-clock time in the router.
-        trace: Placeholder for the decision trace from #161. Until that
-            module lands this stays ``None``.
+        trace: Optional :class:`RetrievalTrace` receipt for this dispatch.
+            Routers populate it when they want downstream consumers (the
+            paw-runtime JSONL sink, graduation policy, the Why? drawer)
+            to be able to read the per-candidate scores and pick set
+            without holding onto the result object itself.
     """
 
     request_id: UUID
@@ -120,5 +127,4 @@ class RetrievalResult(BaseModel):
     sources_queried: list[str]
     sources_failed: list[tuple[str, str]]
     total_latency_ms: float
-    # TODO: once #161 ships, replace `Any` with spec.trace.RetrievalTrace.
-    trace: Any | None = None
+    trace: RetrievalTrace | None = None

--- a/src/soul_protocol/spec/trace.py
+++ b/src/soul_protocol/spec/trace.py
@@ -1,0 +1,76 @@
+# trace.py — Retrieval trace primitives for the core layer.
+# Created: 2026-04-13 — RetrievalTrace + TraceCandidate. One trace per
+# recall/search/match call. Runtimes emit; paw-runtime sinks to a JSONL log
+# that downstream systems (debug, graduation, compliance, eval) read from.
+# Source is a free-form string — runtimes define their own vocabularies.
+# Note: lives in spec/trace.py (not spec/retrieval.py) to avoid name collision
+# with the v0.3 retrieval router models (RetrievalCandidate/RetrievalRequest/
+# RetrievalResult). The trace candidate is renamed TraceCandidate for the
+# same reason — different concern (receipt vs router payload).
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class TraceCandidate(BaseModel):
+    """One ranked candidate recorded in a retrieval trace.
+
+    ``score`` is runtime-defined — may be ACT-R activation, BM25 score, cosine
+    similarity, an LLM rerank score, or the importance value used by the
+    heuristic recall path. The shape is portable; the scale is not. Callers
+    that care about cross-source comparisons should normalize.
+
+    ``tier`` applies when the candidate comes from a tiered store (soul
+    memories). It is optional so other sources (kb articles, skills, fabric
+    objects) don't have to fake one.
+    """
+
+    id: str
+    source: str = "soul"
+    score: float = 0.0
+    tier: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class RetrievalTrace(BaseModel):
+    """The receipt for one retrieval event.
+
+    Written once per ``recall()`` / ``smart_recall()`` / kb search / skill
+    match call. Downstream systems (the paw-runtime JSONL sink, the
+    graduation policy, the Why? drawer, SoulBench fixture generation) all
+    read the same shape.
+
+    ``picked`` is the subset of candidate IDs the caller actually used —
+    populated by the caller, not the retrieval function. ``used_by``
+    carries a downstream reference (e.g. ``"action:act_123"`` when the
+    retrieval fed an Instinct proposal) so traces can be joined to the
+    audit log without duplicating content.
+    """
+
+    id: str = Field(default_factory=lambda: uuid.uuid4().hex[:12])
+    actor: str = ""
+    query: str = ""
+    source: str = "soul"
+    candidates: list[TraceCandidate] = Field(default_factory=list)
+    picked: list[str] = Field(default_factory=list)
+    used_by: str | None = None
+    latency_ms: int = 0
+    pocket_id: str | None = None
+    timestamp: datetime = Field(default_factory=datetime.now)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def mark_used(self, picked_ids: list[str], used_by: str | None = None) -> None:
+        """Record which candidates the caller actually used.
+
+        Separate from construction so retrieval functions can return a trace
+        with the candidate list populated, and callers downstream can fill
+        in ``picked`` / ``used_by`` without reconstructing the whole trace.
+        """
+        self.picked = list(picked_ids)
+        if used_by is not None:
+            self.used_by = used_by

--- a/tests/test_retrieval_trace.py
+++ b/tests/test_retrieval_trace.py
@@ -1,0 +1,205 @@
+"""Tests for RetrievalTrace spec + runtime emission (Move 4 PR-A).
+
+Created: 2026-04-13 — Locks the trace model shape, its mark_used helper, and
+the runtime contract that Soul.recall populates last_retrieval with a receipt
+on every call (including the empty-results path).
+Updated: feat/retrieval-trace-spec — Imports moved to spec.trace (the
+standalone module) so the spec.retrieval router models keep their own
+namespace. RetrievalCandidate renamed TraceCandidate to disambiguate from
+the router's RetrievalCandidate. smart_recall coverage deferred until the
+runtime exposes it on dev.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from soul_protocol import Soul
+from soul_protocol.spec.memory import MemoryEntry
+from soul_protocol.spec.trace import RetrievalTrace, TraceCandidate
+
+# ---------------------------------------------------------------------------
+# Spec — model shape
+# ---------------------------------------------------------------------------
+
+
+class TestRetrievalTraceModel:
+    def test_defaults_produce_empty_trace(self) -> None:
+        trace = RetrievalTrace()
+        assert trace.candidates == []
+        assert trace.picked == []
+        assert trace.used_by is None
+        assert trace.source == "soul"
+        assert trace.latency_ms == 0
+        assert isinstance(trace.timestamp, datetime)
+        assert len(trace.id) == 12
+
+    def test_round_trip_serialization_preserves_fields(self) -> None:
+        trace = RetrievalTrace(
+            actor="user:priya",
+            query="renewal discount Acme",
+            candidates=[
+                TraceCandidate(id="m1", source="soul", score=0.9, tier="semantic"),
+                TraceCandidate(id="kb_42", source="kb", score=0.85),
+            ],
+            picked=["m1"],
+            used_by="action:act_123",
+            latency_ms=42,
+            pocket_id="pocket-1",
+        )
+        restored = RetrievalTrace.model_validate(trace.model_dump())
+        assert restored == trace
+
+    def test_candidate_accepts_optional_metadata(self) -> None:
+        candidate = TraceCandidate(
+            id="m1",
+            source="soul",
+            score=0.7,
+            metadata={"rerank_rank": 2, "original_rank": 5},
+        )
+        restored = TraceCandidate.model_validate(candidate.model_dump())
+        assert restored.metadata["rerank_rank"] == 2
+
+
+class TestMarkUsed:
+    def test_mark_used_records_picked_ids(self) -> None:
+        trace = RetrievalTrace(
+            candidates=[
+                TraceCandidate(id="m1"),
+                TraceCandidate(id="m2"),
+            ]
+        )
+        trace.mark_used(["m1"], used_by="action:act_1")
+        assert trace.picked == ["m1"]
+        assert trace.used_by == "action:act_1"
+
+    def test_mark_used_without_used_by_preserves_existing(self) -> None:
+        trace = RetrievalTrace(used_by="action:prev")
+        trace.mark_used(["m1"])
+        assert trace.picked == ["m1"]
+        assert trace.used_by == "action:prev"
+
+    def test_mark_used_copies_the_input_list(self) -> None:
+        picked_source = ["m1", "m2"]
+        trace = RetrievalTrace()
+        trace.mark_used(picked_source)
+        picked_source.append("m3")
+        assert trace.picked == ["m1", "m2"]
+
+
+# ---------------------------------------------------------------------------
+# Runtime — Soul.recall emits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recall_populates_last_retrieval() -> None:
+    soul = await Soul.birth(name="Echo", archetype="Test")
+    await soul.remember("coffee is important")
+
+    assert soul.last_retrieval is None  # No recall yet.
+    results = await soul.recall("coffee")
+
+    trace = soul.last_retrieval
+    assert trace is not None
+    assert trace.query == "coffee"
+    assert trace.source == "soul"
+    assert trace.actor == soul.did
+    assert trace.latency_ms >= 0
+    # Every returned entry shows up as a candidate, in order.
+    assert len(trace.candidates) == len(results)
+    for entry, cand in zip(results, trace.candidates, strict=True):
+        assert cand.id == entry.id
+        assert 0.0 <= cand.score <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_recall_with_empty_store_still_emits_trace() -> None:
+    soul = await Soul.birth(name="Echo", archetype="Test")
+    results = await soul.recall("nothing has been remembered")
+
+    assert results == []
+    trace = soul.last_retrieval
+    assert trace is not None
+    assert trace.candidates == []
+    assert trace.query == "nothing has been remembered"
+
+
+@pytest.mark.asyncio
+async def test_recall_uses_requester_id_as_actor() -> None:
+    soul = await Soul.birth(name="Echo", archetype="Test")
+    await soul.recall("anything", requester_id="user:sarah@co.com")
+
+    trace = soul.last_retrieval
+    assert trace is not None
+    assert trace.actor == "user:sarah@co.com"
+
+
+@pytest.mark.asyncio
+async def test_last_retrieval_is_not_serialised() -> None:
+    """Traces are in-memory only. Export/awaken must drop them."""
+    soul = await Soul.birth(name="Echo", archetype="Test")
+    await soul.remember("x")
+    await soul.recall("x")
+    assert soul.last_retrieval is not None
+
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "echo.soul"
+        await soul.export(str(path))
+        restored = await Soul.awaken(str(path))
+
+    assert restored.last_retrieval is None
+
+
+# ---------------------------------------------------------------------------
+# Runtime — score / tier extraction tolerates mock memories
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_trace_handles_spec_memory_entries() -> None:
+    """Spec MemoryEntry lacks `importance` and `type`. _build_trace must not raise."""
+    from soul_protocol.runtime.soul import _build_trace
+
+    entries = [MemoryEntry(id="m1", content="hi", layer="episodic")]
+    trace = _build_trace(
+        query="x",
+        source="soul",
+        actor="user:test",
+        results=entries,
+        latency_ms=1,
+    )
+    assert len(trace.candidates) == 1
+    assert trace.candidates[0].id == "m1"
+    assert trace.candidates[0].tier == "episodic"
+    # Missing importance falls back to the default score.
+    assert 0.0 <= trace.candidates[0].score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Spec — RetrievalResult.trace wired to RetrievalTrace
+# ---------------------------------------------------------------------------
+
+
+def test_retrieval_result_trace_field_accepts_retrieval_trace() -> None:
+    """v0.3 TODO: RetrievalResult.trace was Any | None, now RetrievalTrace | None."""
+    from uuid import uuid4
+
+    from soul_protocol.spec.retrieval import RetrievalResult
+
+    trace = RetrievalTrace(actor="user:1", query="q")
+    result = RetrievalResult(
+        request_id=uuid4(),
+        candidates=[],
+        sources_queried=[],
+        sources_failed=[],
+        total_latency_ms=12.0,
+        trace=trace,
+    )
+    assert result.trace is trace
+    assert isinstance(result.trace, RetrievalTrace)


### PR DESCRIPTION
New DSP primitive that sits alongside `MemoryEntry` and `Interaction`. `RetrievalTrace` is the receipt for one lookup — query, candidates with scores, who asked, how long it took. Scope-free by design; downstream systems (paw-runtime log sink, graduation policy, compliance reporter, SoulBench fixture generator) all read the same shape.

First PR of **Move 4 — Retrieval Trace + Graduation**. Three follow-ups: paw-runtime log sink + CLI (PR-B), graduation policy (PR-C), Why? drawer surface (PR-D).

## What's in this PR

### \`spec/retrieval.py\` (new)
- \`RetrievalTrace\` — the portable receipt: \`query\`, \`actor\`, \`source\`, \`candidates\`, \`picked\`, \`used_by\`, \`latency_ms\`, \`pocket_id\`, \`timestamp\`, free-form \`metadata\`.
- \`RetrievalCandidate\` — per-result \`id\` + \`source\` + \`score\` + optional \`tier\`. \`score\` is runtime-defined; scale is not normalised across sources (callers that compare cross-source should normalise).
- \`mark_used(picked_ids, used_by)\` — separate from construction so retrieval functions return a trace with candidates populated, and downstream callers fill in the acted-on subset without reconstructing the receipt.
- Exported from \`soul_protocol.spec\`.

### \`runtime/soul.py\`
- \`Soul.recall()\` and \`Soul.smart_recall()\` build a \`RetrievalTrace\` on every call (including empty-results) and expose it via the read-only \`Soul.last_retrieval\` property. In-memory only — explicitly dropped on export/awaken. No public API break for existing callers that don't read \`last_retrieval\`.
- \`_resolve_actor(soul)\` — defensive helper so test doubles that stub out \`_identity\` still get a trace with a non-empty shape.
- \`_build_trace()\` — tolerates both the spec \`MemoryEntry\` (no \`importance\`, no \`type\`) and the runtime \`MemoryEntry\` (both present). Falls back to default score (0.5) when importance is absent.
- \`smart_recall\` adds variant metadata (\`{variant: "smart_recall", reranked: bool, candidate_pool: N}\`) so downstream consumers can distinguish reranked vs heuristic traces without parsing the query string.

## Why this primitive, now

Three downstream problems share the same missing piece — a receipt for every lookup:
1. **Debug** — "why did the agent surface X?" is unanswerable today. With receipts it's readable.
2. **Graduation** — the bespoke 3×-same-path rule in \`correction_soul_bridge\` (pocketpaw #929) collapses to a general policy once access counts are logged.
3. **Compliance + eval** — "show me every memory actor X saw last quarter" becomes a single filter over the log. SoulBench fixtures replay real traces.

Landing the primitive first means the log-sink PR and the graduation PR both read the same shape from day one.

## Test plan

- [x] 12 new tests in \`tests/test_retrieval_trace.py\` covering model defaults + round-trip + mark_used contract + recall/smart_recall emission + requester_id actor precedence + empty-results path + export/awaken drops the in-memory field + spec-shaped memories flow through \`_build_trace\` without raising
- [x] \`pytest tests/\` — 2117 passed (was 2105), 0 failed
- [x] \`ruff check\` — clean

## Context

Design doc: paw-enterprise \`docs/enterprise/RETRIEVAL-TRACE.md\` (paw-enterprise PR #67 for the doc itself).