### PR TITLE
feat(spec): scope tags on MemoryEntry + match_scope helper

### DIFF
--- a/src/soul_protocol/runtime/soul.py
+++ b/src/soul_protocol/runtime/soul.py
@@ -763,9 +763,22 @@ class Soul:
         requester_id: str | None = None,
         bond_strength: float | None = None,
         bond_threshold: float = 30.0,
+        progressive: bool = False,
+        scopes: list[str] | None = None,
     ) -> list[MemoryEntry]:
-        """Soul recalls relevant memories with visibility filtering."""
-        effective_bond = bond_strength if bond_strength is not None else self._identity.bond.bond_strength
+        """Soul recalls relevant memories with visibility + scope filtering.
+
+        ``scopes`` applies hierarchical RBAC/ABAC matching. When omitted (or
+        empty) the caller sees everything they would otherwise see — back-compat
+        for pre-scope memories and consumers that do not need RBAC. When
+        present, only memories whose own ``scope`` list intersects with the
+        caller's ``scopes`` (via :func:`soul_protocol.spec.match_scope`) are
+        returned. Filtering happens after scoring so the underlying recall
+        order is unchanged.
+        """
+        effective_bond = (
+            bond_strength if bond_strength is not None else self._identity.bond.bond_strength
+        )
         results = await self._memory.recall(
             query=query,
             limit=limit,
@@ -775,6 +788,13 @@ class Soul:
             bond_strength=effective_bond,
             bond_threshold=bond_threshold,
         )
+        if scopes:
+            from soul_protocol.spec.scope import match_scope
+
+            results = [
+                entry for entry in results
+                if match_scope(getattr(entry, "scope", None), scopes)
+            ]
         if not results:
             logger.debug("Recall returned no results: query_len=%d", len(query))
         return results

--- a/src/soul_protocol/runtime/types.py
+++ b/src/soul_protocol/runtime/types.py
@@ -276,6 +276,15 @@ class MemoryEntry(BaseModel):
     # v0.4.0 — Contradiction detection
     superseded: bool = False  # True when a newer memory contradicts this one
     visibility: MemoryVisibility = MemoryVisibility.BONDED
+    # F2 archival memory — marks episodic memories that have been archived
+    archived: bool = False  # True when memory has been compressed into a ConversationArchive
+    # F1 progressive disclosure — runtime-only marker, never persisted
+    is_summarized: bool = False  # Runtime marker: True when content replaced with abstract
+    # Move 5 PR-A — RBAC/ABAC scope tags. Empty list = no scope assigned
+    # (visible to any caller). Hierarchical glob: "org:sales:*" matches
+    # "org:sales:leads". Filtered at retrieval time before results reach
+    # the LLM.
+    scope: list[str] = Field(default_factory=list)
 
 
 class CoreMemory(BaseModel):

--- a/src/soul_protocol/spec/__init__.py
+++ b/src/soul_protocol/spec/__init__.py
@@ -49,6 +49,7 @@ from .decisions import (
 from .journal import ACTION_NAMESPACES, Actor, DataRef, EventEntry
 from .manifest import Manifest
 from .memory import DictMemoryStore, Interaction, MemoryEntry, MemoryStore, MemoryVisibility, Participant
+from .scope import match_scope, normalise_scopes
 from .template import SoulTemplate
 from .learning import LearningEvent
 from .soul_file import pack_soul, unpack_soul, unpack_to_container
@@ -94,6 +95,9 @@ __all__ = [
     "MemoryStore",
     "MemoryVisibility",
     "DictMemoryStore",
+    # Scope
+    "match_scope",
+    "normalise_scopes",
     # Learning
     "LearningEvent",
     "SoulTemplate",

--- a/src/soul_protocol/spec/memory.py
+++ b/src/soul_protocol/spec/memory.py
@@ -104,6 +104,15 @@ class MemoryEntry(BaseModel):
     source: str = ""
     layer: str = ""
     visibility: MemoryVisibility = MemoryVisibility.BONDED
+    scope: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Hierarchical scope tags for RBAC/ABAC. Empty list = no scope check"
+            " (treated as visible to any caller). Glob pattern: 'org:sales:*'"
+            " matches 'org:sales:leads' and 'org:sales:deals'. Runtimes apply"
+            " filtering at retrieval time before results reach the LLM."
+        ),
+    )
     metadata: dict[str, Any] = Field(default_factory=dict)
     ingested_at: datetime | None = None  # When memory entered the pipeline
     superseded: bool = False  # True when a newer memory contradicts this one

--- a/src/soul_protocol/spec/scope.py
+++ b/src/soul_protocol/spec/scope.py
@@ -1,0 +1,59 @@
+# scope.py — Hierarchical scope tag matching for RBAC/ABAC.
+# Created: 2026-04-13 (Move 5 PR-A) — Pure helper. No I/O, no enums, no
+# imports beyond stdlib. The same matcher is used by soul recall, fabric
+# queries, kb retrievals, and pocket visibility checks. Centralised here
+# so behaviour is identical across every retrieval path.
+
+from __future__ import annotations
+
+
+def match_scope(entity_scopes: list[str] | None, allowed_scopes: list[str] | None) -> bool:
+    """Return True when at least one of ``entity_scopes`` is granted by
+    ``allowed_scopes`` (or when either side is empty).
+
+    Empty ``entity_scopes`` is treated as "no scope assigned" — visible
+    to any caller. Empty ``allowed_scopes`` is treated as "caller has no
+    scope filter" — sees everything. This matches the lean default that
+    pre-scope memories continue to surface unchanged.
+
+    Hierarchical glob: ``"org:sales:*"`` matches ``"org:sales:leads"``
+    and ``"org:sales"`` itself. ``"*"`` matches anything. Comparison is
+    case-sensitive — scope tags are namespaced ASCII identifiers, not
+    free-form labels.
+    """
+    if not entity_scopes:
+        return True
+    if not allowed_scopes:
+        return True
+    return any(
+        _granted(entity, allowed)
+        for entity in entity_scopes
+        for allowed in allowed_scopes
+    )
+
+
+def _granted(entity: str, allowed: str) -> bool:
+    if allowed == "*":
+        return True
+    if allowed == entity:
+        return True
+    if allowed.endswith(":*"):
+        prefix = allowed[:-2]
+        return entity == prefix or entity.startswith(prefix + ":")
+    return False
+
+
+def normalise_scopes(scopes: list[str] | None) -> list[str]:
+    """Strip + lowercase + de-duplicate. Returns a fresh list, preserving order."""
+    if not scopes:
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in scopes:
+        if not isinstance(raw, str):
+            continue
+        cleaned = raw.strip().lower()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            out.append(cleaned)
+    return out

--- a/tests/test_scope_tags.py
+++ b/tests/test_scope_tags.py
@@ -1,0 +1,145 @@
+"""Tests for scope tags + the match_scope helper (Move 5 PR-A).
+
+Created: 2026-04-13 — Hierarchical RBAC/ABAC matching, MemoryEntry shape
+preservation across export/awaken, and Soul.recall scope-filter semantics.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from soul_protocol import Soul
+from soul_protocol.runtime.types import MemoryType
+from soul_protocol.spec.memory import MemoryEntry
+from soul_protocol.spec.scope import match_scope, normalise_scopes
+
+# ---------------------------------------------------------------------------
+# match_scope
+# ---------------------------------------------------------------------------
+
+
+class TestMatchScope:
+    def test_exact_match_grants(self) -> None:
+        assert match_scope(["org:sales:leads"], ["org:sales:leads"])
+
+    def test_no_overlap_denies(self) -> None:
+        assert not match_scope(["org:finance:reports"], ["org:sales:*"])
+
+    def test_glob_matches_exact_prefix(self) -> None:
+        assert match_scope(["org:sales:leads"], ["org:sales:*"])
+        assert match_scope(["org:sales:deals"], ["org:sales:*"])
+        # The bare prefix itself is included.
+        assert match_scope(["org:sales"], ["org:sales:*"])
+
+    def test_glob_does_not_cross_segment_boundary(self) -> None:
+        # "org:sales*" is NOT a valid glob — only "*:" wildcarding is supported.
+        assert not match_scope(["org:salesforce"], ["org:sales:*"])
+
+    def test_star_matches_everything(self) -> None:
+        assert match_scope(["org:hr:payroll"], ["*"])
+
+    def test_empty_entity_scopes_visible_to_anyone(self) -> None:
+        """No scope tag = no scope check. Pre-scope memories stay visible."""
+        assert match_scope([], ["org:sales:*"])
+        assert match_scope(None, ["org:sales:*"])
+
+    def test_empty_allowed_scopes_passes_through(self) -> None:
+        """Caller without a scope filter sees everything."""
+        assert match_scope(["org:sales:leads"], [])
+        assert match_scope(["org:sales:leads"], None)
+
+    def test_at_least_one_match_grants(self) -> None:
+        # Entity has multiple scopes; granted if ANY allowed grants ANY of them.
+        assert match_scope(
+            ["org:sales:leads", "org:marketing:content"],
+            ["org:marketing:*"],
+        )
+
+    def test_unknown_pattern_does_not_grant(self) -> None:
+        # Patterns must be exact or end with `:*`; arbitrary substrings don't.
+        assert not match_scope(["org:sales:leads"], ["sales"])
+
+
+class TestNormaliseScopes:
+    def test_lowercases_strips_dedupes(self) -> None:
+        cleaned = normalise_scopes(["Org:Sales:*", "  org:sales:*  ", "org:finance:read"])
+        assert cleaned == ["org:sales:*", "org:finance:read"]
+
+    def test_drops_empty_and_non_string(self) -> None:
+        cleaned = normalise_scopes(["", " ", None, 42, "org:sales"])  # type: ignore[list-item]
+        assert cleaned == ["org:sales"]
+
+    def test_none_returns_empty(self) -> None:
+        assert normalise_scopes(None) == []
+
+
+# ---------------------------------------------------------------------------
+# MemoryEntry shape
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryEntryScopeField:
+    def test_default_is_empty_list(self) -> None:
+        entry = MemoryEntry(content="hi")
+        assert entry.scope == []
+
+    def test_round_trip_preserves_scope(self) -> None:
+        entry = MemoryEntry(content="hi", scope=["org:sales:*", "org:marketing:read"])
+        restored = MemoryEntry.model_validate(entry.model_dump())
+        assert restored.scope == entry.scope
+
+
+# ---------------------------------------------------------------------------
+# Soul.recall scope filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recall_without_scopes_kwarg_returns_all() -> None:
+    soul = await Soul.birth(name="Echo", archetype="Test")
+    await soul.remember("coffee is part of the morning routine")
+    await soul.remember("the team prefers light roast coffee")
+
+    results = await soul.recall("coffee")
+    # Default behaviour preserved — no scope filter applied.
+    assert len(results) >= 2
+
+
+@pytest.mark.asyncio
+async def test_recall_with_scopes_filters_unscoped_memories_in() -> None:
+    """Memories without scope are visible to any scoped caller — back-compat."""
+    soul = await Soul.birth(name="Echo", archetype="Test")
+    await soul.remember("the renewal policy caps discount at twenty percent")
+
+    results = await soul.recall("renewal policy discount", scopes=["org:sales:*"])
+    assert len(results) >= 1
+
+
+@pytest.mark.asyncio
+async def test_recall_with_scopes_filters_disallowed_memories_out() -> None:
+    soul = await Soul.birth(name="Echo", archetype="Test")
+    await soul.remember("internal salary band data confidential")
+
+    semantic = soul._memory._semantic._facts  # type: ignore[attr-defined]
+    assert len(semantic) >= 1
+    for entry in semantic.values():
+        entry.scope = ["org:finance:reports"]
+
+    sales_caller = await soul.recall("salary band", scopes=["org:sales:*"])
+    assert sales_caller == []
+
+    finance_caller = await soul.recall("salary band", scopes=["org:finance:*"])
+    assert len(finance_caller) >= 1
+
+
+@pytest.mark.asyncio
+async def test_runtime_memory_entry_carries_scope() -> None:
+    """The runtime MemoryEntry has the field too — so producers can attach it."""
+    from soul_protocol.runtime.types import MemoryEntry as RuntimeMemoryEntry
+
+    entry = RuntimeMemoryEntry(
+        type=MemoryType.SEMANTIC,
+        content="hi",
+        scope=["org:sales:*"],
+    )
+    assert entry.scope == ["org:sales:*"]


### PR DESCRIPTION
First foundational primitive for the RBAC/ABAC layer described in the fleet vision. \`MemoryEntry\` gains an optional \`scope: list[str]\` field; \`Soul.recall\` accepts an optional \`scopes=\` kwarg; a standalone \`match_scope\` helper centralises hierarchical glob matching so every retrieval path uses the same logic once paw-runtime adopts it in PR-B.

Move 5 PR-A. Three follow-ups: PR-B (Fabric + Pocket scope + policy engine in pocketpaw), PR-C (scope chip UI), PR-D (E2E enforcement test).

## What's in this PR

### \`spec/memory.py\`
- New \`scope: list[str]\` field on \`MemoryEntry\`. Default empty list = "no scope assigned, visible to anyone." Round-trips through \`model_dump\` cleanly.

### \`spec/scope.py\` (new)
- \`match_scope(entity_scopes, allowed_scopes)\` — boolean OR over cartesian; empty either side passes through (back-compat for pre-scope memories AND callers without a scope filter). Hierarchical glob: \`org:sales:*\` matches \`org:sales:leads\` and \`org:sales:deals\`, \`*\` matches everything.
- \`normalise_scopes(scopes)\` — strip + lowercase + dedupe, drops empty + non-string entries.

### \`runtime/types.py\`
- Same \`scope\` field on the runtime \`MemoryEntry\` so producers can attach scope at remember-time once PR-B lands. Spec and runtime entries diverge on tier-related fields but share the scope shape exactly.

### \`runtime/soul.py\`
- \`Soul.recall\` accepts \`scopes: list[str] | None\`. Empty/None preserves existing behaviour. When set, results are filtered after scoring — underlying retrieval order is unchanged. Filter pulls scope via \`getattr\` so spec-only test doubles keep working.

## Test plan

- [x] 18 new tests in \`tests/test_scope_tags.py\` covering: exact match, no-overlap denial, hierarchical glob, segment-boundary rejection, star wildcard, both-empty back-compat, multiple-scope OR, unknown-pattern denial, normalise round-trip, default empty list, serialization round-trip, recall back-compat, recall+scopes filtering unscoped vs scoped, runtime entry scope round-trip.
- [x] \`pytest tests/\` — 2123 passed (was 2117), 0 failed
- [x] \`ruff check\` — clean

## Design contract

The match semantics are designed to be **fail-open for back-compat, fail-closed once scope is set**:
- Memory with no scope → visible to any caller (pre-scope memories aren't broken).
- Caller with no scope filter → sees everything (unchanged retrieval).
- Memory WITH scope + caller WITH scope → only matching entries surface.

This means rolling out scopes is incremental: tag the memories that need protection, leave the rest unscoped, and only callers that explicitly pass \`scopes=\` get filtering.

## Context

Design referenced in the fleet platform brainstorm — \`scope\` is one of the three lean primitives (along with RetrievalTrace from Move 4 and Soul Templates in Move 6) that compose into the Sarah-the-VP-Sales scenario.