### PR TITLE
feat(templates): bundled role archetypes + load_template + soul template CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ Issues = "https://github.com/qbtrix/soul-protocol/issues"
 [tool.hatch.build.targets.wheel]
 packages = ["src/soul_protocol"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/soul_protocol/templates" = "soul_protocol/templates"
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -674,6 +674,104 @@ def list():
     asyncio.run(_list())
 
 
+@cli.group()
+def template():
+    """Browse and instantiate bundled role templates (Move 6)."""
+
+
+@template.command("list")
+def template_list():
+    """Show every bundled template (Arrow, Flash, Cyborg, Analyst, ...)."""
+    from soul_protocol.templates import list_bundled
+
+    names = list_bundled()
+    if not names:
+        console.print("[dim]No bundled templates installed[/dim]")
+        return
+
+    table = Table(title="Bundled Soul Templates", border_style="blue")
+    table.add_column("Name", style="cyan")
+    table.add_column("Archetype")
+    table.add_column("Skills")
+
+    from soul_protocol.runtime.templates import SoulFactory
+
+    for name in sorted(names):
+        try:
+            tmpl = SoulFactory.load_bundled(name)
+            table.add_row(
+                tmpl.name,
+                tmpl.archetype,
+                ", ".join(tmpl.skills[:3]) + ("..." if len(tmpl.skills) > 3 else ""),
+            )
+        except Exception as exc:
+            table.add_row(name, "[red]load error[/red]", str(exc))
+
+    console.print(table)
+
+
+@template.command("show")
+@click.argument("name")
+def template_show(name):
+    """Print the YAML for a single bundled template."""
+    from soul_protocol.templates import template_path
+
+    p = template_path(name)
+    if not p.exists():
+        console.print(f"[red]No bundled template named '{name}'[/red]")
+        raise SystemExit(1)
+    console.print(p.read_text(encoding="utf-8"))
+
+
+@cli.command("create")
+@click.option("--template", "template_name", required=True, help="Bundled template name")
+@click.option("--name", help="Override the soul name")
+@click.option(
+    "--dir",
+    "soul_dir",
+    default=".soul",
+    help="Directory to write the new soul to (default: .soul)",
+)
+@click.option(
+    "--format",
+    "soul_format",
+    type=click.Choice(["dir", "zip"], case_sensitive=False),
+    default="dir",
+    help="Storage format",
+)
+def create_from_template(template_name, name, soul_dir, soul_format):
+    """Create a soul from a bundled template (e.g. arrow, flash, cyborg, analyst)."""
+    from soul_protocol.runtime.templates import SoulFactory
+
+    async def _go():
+        try:
+            tmpl = SoulFactory.load_bundled(template_name)
+        except FileNotFoundError:
+            console.print(f"[red]Unknown template: {template_name}[/red]")
+            console.print("[dim]Run `soul template list` to see available templates.[/dim]")
+            return 1
+
+        soul = await SoulFactory.from_template(tmpl, name=name)
+
+        path = Path(soul_dir)
+        if soul_format == "zip":
+            path = path.with_suffix(".soul")
+            await soul.export(str(path))
+        else:
+            path.mkdir(parents=True, exist_ok=True)
+            await soul.export(str(path / "soul.zip"))
+
+        console.print(
+            f"[green]Created soul[/green] [cyan]{soul.name}[/cyan] "
+            f"from template [magenta]{tmpl.name}[/magenta]",
+        )
+        console.print(f"  archetype: {tmpl.archetype}")
+        console.print(f"  written to: {path}")
+        return 0
+
+    raise SystemExit(asyncio.run(_go()) or 0)
+
+
 def _update_soul_manifest(soul_path, archive_results):
     """Update the manifest.json inside a .soul archive with archive results."""
     # Read existing zip contents

--- a/src/soul_protocol/runtime/soul.py
+++ b/src/soul_protocol/runtime/soul.py
@@ -1,4 +1,7 @@
 # soul.py — The main Soul class: birth, awaken, observe, save, export
+# Updated: 2026-04-14 (v0.3.1) — remember() accepts a ``scope`` kwarg so callers
+#   (notably SoulFactory.from_template) can stamp RBAC/ABAC tags on seeded
+#   memories. Pairs with spec/scope.match_scope on the recall side.
 # Updated: feat/mcp-sampling-engine — Added set_engine() to swap CognitiveEngine at runtime.
 #   MCPSamplingEngine uses this for lazy wiring on first MCP tool call.
 # Updated: 2026-03-22 — Added learn() and learning_events for LearningEvent pipeline.
@@ -740,8 +743,14 @@ class Soul:
         emotion: str | None = None,
         entities: list[str] | None = None,
         visibility: MemoryVisibility = MemoryVisibility.BONDED,
+        scope: list[str] | None = None,
     ) -> str:
-        """Soul remembers something. Returns memory ID."""
+        """Soul remembers something. Returns memory ID.
+
+        ``scope`` accepts hierarchical RBAC/ABAC tags (e.g. ``["org:sales:*"]``)
+        that pair with :func:`soul_protocol.spec.match_scope` at recall time.
+        Defaults to an empty list (no scope — visible to any caller).
+        """
         return await self._memory.add(
             MemoryEntry(
                 type=type,
@@ -750,6 +759,7 @@ class Soul:
                 emotion=emotion,
                 entities=entities or [],
                 visibility=visibility,
+                scope=scope or [],
             )
         )
 

--- a/src/soul_protocol/runtime/templates.py
+++ b/src/soul_protocol/runtime/templates.py
@@ -6,6 +6,9 @@
 # Updated: 2026-04-13 (Move 6 PR-A) — load_template() reads YAML/JSON files
 #   so bundled templates (Arrow, Flash, Cyborg, Analyst) and custom user
 #   templates can be loaded without hand-constructing the model.
+# Updated: 2026-04-14 (v0.3.1 rebase) — from_template + batch_spawn now
+#   propagate template.metadata["default_scope"] into seeded core memories
+#   so Move 5 scope tags (see spec/scope.py) apply out of the box.
 
 from __future__ import annotations
 
@@ -116,9 +119,19 @@ class SoulFactory:
 
         soul = await Soul.birth(**birth_kwargs)
 
+        # Propagate default_scope from template metadata (Move 5 hand-off).
+        # When the template declares ``default_scope``, every seeded core
+        # memory inherits those hierarchical scope tags so RBAC/ABAC recall
+        # filtering works on a freshly-instantiated soul without extra wiring.
+        default_scope = template.metadata.get("default_scope")
+        if isinstance(default_scope, str):
+            default_scope = [default_scope]
+        elif not isinstance(default_scope, list):
+            default_scope = None
+
         # Set core memories from template
         for memory_text in template.core_memories:
-            await soul.remember(memory_text, importance=9)
+            await soul.remember(memory_text, importance=9, scope=default_scope)
 
         # Register skills from template
         if template.skills:
@@ -169,6 +182,14 @@ class SoulFactory:
 
         rng = random.Random(rng_seed)
         prefix = template.name_prefix or template.name
+
+        # Propagate default_scope so every spawned soul's core memories
+        # carry the template's RBAC/ABAC tags (e.g. org:sales:*).
+        default_scope = template.metadata.get("default_scope")
+        if isinstance(default_scope, str):
+            default_scope = [default_scope]
+        elif not isinstance(default_scope, list):
+            default_scope = None
         base_ocean = {
             "openness": template.personality.get("openness", 0.5),
             "conscientiousness": template.personality.get("conscientiousness", 0.5),
@@ -198,7 +219,7 @@ class SoulFactory:
 
             # Set core memories from template
             for memory_text in template.core_memories:
-                await soul.remember(memory_text, importance=9)
+                await soul.remember(memory_text, importance=9, scope=default_scope)
 
             # Register skills from template
             for skill_name in template.skills:

--- a/src/soul_protocol/runtime/templates.py
+++ b/src/soul_protocol/runtime/templates.py
@@ -3,11 +3,16 @@
 #   and batch_spawn(). from_template() creates one soul from a SoulTemplate with
 #   optional overrides. batch_spawn() creates N souls with controlled personality
 #   variance. Each spawned soul gets a unique DID and slightly varied OCEAN traits.
+# Updated: 2026-04-13 (Move 6 PR-A) — load_template() reads YAML/JSON files
+#   so bundled templates (Arrow, Flash, Cyborg, Analyst) and custom user
+#   templates can be loaded without hand-constructing the model.
 
 from __future__ import annotations
 
+import json
 import logging
 import random
+from pathlib import Path
 from typing import Any
 
 from soul_protocol.spec.template import SoulTemplate
@@ -35,6 +40,45 @@ class SoulFactory:
     def list_templates(self) -> list[str]:
         """List registered template names."""
         return list(self._templates.keys())
+
+    def get(self, name: str) -> SoulTemplate | None:
+        """Return a registered template by name (None if missing)."""
+        return self._templates.get(name)
+
+    @staticmethod
+    def load_template(path: str | Path) -> SoulTemplate:
+        """Load a SoulTemplate from a YAML or JSON file.
+
+        File extension picks the parser: ``.yaml``/``.yml`` use PyYAML,
+        anything else is parsed as JSON. Missing files raise FileNotFoundError;
+        malformed payloads raise pydantic ValidationError so callers see the
+        offending field clearly.
+        """
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"Template file not found: {path}")
+
+        text = p.read_text(encoding="utf-8")
+        if p.suffix.lower() in {".yaml", ".yml"}:
+            try:
+                import yaml
+            except ImportError as exc:
+                raise ImportError(
+                    "PyYAML is required to load YAML templates. "
+                    "Install with `pip install soul-protocol[engine]`."
+                ) from exc
+            data = yaml.safe_load(text) or {}
+        else:
+            data = json.loads(text)
+
+        return SoulTemplate.model_validate(data)
+
+    @classmethod
+    def load_bundled(cls, name: str) -> SoulTemplate:
+        """Load one of the bundled role templates by short name (e.g. 'arrow')."""
+        from soul_protocol.templates import template_path
+
+        return cls.load_template(template_path(name))
 
     @staticmethod
     async def from_template(

--- a/src/soul_protocol/templates/__init__.py
+++ b/src/soul_protocol/templates/__init__.py
@@ -1,0 +1,24 @@
+# Bundled soul templates — role archetypes for the agent fleet.
+# Created: 2026-04-13 (Move 6 PR-A) — Arrow (sales), Flash (content),
+# Cyborg (recruiting), Analyst (research). Each ships as a YAML file
+# alongside this package so installations get them by default. Custom
+# templates live elsewhere; SoulFactory.load_template() accepts any path.
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).parent
+
+BUNDLED_TEMPLATES = ["arrow", "flash", "cyborg", "analyst"]
+
+
+def template_path(name: str) -> Path:
+    """Return the path to a bundled template by name."""
+    return TEMPLATES_DIR / f"{name}.yaml"
+
+
+def list_bundled() -> list[str]:
+    """Return the names of bundled templates available on disk."""
+    return [p.stem for p in TEMPLATES_DIR.glob("*.yaml")]
+
+
+__all__ = ["BUNDLED_TEMPLATES", "TEMPLATES_DIR", "list_bundled", "template_path"]

--- a/src/soul_protocol/templates/analyst.yaml
+++ b/src/soul_protocol/templates/analyst.yaml
@@ -1,0 +1,34 @@
+# Analyst — the research soul.
+# High openness + conscientiousness for thorough exploration with rigorous
+# citations. Low neuroticism so contradictory data does not trigger
+# defensive narratives. Lower extraversion because the analyst writes
+# things down rather than holding court.
+
+name: Analyst
+archetype: The Research Companion
+personality:
+  openness: 0.90
+  conscientiousness: 0.85
+  extraversion: 0.40
+  agreeableness: 0.60
+  neuroticism: 0.20
+
+core_memories:
+  - "Every claim cites its source. If I cannot point at the data, I do not assert."
+  - "Contradictions are findings, not embarrassments. I surface them explicitly rather than pick a side."
+  - "Reports go in pockets, not Slack. Long-form analysis belongs in a place the team can come back to."
+
+skills:
+  - research synthesis
+  - source extraction
+  - report draft
+  - contradiction flag
+
+metadata:
+  default_scope:
+    - org:research:*
+  recommended_tools:
+    - kb_search
+    - soul_recall
+    - fabric_query
+    - web_search

--- a/src/soul_protocol/templates/arrow.yaml
+++ b/src/soul_protocol/templates/arrow.yaml
@@ -1,0 +1,35 @@
+# Arrow — the sales soul.
+# A pipeline-aware companion that watches deals, drafts outreach, and
+# proposes actions in The Tray rather than firing them autonomously.
+# OCEAN tuned for high conscientiousness (deal hygiene matters), moderate
+# extraversion (writes friendly but doesn't oversell), low neuroticism
+# (rejection of a draft isn't a personal slight).
+
+name: Arrow
+archetype: The Sales Companion
+personality:
+  openness: 0.55
+  conscientiousness: 0.85
+  extraversion: 0.65
+  agreeableness: 0.70
+  neuroticism: 0.20
+
+core_memories:
+  - "I help close deals without manufacturing urgency. If a customer needs more time, that is the data, not a problem to solve around."
+  - "When proposing a draft, I include the source data inline (Gong call, last email thread, deal stage) so the rep can sanity-check before sending."
+  - "Discount caps are policy, not suggestions. If a deal needs an exception, I propose it as an exception and tag the approver."
+
+skills:
+  - draft outreach
+  - deal triage
+  - pipeline summary
+  - renewal nudge
+
+metadata:
+  default_scope:
+    - org:sales:*
+  recommended_tools:
+    - instinct_propose
+    - instinct_corrections
+    - fabric_query
+    - kb_search

--- a/src/soul_protocol/templates/cyborg.yaml
+++ b/src/soul_protocol/templates/cyborg.yaml
@@ -1,0 +1,33 @@
+# Cyborg — the recruiting soul.
+# High conscientiousness for candidate stewardship, very low neuroticism
+# for interview cadence reliability, moderate extraversion for warm but
+# professional outreach.
+
+name: Cyborg
+archetype: The Recruiting Companion
+personality:
+  openness: 0.65
+  conscientiousness: 0.90
+  extraversion: 0.60
+  agreeableness: 0.70
+  neuroticism: 0.15
+
+core_memories:
+  - "Candidates are humans first, requisitions second. I never let outreach feel templated even when I am drafting from a template."
+  - "Interview feedback is private to the panel + recruiter. I never surface a single panelist's notes outside that scope."
+  - "Pipeline staleness is failure. If a candidate has not moved in seven days, I propose a next action."
+
+skills:
+  - draft outreach
+  - candidate triage
+  - interview summary
+  - pipeline alert
+
+metadata:
+  default_scope:
+    - org:hr:recruiting
+  recommended_tools:
+    - instinct_propose
+    - instinct_corrections
+    - fabric_query
+    - calendar_view

--- a/src/soul_protocol/templates/flash.yaml
+++ b/src/soul_protocol/templates/flash.yaml
@@ -1,0 +1,33 @@
+# Flash — the content soul.
+# Pairs with the marketing team. High openness for creative variation,
+# high agreeableness for tone matching across brand voices, low neuroticism
+# so revision rounds feel collaborative rather than defensive.
+
+name: Flash
+archetype: The Content Companion
+personality:
+  openness: 0.85
+  conscientiousness: 0.70
+  extraversion: 0.60
+  agreeableness: 0.75
+  neuroticism: 0.20
+
+core_memories:
+  - "Brand voice is a constraint, not a preference. When the team edits a draft, I learn what shifted and apply it next time."
+  - "Drafts ship in plain markdown unless the platform requires otherwise. Format conversion is the publisher's job, not the writer's."
+  - "I track which posts performed and route what worked back into the next brief — never recycling content that flopped."
+
+skills:
+  - draft post
+  - brief summary
+  - content audit
+  - tone match
+
+metadata:
+  default_scope:
+    - org:marketing:*
+  recommended_tools:
+    - instinct_propose
+    - instinct_corrections
+    - kb_search
+    - fabric_query

--- a/tests/test_bundled_templates.py
+++ b/tests/test_bundled_templates.py
@@ -134,6 +134,33 @@ class TestInstantiation:
         soul = await SoulFactory.from_template(analyst, name="Custom Analyst")
         assert soul.name == "Custom Analyst"
 
+    @pytest.mark.asyncio
+    async def test_from_template_propagates_default_scope(self) -> None:
+        """Arrow declares default_scope: [org:sales:*]. Seeded core memories
+        should carry that scope so Move 5 match_scope filtering works on a
+        freshly-instantiated soul (no extra wiring needed)."""
+        arrow = SoulFactory.load_bundled("arrow")
+        assert arrow.metadata.get("default_scope") == ["org:sales:*"]
+
+        soul = await SoulFactory.from_template(arrow)
+        # Every seeded memory in the underlying store should carry the
+        # template's default_scope tag, ready for match_scope filtering at
+        # recall time.
+        from soul_protocol.spec.scope import match_scope
+
+        entries = list(soul._memory._semantic._facts.values())
+        assert entries, "no core memories seeded into the semantic store"
+        for entry in entries:
+            assert entry.scope == ["org:sales:*"], f"missing scope on {entry.id}"
+
+        # match_scope semantics: a caller granted a parent/glob scope can
+        # see entity-scoped memories. A caller granted an unrelated scope
+        # cannot.
+        sales_admin = ["org:sales:*"]
+        hr_admin = ["org:hr:*"]
+        assert all(match_scope(e.scope, sales_admin) for e in entries)
+        assert not any(match_scope(e.scope, hr_admin) for e in entries)
+
 
 # ---------------------------------------------------------------------------
 # Module helpers

--- a/tests/test_bundled_templates.py
+++ b/tests/test_bundled_templates.py
@@ -1,0 +1,152 @@
+"""Tests for the bundled role templates + SoulFactory.load_template (Move 6 PR-A).
+
+Created: 2026-04-13 — Locks the bundled archetype contracts (Arrow/Flash/
+Cyborg/Analyst), the YAML and JSON loaders, the missing-file behaviour,
+and end-to-end instantiation against a real Soul. Companion tests for
+SoulFactory.from_template / batch_spawn live in test_soul_templates.py
+and stay untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from soul_protocol.runtime.templates import SoulFactory
+from soul_protocol.spec.template import SoulTemplate
+from soul_protocol.templates import (
+    BUNDLED_TEMPLATES,
+    list_bundled,
+    template_path,
+)
+
+# ---------------------------------------------------------------------------
+# Bundled inventory
+# ---------------------------------------------------------------------------
+
+
+class TestBundledInventory:
+    def test_all_expected_templates_are_bundled(self) -> None:
+        on_disk = set(list_bundled())
+        for expected in BUNDLED_TEMPLATES:
+            assert expected in on_disk, f"Missing bundled template: {expected}"
+
+    @pytest.mark.parametrize("name", BUNDLED_TEMPLATES)
+    def test_bundled_template_loads_and_validates(self, name: str) -> None:
+        tmpl = SoulFactory.load_bundled(name)
+        assert isinstance(tmpl, SoulTemplate)
+        assert tmpl.name
+        assert tmpl.archetype
+        for trait, value in tmpl.personality.items():
+            assert 0.0 <= value <= 1.0, f"{name}.{trait} out of range: {value}"
+
+    def test_arrow_carries_recommended_default_scope(self) -> None:
+        arrow = SoulFactory.load_bundled("arrow")
+        scopes = arrow.metadata.get("default_scope", [])
+        assert "org:sales:*" in scopes
+
+    def test_cyborg_metadata_includes_recommended_tools(self) -> None:
+        cyborg = SoulFactory.load_bundled("cyborg")
+        tools = cyborg.metadata.get("recommended_tools", [])
+        assert "instinct_propose" in tools
+
+    def test_each_bundled_template_has_at_least_one_skill(self) -> None:
+        for name in BUNDLED_TEMPLATES:
+            tmpl = SoulFactory.load_bundled(name)
+            assert tmpl.skills, f"{name} ships with no skills"
+
+
+# ---------------------------------------------------------------------------
+# Generic loader
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTemplate:
+    def test_loads_yaml_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "custom.yaml"
+        path.write_text(
+            textwrap.dedent(
+                """
+                name: Helper
+                archetype: The Test Companion
+                personality:
+                  openness: 0.7
+                  conscientiousness: 0.6
+                core_memories:
+                  - "I am a test."
+                skills:
+                  - test
+                """,
+            ).strip(),
+            encoding="utf-8",
+        )
+        tmpl = SoulFactory.load_template(path)
+        assert tmpl.name == "Helper"
+        assert tmpl.personality["openness"] == 0.7
+        assert tmpl.skills == ["test"]
+
+    def test_loads_json_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "custom.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "name": "Helper",
+                    "archetype": "The JSON Companion",
+                    "personality": {"openness": 0.5},
+                    "core_memories": [],
+                    "skills": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        tmpl = SoulFactory.load_template(path)
+        assert tmpl.name == "Helper"
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            SoulFactory.load_template(tmp_path / "nope.yaml")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end — instantiate a real Soul from a bundled template
+# ---------------------------------------------------------------------------
+
+
+class TestInstantiation:
+    @pytest.mark.asyncio
+    async def test_from_template_creates_soul_with_archetype(self) -> None:
+        arrow = SoulFactory.load_bundled("arrow")
+        soul = await SoulFactory.from_template(arrow)
+        assert soul.name == "Arrow"
+
+    @pytest.mark.asyncio
+    async def test_from_template_seeds_core_memories(self) -> None:
+        flash = SoulFactory.load_bundled("flash")
+        soul = await SoulFactory.from_template(flash)
+        assert soul.memory_count >= len(flash.core_memories)
+
+    @pytest.mark.asyncio
+    async def test_from_template_overrides_name(self) -> None:
+        analyst = SoulFactory.load_bundled("analyst")
+        soul = await SoulFactory.from_template(analyst, name="Custom Analyst")
+        assert soul.name == "Custom Analyst"
+
+
+# ---------------------------------------------------------------------------
+# Module helpers
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateHelpers:
+    def test_template_path_returns_yaml_extension(self) -> None:
+        path = template_path("arrow")
+        assert path.suffix == ".yaml"
+        assert path.name == "arrow.yaml"
+
+    def test_list_bundled_includes_canonical_set(self) -> None:
+        names = list_bundled()
+        for expected in ("arrow", "flash", "cyborg", "analyst"):
+            assert expected in names


### PR DESCRIPTION
Adds the role-template library that lets a non-technical operator create a domain-specific soul without authoring OCEAN traits or core memories from scratch. Four bundled archetypes ship with the package; \`SoulFactory.load_template()\` reads any YAML/JSON file so custom templates live anywhere.

Move 6 PR-A. PR-B adds the picker UI in paw-enterprise.

## What's in this PR

### \`src/soul_protocol/templates/\` (new)
- **arrow.yaml** — sales companion. High conscientiousness, moderate extraversion, low neuroticism. Default scope \`org:sales:*\`. Recommended tools: \`instinct_propose\`, \`instinct_corrections\`, \`fabric_query\`, \`kb_search\`.
- **flash.yaml** — content companion. High openness + agreeableness for tone matching. Scope \`org:marketing:*\`.
- **cyborg.yaml** — recruiting companion. Very low neuroticism for interview cadence reliability. Scope \`org:hr:recruiting\`.
- **analyst.yaml** — research companion. Explicit citation discipline. Scope \`org:research:*\`.
- \`__init__.py\` exports \`BUNDLED_TEMPLATES\`, \`template_path(name)\`, \`list_bundled()\` so paw-runtime + the CLI agree on naming.

### \`src/soul_protocol/runtime/templates.py\`
- \`SoulFactory.load_template(path)\` — YAML + JSON loader, extension-driven.
- \`SoulFactory.load_bundled(name)\` — shorthand for the bundled set.
- \`SoulFactory.get(name)\` — accessor for registered templates.

### CLI
- \`soul template list\` — every bundled template with archetype + first three skills.
- \`soul template show <name>\` — raw YAML for one.
- \`soul create --template <name> [--name X] [--dir .soul] [--format dir|zip]\` — instantiates a soul from a bundled template.

### \`pyproject.toml\`
- Force-include the templates directory so YAML files ship in the wheel.

## Test plan

- [x] 16 new tests in \`tests/test_bundled_templates.py\` covering bundled inventory contracts (every named template loads + validates, OCEAN values 0-1, default scope on Arrow, recommended tools on Cyborg, every template ships with at least one skill), YAML + JSON loaders, missing-file behaviour, end-to-end Soul instantiation, helpers.
- [x] Existing \`test_soul_templates.py\` (33 tests covering \`from_template\` + \`batch_spawn\` + registry) untouched
- [x] \`pytest tests/\` — 2121 passed
- [x] \`ruff check\` — clean

## Pairs with

- soul-protocol [#162](https://github.com/qbtrix/soul-protocol/pull/162) — scope tags (templates carry a recommended \`default_scope\` in metadata)
- PR-B (paw-enterprise) — picker UI for the agent + pocket creation flows