### PR TITLE
feat(spec): journal EventEntry + Actor + DataRef

### DIFF
--- a/src/soul_protocol/__init__.py
+++ b/src/soul_protocol/__init__.py
@@ -16,6 +16,8 @@
 #   v0.2.1 — Added CognitiveEngine, HeuristicEngine, ReflectionResult exports.
 #   v0.2.0 — Added psychology types (SomaticMarker, SignificanceScore,
 #   GeneralEvent, SelfImage) to public exports.
+# Updated: feat/journal-spec — Added org journal primitives (Actor, DataRef,
+#   EventEntry, ACTION_NAMESPACES) from spec.journal. See RFC PR #164.
 
 from __future__ import annotations
 
@@ -68,6 +70,7 @@ from .runtime.eternal import ArchiveResult, EternalStorageManager, EternalStorag
 # Core primitives from spec/ (always available — only requires pydantic)
 from .spec.identity import BondTarget as CoreBondTarget
 from .spec.identity import Identity as CoreIdentity
+from .spec.journal import ACTION_NAMESPACES, Actor, DataRef, EventEntry
 from .spec.manifest import Manifest as CoreManifest
 from .spec.memory import DictMemoryStore, MemoryStore
 from .spec.memory import Interaction as CoreInteraction
@@ -138,6 +141,11 @@ __all__ = [
     "CoreParticipant",
     "DictMemoryStore",
     "MemoryStore",
+    # Org Journal (feat/journal-spec)
+    "ACTION_NAMESPACES",
+    "Actor",
+    "DataRef",
+    "EventEntry",
 ]
 
 __version__ = "0.2.5"

--- a/src/soul_protocol/spec/__init__.py
+++ b/src/soul_protocol/spec/__init__.py
@@ -5,6 +5,8 @@
 # Updated: Added EternalStorageProvider, EmbeddingProvider, similarity functions.
 # Updated: Added ContextEngine protocol and LCM models for Lossless Context Management.
 # Updated: 2026-03-23 — Added A2A Agent Card models (A2AAgentCard, A2ASkill, SoulExtension).
+# Updated: feat/journal-spec — Exported Journal primitives (Actor, DataRef, EventEntry,
+#   ACTION_NAMESPACES) from the new org journal module. See RFC PR #164.
 
 from __future__ import annotations
 
@@ -28,6 +30,7 @@ from .embeddings import (
 from .eternal import ArchiveResult, EternalStorageProvider, RecoverySource
 from .a2a import A2AAgentCard, A2ASkill, SoulExtension
 from .identity import BondTarget, Identity
+from .journal import ACTION_NAMESPACES, Actor, DataRef, EventEntry
 from .manifest import Manifest
 from .memory import DictMemoryStore, Interaction, MemoryEntry, MemoryStore, MemoryVisibility, Participant
 from .template import SoulTemplate
@@ -53,6 +56,11 @@ __all__ = [
     # Identity
     "BondTarget",
     "Identity",
+    # Journal (org-level event sourcing)
+    "ACTION_NAMESPACES",
+    "Actor",
+    "DataRef",
+    "EventEntry",
     # Memory
     "Interaction",
     "MemoryEntry",

--- a/src/soul_protocol/spec/journal.py
+++ b/src/soul_protocol/spec/journal.py
@@ -1,8 +1,9 @@
 # journal.py — Org Journal primitives (Actor, DataRef, EventEntry).
-# Created: feat/journal-spec — Phase 1 slice of the Org Architecture RFC (PR #164).
-# The journal is the append-only, UTC-stamped, scope-tagged source of truth for
-# a Paw OS instance. This module ships the spec models only — the SQLite WAL
-# engine and the `paw os init` CLI land in follow-up PRs.
+# Updated: feat/journal-spec — renamed paw.os.destroyed -> org.destroyed in
+# ACTION_NAMESPACES to align with the framework-agnostic org-journal-spec.
+# The journal is the append-only, UTC-stamped, scope-tagged source of truth
+# for an org instance. This module ships the spec models only — the SQLite WAL
+# engine and the `soul org init` CLI land in follow-up PRs.
 #
 # Semantics locked here:
 #   - `ts` and `DataRef.point_in_time` must be timezone-aware (UTC). Naive
@@ -59,7 +60,7 @@ ACTION_NAMESPACES: tuple[str, ...] = (
     "user.admin_revoked",
     "scope.created",
     "key.rotated",
-    "paw.os.destroyed",
+    "org.destroyed",
     # Identity
     "agent.spawned",
     "agent.retired",

--- a/src/soul_protocol/spec/journal.py
+++ b/src/soul_protocol/spec/journal.py
@@ -1,0 +1,215 @@
+# journal.py — Org Journal primitives (Actor, DataRef, EventEntry).
+# Created: feat/journal-spec — Phase 1 slice of the Org Architecture RFC (PR #164).
+# The journal is the append-only, UTC-stamped, scope-tagged source of truth for
+# a Paw OS instance. This module ships the spec models only — the SQLite WAL
+# engine and the `paw os init` CLI land in follow-up PRs.
+#
+# Semantics locked here:
+#   - `ts` and `DataRef.point_in_time` must be timezone-aware (UTC). Naive
+#     datetimes raise at validation time. The journal layer is where the
+#     project's naive-datetime bugs get fixed, not per subsystem.
+#   - `scope` is required and non-empty. There is no "global" write path.
+#   - `action` is a free-form dot-separated string; see ACTION_NAMESPACES for
+#     the initial catalog, kept as a constant (not an enum) so callers can ship
+#     new action names additively without a library upgrade.
+#   - `payload` is a union of `dict` or `DataRef` — inline data or an external
+#     reference for Zero-Copy sources.
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+from pydantic.functional_serializers import PlainSerializer
+from pydantic.functional_validators import BeforeValidator
+
+
+def _decode_bytes(v: object) -> bytes | None:
+    """Accept raw bytes or a base64-encoded string (JSON round-trip) or None."""
+    if v is None or isinstance(v, bytes):
+        return v  # type: ignore[return-value]
+    if isinstance(v, str):
+        return base64.b64decode(v)
+    raise TypeError(f"expected bytes, str, or None — got {type(v).__name__}")
+
+
+def _encode_bytes(v: bytes | None) -> str | None:
+    """Serialize bytes to a base64 string for JSON transport."""
+    if v is None:
+        return None
+    return base64.b64encode(v).decode("ascii")
+
+
+JournalBytes = Annotated[
+    bytes | None,
+    BeforeValidator(_decode_bytes),
+    PlainSerializer(_encode_bytes, return_type=str, when_used="json"),
+]
+"""Optional raw bytes that round-trip through JSON as base64 strings."""
+
+
+ACTION_NAMESPACES: tuple[str, ...] = (
+    # Governance (root-signed)
+    "org.created",
+    "schema.migrated",
+    "user.admin_granted",
+    "user.admin_revoked",
+    "scope.created",
+    "key.rotated",
+    "paw.os.destroyed",
+    # Identity
+    "agent.spawned",
+    "agent.retired",
+    "user.joined",
+    "user.left",
+    "team.created",
+    "team.disbanded",
+    "soul.exported",
+    "soul.imported",
+    # Memory & Knowledge
+    "memory.remembered",
+    "memory.graduated",
+    "memory.forgotten",
+    "kb.source.ingested",
+    "kb.article.compiled",
+    "kb.article.revised",
+    # Retrieval & Fabric
+    "retrieval.query",
+    "fabric.object.created",
+    "fabric.object.updated",
+    "fabric.object.archived",
+    "scope.assigned",
+    "scope.revoked",
+    # Decisions
+    "agent.proposed",
+    "human.corrected",
+    "decision.graduated",
+    # Credentials & Zero-Copy
+    "credential.acquired",
+    "credential.used",
+    "credential.expired",
+    "dataref.resolved",
+    # Graduation & Policy
+    "graduation.applied",
+    "policy.evaluated",
+)
+"""The initial event action catalog from the RFC Appendix.
+
+This is a lint/discoverability aid — not enforced as an enum. Callers may
+ship new action names additively; removing an action is a schema migration.
+"""
+
+
+ActorKind = Literal["agent", "user", "system", "root"]
+
+
+class Actor(BaseModel):
+    """Who performed the action that produced an event.
+
+    There are no anonymous writes. ``system:*`` actors are reserved for
+    subsystem-triggered events (kb compile cascades, graduation scheduler,
+    retention policies).
+
+    Fields:
+        kind: One of ``agent``, ``user``, ``system``, ``root``.
+        id: Stable identifier — ``did:soul:...``, ``user:alice``,
+            ``system:kb-go``. Required; empty strings are rejected.
+        scope_context: The scopes the actor held when acting. Recorded at
+            write time so later scope changes don't rewrite history.
+    """
+
+    kind: ActorKind
+    id: str = Field(min_length=1)
+    scope_context: list[str] = Field(default_factory=list)
+
+
+CachePolicy = Literal["always", "invalidate_on_event", "ttl"]
+
+
+class DataRef(BaseModel):
+    """A reference to data that lives outside the journal.
+
+    Used for Zero-Copy retrieval against live systems (Salesforce, Drive,
+    Snowflake, S3, ...) where freshness and data-residency matter more than
+    retrieval latency. The journal records the *reference*, not the payload.
+
+    Fields:
+        source: Source adapter name (``"salesforce"``, ``"gdrive"``,
+            ``"snowflake"``, ``"s3"``, ...).
+        query: Source-native query recipe. Opaque to the journal.
+        point_in_time: Timezone-aware UTC timestamp the reference was taken
+            at. Naive datetimes raise.
+        cache_policy: How downstream caches should treat this ref.
+        cache_ttl_s: TTL for the ``ttl`` policy, in seconds. ``None`` when
+            the policy is not ``ttl``.
+    """
+
+    source: str = Field(min_length=1)
+    query: str
+    point_in_time: datetime
+    cache_policy: CachePolicy = "ttl"
+    cache_ttl_s: int | None = None
+
+    @field_validator("point_in_time")
+    @classmethod
+    def _point_in_time_must_be_aware(cls, v: datetime) -> datetime:
+        if v.tzinfo is None or v.tzinfo.utcoffset(v) is None:
+            raise ValueError("DataRef.point_in_time must be timezone-aware (UTC)")
+        return v
+
+
+class EventEntry(BaseModel):
+    """A single immutable event in the org journal.
+
+    The journal is append-only: there is no ``UPDATE`` and no ``DELETE``.
+    Corrections are new events that reference the original via
+    ``causation_id``. Every event carries a non-empty ``scope`` — unscoped
+    writes are rejected.
+
+    Fields:
+        id: UUID for this event.
+        ts: Timezone-aware UTC timestamp. Monotonic per journal (enforced
+            at the engine layer, not here). Naive datetimes raise.
+        actor: Who wrote this event.
+        action: Dot-separated namespaced verb. Not enum-enforced — see
+            :data:`ACTION_NAMESPACES` for the initial catalog.
+        scope: DSP scope tags (from #162). Required and non-empty.
+        causation_id: The prior event that caused this one, or ``None``
+            for genesis / unsolicited events.
+        correlation_id: The session or flow this event belongs to, or
+            ``None`` if the event stands alone.
+        payload: Either an inline dict (small structured data) or a
+            :class:`DataRef` (external reference for Zero-Copy sources).
+            Large binary payloads go to blob storage with a DataRef here.
+        prev_hash: Optional hash-chain link to the previous event. Will
+            become required once signing ships.
+        sig: Optional signature over ``(id, ts, actor, action, prev_hash)``.
+    """
+
+    id: UUID
+    ts: datetime
+    actor: Actor
+    action: str = Field(min_length=1)
+    scope: list[str] = Field(min_length=1)
+    causation_id: UUID | None = None
+    correlation_id: UUID | None = None
+    payload: DataRef | dict = Field(default_factory=dict)
+    prev_hash: JournalBytes = None
+    sig: JournalBytes = None
+
+    @field_validator("ts")
+    @classmethod
+    def _ts_must_be_aware(cls, v: datetime) -> datetime:
+        if v.tzinfo is None or v.tzinfo.utcoffset(v) is None:
+            raise ValueError("EventEntry.ts must be timezone-aware (UTC)")
+        return v
+
+    @field_validator("scope")
+    @classmethod
+    def _scope_entries_non_empty(cls, v: list[str]) -> list[str]:
+        if any(not s or not s.strip() for s in v):
+            raise ValueError("EventEntry.scope entries must be non-empty strings")
+        return v

--- a/src/soul_protocol/spec/journal.py
+++ b/src/soul_protocol/spec/journal.py
@@ -1,6 +1,9 @@
 # journal.py — Org Journal primitives (Actor, DataRef, EventEntry).
-# Updated: feat/journal-spec — renamed paw.os.destroyed -> org.destroyed in
-# ACTION_NAMESPACES to align with the framework-agnostic org-journal-spec.
+# Updated: feat/journal-spec — tighten DataRef.point_in_time to UTC-only
+# (non-UTC tz-aware datetimes now raise instead of being silently accepted),
+# add a __dataref__ marker so the `DataRef | dict` payload union on
+# EventEntry round-trips without silent misdeserialization, and drop the
+# fabric.* namespaces from ACTION_NAMESPACES (runtime-specific, not protocol).
 # The journal is the append-only, UTC-stamped, scope-tagged source of truth
 # for an org instance. This module ships the spec models only — the SQLite WAL
 # engine and the `soul org init` CLI land in follow-up PRs.
@@ -19,13 +22,21 @@
 from __future__ import annotations
 
 import base64
-from datetime import datetime
-from typing import Annotated, Literal
+from datetime import datetime, timedelta
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_serializer, model_validator
 from pydantic.functional_serializers import PlainSerializer
 from pydantic.functional_validators import BeforeValidator
+
+# Marker written on JSON-serialized DataRef payloads so the `DataRef | dict`
+# union in EventEntry.payload can be disambiguated on the way back in.
+# A plain dict payload that happens to carry DataRef-shaped keys (e.g. a user
+# query dict with a "source" field) would otherwise get silently coerced into
+# a DataRef on deserialization — and that silent coercion is the bug this
+# discriminator closes.
+_DATAREF_MARKER = "__dataref__"
 
 
 def _decode_bytes(v: object) -> bytes | None:
@@ -77,11 +88,8 @@ ACTION_NAMESPACES: tuple[str, ...] = (
     "kb.source.ingested",
     "kb.article.compiled",
     "kb.article.revised",
-    # Retrieval & Fabric
+    # Retrieval & scope
     "retrieval.query",
-    "fabric.object.created",
-    "fabric.object.updated",
-    "fabric.object.archived",
     "scope.assigned",
     "scope.revoked",
     # Decisions
@@ -154,11 +162,37 @@ class DataRef(BaseModel):
     cache_policy: CachePolicy = "ttl"
     cache_ttl_s: int | None = None
 
+    @model_serializer(mode="wrap", when_used="json")
+    def _serialize_with_marker(self, handler: Any) -> dict[str, Any]:
+        """Stamp ``__dataref__: true`` on every JSON dump so a
+        ``DataRef | dict`` union can disambiguate on the way back in.
+        """
+        data = handler(self)
+        data[_DATAREF_MARKER] = True
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def _strip_marker(cls, data: Any) -> Any:
+        """Strip the ``__dataref__`` marker before field validation so
+        round-tripped JSON payloads don't trip extra-fields checks."""
+        if isinstance(data, dict) and _DATAREF_MARKER in data:
+            data = {k: v for k, v in data.items() if k != _DATAREF_MARKER}
+        return data
+
     @field_validator("point_in_time")
     @classmethod
-    def _point_in_time_must_be_aware(cls, v: datetime) -> datetime:
-        if v.tzinfo is None or v.tzinfo.utcoffset(v) is None:
+    def _point_in_time_must_be_utc(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
             raise ValueError("DataRef.point_in_time must be timezone-aware (UTC)")
+        offset = v.tzinfo.utcoffset(v)
+        if offset is None:
+            raise ValueError("DataRef.point_in_time must be timezone-aware (UTC)")
+        if offset != timedelta(0):
+            raise ValueError(
+                "DataRef.point_in_time must be UTC — got offset "
+                f"{offset}. Normalize at the source."
+            )
         return v
 
 
@@ -197,9 +231,35 @@ class EventEntry(BaseModel):
     scope: list[str] = Field(min_length=1)
     causation_id: UUID | None = None
     correlation_id: UUID | None = None
-    payload: DataRef | dict = Field(default_factory=dict)
+    payload: dict | DataRef = Field(default_factory=dict)
     prev_hash: JournalBytes = None
     sig: JournalBytes = None
+
+    @field_validator("payload", mode="before")
+    @classmethod
+    def _disambiguate_payload(cls, v: Any) -> Any:
+        """Use the ``__dataref__`` marker to tell a DataRef payload apart
+        from a plain dict that happens to share DataRef field names.
+
+        A ``DataRef | dict`` union would otherwise greedily coerce any
+        dict carrying the right shape (``source``, ``query``,
+        ``point_in_time``) into a DataRef on deserialization. By round-
+        tripping DataRef with an explicit marker, we can keep dicts as
+        dicts unless the caller opted into DataRef semantics, and
+        promote marked dicts to a concrete DataRef before the union sees
+        them so the choice is unambiguous.
+        """
+        if isinstance(v, DataRef):
+            return v
+        if isinstance(v, dict):
+            if v.get(_DATAREF_MARKER) is True:
+                inner = {k: val for k, val in v.items() if k != _DATAREF_MARKER}
+                return DataRef.model_validate(inner)
+            # No marker — keep as a plain dict. Return a fresh dict so
+            # pydantic's union resolver sees a clean shape (not a
+            # DataRef-lookalike that would otherwise match first).
+            return dict(v)
+        return v
 
     @field_validator("ts")
     @classmethod

--- a/tests/test_spec/test_journal.py
+++ b/tests/test_spec/test_journal.py
@@ -1,0 +1,226 @@
+# test_spec/test_journal.py — Tests for the Org Journal spec primitives.
+# Created: feat/journal-spec — Phase 1 slice of the Org Architecture RFC (PR #164).
+# Covers: round-trip JSON, tz-aware datetime enforcement on EventEntry.ts and
+# DataRef.point_in_time, scope required/non-empty, payload union (dict | DataRef),
+# Actor.kind rejects unknown values, causation_id None (genesis) and UUID round-trip.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from soul_protocol.spec import ACTION_NAMESPACES, Actor, DataRef, EventEntry
+
+
+# ----- Actor ---------------------------------------------------------------
+
+
+def test_actor_round_trips_json():
+    """Actor serializes to JSON and back with all fields preserved."""
+    actor = Actor(
+        kind="agent",
+        id="did:soul:sales-lead",
+        scope_context=["org:sales", "org:sales:pipeline"],
+    )
+    restored = Actor.model_validate_json(actor.model_dump_json())
+    assert restored == actor
+
+
+def test_actor_rejects_unknown_kind():
+    """Actor.kind is a Literal — unknown values raise at validation time."""
+    with pytest.raises(ValidationError):
+        Actor(kind="wizard", id="did:soul:merlin")  # type: ignore[arg-type]
+
+
+def test_actor_requires_non_empty_id():
+    """Actor.id must be non-empty — no anonymous writes."""
+    with pytest.raises(ValidationError):
+        Actor(kind="user", id="")
+
+
+def test_actor_scope_context_defaults_to_empty_list():
+    """scope_context defaults to an empty list when omitted."""
+    actor = Actor(kind="system", id="system:kb-go")
+    assert actor.scope_context == []
+
+
+# ----- DataRef -------------------------------------------------------------
+
+
+def test_dataref_round_trips_json():
+    """DataRef serializes and deserializes with tz-aware point_in_time."""
+    ref = DataRef(
+        source="salesforce",
+        query="SELECT Id, Name FROM Account WHERE OwnerId = :me",
+        point_in_time=datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+        cache_policy="ttl",
+        cache_ttl_s=300,
+    )
+    restored = DataRef.model_validate_json(ref.model_dump_json())
+    assert restored == ref
+    assert restored.point_in_time.tzinfo is not None
+
+
+def test_dataref_rejects_naive_point_in_time():
+    """Naive datetimes on point_in_time raise — UTC-aware only."""
+    with pytest.raises(ValidationError):
+        DataRef(
+            source="snowflake",
+            query="SELECT 1",
+            point_in_time=datetime(2026, 4, 13, 12, 0),  # naive
+        )
+
+
+def test_dataref_accepts_non_utc_tz_but_preserves_offset():
+    """Any tz-aware datetime is accepted — callers are expected to normalize to UTC."""
+    tz = timezone(timedelta(hours=5))
+    ref = DataRef(
+        source="s3",
+        query="s3://bucket/key",
+        point_in_time=datetime(2026, 4, 13, 17, 0, tzinfo=tz),
+    )
+    assert ref.point_in_time.tzinfo is not None
+
+
+def test_dataref_default_cache_policy_is_ttl():
+    """cache_policy defaults to 'ttl' per the RFC."""
+    ref = DataRef(
+        source="gdrive",
+        query="file:abc123",
+        point_in_time=datetime(2026, 4, 13, tzinfo=UTC),
+    )
+    assert ref.cache_policy == "ttl"
+    assert ref.cache_ttl_s is None
+
+
+def test_dataref_rejects_unknown_cache_policy():
+    """cache_policy is a Literal — unknown values raise."""
+    with pytest.raises(ValidationError):
+        DataRef(
+            source="s3",
+            query="s3://x",
+            point_in_time=datetime(2026, 4, 13, tzinfo=UTC),
+            cache_policy="forever",  # type: ignore[arg-type]
+        )
+
+
+# ----- EventEntry ----------------------------------------------------------
+
+
+def _make_event(**overrides) -> EventEntry:
+    base = dict(
+        id=uuid4(),
+        ts=datetime.now(UTC),
+        actor=Actor(kind="agent", id="did:soul:sales-lead", scope_context=["org:sales"]),
+        action="retrieval.query",
+        scope=["org:sales:pocket:acme"],
+        causation_id=None,
+        correlation_id=None,
+        payload={"q": "what is the status of the Acme deal?"},
+    )
+    base.update(overrides)
+    return EventEntry(**base)
+
+
+def test_event_round_trips_json_with_dict_payload():
+    """EventEntry with an inline dict payload round-trips cleanly."""
+    event = _make_event()
+    restored = EventEntry.model_validate_json(event.model_dump_json())
+    assert restored == event
+    assert isinstance(restored.payload, dict)
+
+
+def test_event_round_trips_json_with_dataref_payload():
+    """EventEntry with a DataRef payload round-trips cleanly."""
+    ref = DataRef(
+        source="salesforce",
+        query="SELECT Id FROM Opportunity WHERE Amount > 10000",
+        point_in_time=datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+        cache_policy="invalidate_on_event",
+    )
+    event = _make_event(payload=ref)
+    restored = EventEntry.model_validate_json(event.model_dump_json())
+    assert isinstance(restored.payload, DataRef)
+    assert restored.payload == ref
+
+
+def test_event_rejects_naive_ts():
+    """Naive datetimes on ts raise — the journal refuses non-UTC-aware writes."""
+    with pytest.raises(ValidationError):
+        _make_event(ts=datetime(2026, 4, 13, 12, 0))
+
+
+def test_event_requires_non_empty_scope():
+    """Events must carry at least one scope tag — no 'global' writes."""
+    with pytest.raises(ValidationError):
+        _make_event(scope=[])
+
+
+def test_event_rejects_empty_string_scope_entry():
+    """Scope entries must themselves be non-empty strings."""
+    with pytest.raises(ValidationError):
+        _make_event(scope=["org:sales", ""])
+
+
+def test_event_requires_non_empty_action():
+    """action is required — min_length=1."""
+    with pytest.raises(ValidationError):
+        _make_event(action="")
+
+
+def test_event_causation_id_none_for_genesis():
+    """causation_id is None for genesis / unsolicited events and round-trips."""
+    event = _make_event(action="org.created", causation_id=None)
+    restored = EventEntry.model_validate_json(event.model_dump_json())
+    assert restored.causation_id is None
+
+
+def test_event_causation_id_round_trips_when_set():
+    """A causation_id pointing at a prior event preserves its UUID through JSON."""
+    prior = uuid4()
+    event = _make_event(action="human.corrected", causation_id=prior)
+    restored = EventEntry.model_validate_json(event.model_dump_json())
+    assert restored.causation_id == prior
+
+
+def test_event_correlation_id_round_trips():
+    """correlation_id binds events within a session / flow and survives JSON."""
+    correlation = uuid4()
+    event = _make_event(correlation_id=correlation)
+    restored = EventEntry.model_validate_json(event.model_dump_json())
+    assert restored.correlation_id == correlation
+
+
+def test_event_prev_hash_and_sig_round_trip():
+    """Optional prev_hash and sig bytes survive the JSON round-trip."""
+    event = _make_event(prev_hash=b"\x00\x01\x02\x03", sig=b"\xde\xad\xbe\xef")
+    restored = EventEntry.model_validate_json(event.model_dump_json())
+    assert restored.prev_hash == b"\x00\x01\x02\x03"
+    assert restored.sig == b"\xde\xad\xbe\xef"
+
+
+# ----- ACTION_NAMESPACES ---------------------------------------------------
+
+
+def test_action_namespaces_includes_expected_catalog_entries():
+    """The initial catalog covers the primitives called out in the RFC."""
+    expected = {
+        "org.created",
+        "retrieval.query",
+        "agent.proposed",
+        "human.corrected",
+        "dataref.resolved",
+        "memory.remembered",
+        "kb.source.ingested",
+        "scope.created",
+    }
+    assert expected.issubset(set(ACTION_NAMESPACES))
+
+
+def test_action_field_is_not_enum_enforced():
+    """action is free-form — callers can ship new namespaces additively."""
+    event = _make_event(action="custom.vertical.event")
+    assert event.action == "custom.vertical.event"

--- a/tests/test_spec/test_journal.py
+++ b/tests/test_spec/test_journal.py
@@ -74,15 +74,28 @@ def test_dataref_rejects_naive_point_in_time():
         )
 
 
-def test_dataref_accepts_non_utc_tz_but_preserves_offset():
-    """Any tz-aware datetime is accepted — callers are expected to normalize to UTC."""
-    tz = timezone(timedelta(hours=5))
+def test_dataref_rejects_non_utc_tz_aware_datetime():
+    """Non-UTC tz-aware datetimes raise — the spec is UTC-only, not
+    'any tz-aware'. Callers normalize at the source."""
+    tz = timezone(timedelta(hours=5, minutes=30))
+    with pytest.raises(ValidationError):
+        DataRef(
+            source="s3",
+            query="s3://bucket/key",
+            point_in_time=datetime(2026, 4, 13, 17, 0, tzinfo=tz),
+        )
+
+
+def test_dataref_accepts_alternate_utc_equivalent_tz():
+    """Any tzinfo whose utcoffset is zero (e.g. datetime.timezone.utc,
+    a zero-offset timezone(timedelta(0))) is accepted."""
+    zero_offset = timezone(timedelta(0), name="UTC+0")
     ref = DataRef(
         source="s3",
         query="s3://bucket/key",
-        point_in_time=datetime(2026, 4, 13, 17, 0, tzinfo=tz),
+        point_in_time=datetime(2026, 4, 13, 12, 0, tzinfo=zero_offset),
     )
-    assert ref.point_in_time.tzinfo is not None
+    assert ref.point_in_time.utcoffset() == timedelta(0)
 
 
 def test_dataref_default_cache_policy_is_ttl():
@@ -224,3 +237,64 @@ def test_action_field_is_not_enum_enforced():
     """action is free-form — callers can ship new namespaces additively."""
     event = _make_event(action="custom.vertical.event")
     assert event.action == "custom.vertical.event"
+
+
+def test_action_namespaces_excludes_runtime_specific_fabric():
+    """Fabric is a runtime-specific concept (pocket object store) and
+    must not ship in the framework-agnostic catalog. Runtimes extend
+    the tuple from their own code."""
+    assert not any(ns.startswith("fabric.") for ns in ACTION_NAMESPACES)
+
+
+# ----- payload union discriminator -----------------------------------------
+
+
+def test_payload_dict_with_dataref_shaped_keys_stays_a_dict():
+    """A plain dict payload whose keys happen to overlap DataRef
+    (``source``, ``query``, ``point_in_time``) must deserialize as a
+    dict, not silently coerce into a DataRef."""
+    lookalike = {
+        "source": "user typed this",
+        "query": "what's the status?",
+        "point_in_time": "2026-04-13T12:00:00+00:00",
+    }
+    event = _make_event(payload=lookalike)
+    restored = EventEntry.model_validate_json(event.model_dump_json())
+    assert isinstance(restored.payload, dict)
+    assert not isinstance(restored.payload, DataRef)
+    assert restored.payload["source"] == "user typed this"
+
+
+def test_payload_dataref_round_trips_through_the_union():
+    """A DataRef payload round-trips through JSON as a DataRef."""
+    ref = DataRef(
+        source="salesforce",
+        query="SELECT Id FROM Account",
+        point_in_time=datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+    )
+    event = _make_event(payload=ref)
+    restored = EventEntry.model_validate_json(event.model_dump_json())
+    assert isinstance(restored.payload, DataRef)
+    assert restored.payload.source == "salesforce"
+
+
+def test_payload_plain_dict_unchanged_by_discriminator():
+    """Ordinary dict payloads (no DataRef-ish keys) round-trip unchanged."""
+    event = _make_event(payload={"note": "hello", "count": 3})
+    restored = EventEntry.model_validate_json(event.model_dump_json())
+    assert isinstance(restored.payload, dict)
+    assert restored.payload == {"note": "hello", "count": 3}
+
+
+def test_payload_dataref_json_carries_discriminator_marker():
+    """DataRef's JSON form stamps ``__dataref__: true`` so consumers
+    (and the union resolver) can tell it apart from a plain dict."""
+    import json as _json
+
+    ref = DataRef(
+        source="gdrive",
+        query="file:abc",
+        point_in_time=datetime(2026, 4, 13, tzinfo=UTC),
+    )
+    payload = _json.loads(ref.model_dump_json())
+    assert payload.get("__dataref__") is True


### PR DESCRIPTION
First slice of the Org Architecture RFC (#164). Ships the spec-only Pydantic models for the org journal — the append-only, UTC-stamped, scope-tagged event log the RFC proposes as Paw OS's source of truth.

## What's in

- `Actor` — `kind` (agent/user/system/root), `id`, `scope_context`. No anonymous writes.
- `DataRef` — `source`, `query`, `point_in_time` (tz-aware enforced), `cache_policy`, `cache_ttl_s`. The reference type for zero-copy retrieval against live systems.
- `EventEntry` — `id`, `ts` (tz-aware enforced), `actor`, `action`, `scope` (required + non-empty), `causation_id`, `correlation_id`, `payload: DataRef | dict`, optional `prev_hash` and `sig` as bytes that round-trip through JSON as base64.
- `ACTION_NAMESPACES` — initial catalog from the RFC appendix, kept as a tuple rather than an enum so verticals can ship new actions without a library bump.

Semantics locked in docstrings: append-only, scope required, UTC-only timestamps, system:* actors reserved for subsystems.

## What's not

No engine code, no CLI, no migration scripts. The SQLite WAL engine and `paw os init` come in follow-up PRs. This PR is deliberately small so the shape of the models can get reviewed before anything depends on them.

## Tests

`tests/test_spec/test_journal.py` — 21 tests covering:
- JSON round-trips for each model
- `ts` and `point_in_time` reject naive datetimes (the naive-datetime bugs from today's review won't recur here)
- `scope` is required and every entry must be non-empty
- `payload` union round-trips for both `dict` and `DataRef` variants
- `Actor.kind` rejects unknown values; `id` must be non-empty
- `causation_id` is `None` for genesis events and round-trips when set
- `ACTION_NAMESPACES` covers the catalog, and `action` itself stays free-form

All 62 tests in `tests/test_spec/` still pass.

## Design source

Matches the shape laid out in #164 § "The Org Journal" and the Appendix event catalog. Same spec-only PR shape as #161 (RetrievalTrace) and #162 (scope tags).