### PR TITLE
feat(spec): decision traces — agent.proposed + human.corrected payload types

### DIFF
--- a/docs/decision-traces.md
+++ b/docs/decision-traces.md
@@ -1,0 +1,126 @@
+<!--
+decision-traces.md — Concept doc for the decision-trace event chain.
+Created: feat/decision-traces — Workstream D of Org Architecture RFC (PR #164).
+Pairs with src/soul_protocol/spec/decisions.py and tests/test_spec/test_decisions.py.
+-->
+
+# Decision Traces
+
+> Every agent proposal a human edits, accepts, rejects, or defers becomes a
+> structured, auditable, replayable pair of events in the org journal. Over
+> time, recurring corrections graduate into standing guidance the agent
+> loads as memory.
+
+This is one of the four compounding data types that differentiate Paw OS
+from generic stack-of-record systems. Decisions are not built in SAP or
+Salesforce. They are built here.
+
+---
+
+## The three event types
+
+A decision trace is a chain of journal events linked by `causation_id`:
+
+1. **`agent.proposed`** — payload: [`AgentProposal`](../src/soul_protocol/spec/decisions.py)
+   The agent emits a structured proposal: a tool call, a draft message, or
+   a decision among options. The proposal carries a one-to-three sentence
+   summary, the structured payload, an optional self-reported confidence,
+   the alternatives the agent considered, and references to prior journal
+   events the agent consulted (`context_refs`).
+
+2. **`human.corrected`** — payload: [`HumanCorrection`](../src/soul_protocol/spec/decisions.py)
+   A reviewer dispositions the proposal — `accepted`, `edited`, `rejected`,
+   or `deferred`. The event's `causation_id` points at the
+   `agent.proposed` event. `structured_reason_tags` (e.g.
+   `tone_too_formal`, `wrong_recipient`) carry the *why* in a form the
+   graduation pipeline can cluster on.
+
+3. **`decision.graduated`** — payload: [`DecisionGraduation`](../src/soul_protocol/spec/decisions.py)
+   When a pattern of corrections recurs, the system promotes it from
+   episodic memory (the raw correction events) to semantic or core memory
+   (standing guidance the agent reads on every relevant turn). The payload
+   carries the pattern summary, the supporting correction ids (so the
+   rule is auditable), the target tier, and the scope it applies to.
+
+---
+
+## Example flow
+
+The sales agent at Acme drafts a reply to a buyer:
+
+```text
+ts=T0  action=agent.proposed       payload=AgentProposal(kind="message_draft",
+                                                         summary="Reply to pricing question",
+                                                         proposal={...})
+ts=T1  action=human.corrected      causation_id=<T0.id>
+                                   payload=HumanCorrection(disposition="edited",
+                                                           corrected_value={...},
+                                                           structured_reason_tags=["tone_too_formal"])
+```
+
+Ten similar corrections accumulate over a month. The graduation pipeline
+spots the cluster:
+
+```text
+ts=T_n  action=decision.graduated   payload=DecisionGraduation(
+                                       pattern_summary="Use casual register for replies to existing buyers",
+                                       supporting_correction_ids=[<10 uuids>],
+                                       graduated_to_tier="semantic",
+                                       confidence=0.91,
+                                       applies_to={"channel": "email", "stage": "post-sale"})
+```
+
+From that point on the agent loads the rule as memory — and the team
+stops having to make the same edit.
+
+---
+
+## Why this matters vs. raw training data
+
+- **Structured.** Every correction carries a disposition and a small set of
+  reason tags from a closed vocabulary. Cluster-able by construction. No
+  vibes-based "the agent should just sound more like us."
+- **Auditable.** Every graduated rule cites the corrections it was drawn
+  from. A reviewer can trace any standing rule back to the raw events,
+  decide it's wrong, and demote it.
+- **Org-scoped.** Events carry DSP scope tags. A rule learned in
+  `org:sales:pocket:acme` does not bleed into `org:engineering`.
+- **Replayable.** Because the journal is append-only with monotonic
+  timestamps, the entire decision history can be replayed against a new
+  graduation policy without losing fidelity.
+
+---
+
+## Programming surface
+
+The spec ships three Pydantic models and four helpers in
+[`soul_protocol.spec.decisions`](../src/soul_protocol/spec/decisions.py):
+
+| Helper | Purpose |
+|---|---|
+| `build_proposal_event(actor, scope, correlation_id, proposal)` | Construct the `agent.proposed` `EventEntry` with the right action and serialized payload. |
+| `build_correction_event(actor, scope, correlation_id, causation_id, correction)` | Same for `human.corrected`, with the required link to the prior proposal. |
+| `find_corrections_for(journal, proposal_id)` | List every `human.corrected` event whose `causation_id` is `proposal_id`. |
+| `trace_decision_chain(journal, correlation_id)` | Return the time-ordered proposal/correction events for a session or flow. |
+| `cluster_correction_patterns(journal, since=..., min_occurrences=3)` | Surface candidate graduation patterns by tag co-occurrence. Promotion logic itself ships in a follow-up slice. |
+
+The pocketpaw runtime wires these into the tool-preview UI and the draft
+approval flow — that integration lands in a follow-up PR in the
+`pocketpaw` repo, not here.
+
+---
+
+## What's deliberately not in this slice
+
+- **Promotion logic.** `cluster_correction_patterns` *surfaces* candidate
+  patterns. The actual write of `decision.graduated` events, plus the
+  policy for picking `semantic` vs `core`, is future work.
+- **Embedding-based clustering.** Today's clustering is exact match on the
+  sorted tag tuple. Richer schemes (tag hierarchies, embedding-similarity
+  on `correction_reason`) are intentional next steps.
+- **Edit-distance scoring.** The field is on the model (`HumanCorrection.edit_distance`)
+  but no scorer is bundled — consumers compute the score they want and
+  attach it.
+
+See [RFC PR #164](https://github.com/qbtrix/soul-protocol/pull/164) and
+the [org architecture doc](./org-architecture.md) for the larger context.

--- a/src/soul_protocol/__init__.py
+++ b/src/soul_protocol/__init__.py
@@ -18,6 +18,9 @@
 #   GeneralEvent, SelfImage) to public exports.
 # Updated: feat/journal-spec — Added org journal primitives (Actor, DataRef,
 #   EventEntry, ACTION_NAMESPACES) from spec.journal. See RFC PR #164.
+# Updated: feat/decision-traces — Added decision-trace payload models and
+#   helpers (AgentProposal, HumanCorrection, DecisionGraduation, build/trace
+#   helpers, cluster_correction_patterns). See RFC PR #164, Workstream D.
 
 from __future__ import annotations
 
@@ -70,6 +73,16 @@ from .runtime.eternal import ArchiveResult, EternalStorageManager, EternalStorag
 # Core primitives from spec/ (always available — only requires pydantic)
 from .spec.identity import BondTarget as CoreBondTarget
 from .spec.identity import Identity as CoreIdentity
+from .spec.decisions import (
+    AgentProposal,
+    DecisionGraduation,
+    HumanCorrection,
+    build_correction_event,
+    build_proposal_event,
+    cluster_correction_patterns,
+    find_corrections_for,
+    trace_decision_chain,
+)
 from .spec.journal import ACTION_NAMESPACES, Actor, DataRef, EventEntry
 from .spec.manifest import Manifest as CoreManifest
 from .spec.memory import DictMemoryStore, MemoryStore
@@ -146,6 +159,15 @@ __all__ = [
     "Actor",
     "DataRef",
     "EventEntry",
+    # Decision traces (feat/decision-traces)
+    "AgentProposal",
+    "HumanCorrection",
+    "DecisionGraduation",
+    "build_proposal_event",
+    "build_correction_event",
+    "find_corrections_for",
+    "trace_decision_chain",
+    "cluster_correction_patterns",
 ]
 
 __version__ = "0.2.5"

--- a/src/soul_protocol/spec/__init__.py
+++ b/src/soul_protocol/spec/__init__.py
@@ -7,6 +7,11 @@
 # Updated: 2026-03-23 — Added A2A Agent Card models (A2AAgentCard, A2ASkill, SoulExtension).
 # Updated: feat/journal-spec — Exported Journal primitives (Actor, DataRef, EventEntry,
 #   ACTION_NAMESPACES) from the new org journal module. See RFC PR #164.
+# Updated: feat/decision-traces — Exported decision trace payload models
+#   (AgentProposal, HumanCorrection, DecisionGraduation) and helpers
+#   (build_proposal_event, build_correction_event, find_corrections_for,
+#   trace_decision_chain, cluster_correction_patterns). See RFC PR #164,
+#   Workstream D.
 
 from __future__ import annotations
 
@@ -30,6 +35,17 @@ from .embeddings import (
 from .eternal import ArchiveResult, EternalStorageProvider, RecoverySource
 from .a2a import A2AAgentCard, A2ASkill, SoulExtension
 from .identity import BondTarget, Identity
+from .decisions import (
+    AgentProposal,
+    DecisionGraduation,
+    Disposition,
+    HumanCorrection,
+    build_correction_event,
+    build_proposal_event,
+    cluster_correction_patterns,
+    find_corrections_for,
+    trace_decision_chain,
+)
 from .journal import ACTION_NAMESPACES, Actor, DataRef, EventEntry
 from .manifest import Manifest
 from .memory import DictMemoryStore, Interaction, MemoryEntry, MemoryStore, MemoryVisibility, Participant
@@ -61,6 +77,16 @@ __all__ = [
     "Actor",
     "DataRef",
     "EventEntry",
+    # Decision traces (agent.proposed / human.corrected / decision.graduated)
+    "AgentProposal",
+    "HumanCorrection",
+    "DecisionGraduation",
+    "Disposition",
+    "build_proposal_event",
+    "build_correction_event",
+    "find_corrections_for",
+    "trace_decision_chain",
+    "cluster_correction_patterns",
     # Memory
     "Interaction",
     "MemoryEntry",

--- a/src/soul_protocol/spec/decisions.py
+++ b/src/soul_protocol/spec/decisions.py
@@ -1,0 +1,282 @@
+# decisions.py — Decision trace payload types and helpers for the Org Journal.
+# Created: feat/decision-traces — Workstream D of the Org Architecture RFC (PR #164).
+#
+# Every agent proposal a human edits or rejects becomes a structured, auditable
+# pair of events in the journal:
+#   - ``agent.proposed``   : the agent's proposed action with a structured payload.
+#   - ``human.corrected``  : the human's disposition (accepted / edited / rejected /
+#                            deferred) linked back via ``causation_id``.
+#   - ``decision.graduated``: a pattern of recurring corrections promoted from
+#                            episodic to semantic memory (promotion logic ships
+#                            in a later slice; this module only carries the
+#                            payload type and a candidate-surfacing helper).
+#
+# The Paw OS gaps analysis names "Decisions" as one of the four compounding
+# data types that differentiate it from generic stack-of-record systems. This
+# module is the spec side of that story. The pocketpaw-side emit points
+# (tool-call preview, draft-approval UI hooks, etc.) land in a follow-up PR in
+# that repo.
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+from .journal import Actor, EventEntry
+
+
+# ----- Payload models ------------------------------------------------------
+
+
+class AgentProposal(BaseModel):
+    """Payload for an ``agent.proposed`` :class:`EventEntry`.
+
+    An agent's proposed action awaiting human review, edit, or acceptance.
+    The proposal is structured (not just a blob) so that the matching
+    ``human.corrected`` event can be aligned field-for-field when a reviewer
+    edits the output. See :func:`build_proposal_event`.
+
+    Fields:
+        proposal_kind: One of ``"tool_call"``, ``"message_draft"``,
+            ``"decision"``, or ``"custom:<namespace>"`` for domain extensions.
+            Free-form string — the catalog is a convention, not an enum.
+        summary: One to three sentences that a human can skim in a queue.
+        proposal: The structured proposal payload — tool arguments, draft
+            body, decision options, etc. Shape is kind-dependent.
+        confidence: The agent's self-reported confidence in the proposal,
+            in ``[0.0, 1.0]``. ``None`` when the agent does not emit one.
+        alternatives: Alternative proposals the agent considered but did
+            not surface as the primary. Useful when the human prefers an
+            already-explored option.
+        context_refs: Prior ``EventEntry`` ids the agent consulted when
+            drafting the proposal (retrievals, prior proposals, prior
+            corrections). Grounds the proposal in the journal.
+    """
+
+    proposal_kind: str = Field(min_length=1)
+    summary: str = Field(min_length=1)
+    proposal: dict
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    alternatives: list[dict] = Field(default_factory=list)
+    context_refs: list[UUID] = Field(default_factory=list)
+
+
+Disposition = Literal["accepted", "edited", "rejected", "deferred"]
+
+
+class HumanCorrection(BaseModel):
+    """Payload for a ``human.corrected`` :class:`EventEntry`.
+
+    A human's edit, rejection, acceptance, or deferral of an agent
+    proposal. The matching event's ``causation_id`` must point to the
+    ``agent.proposed`` event this correction responds to — that link is
+    what makes the proposal/correction pair queryable and graduatable.
+
+    Fields:
+        disposition: ``"accepted"``, ``"edited"``, ``"rejected"``, or
+            ``"deferred"``. Enforced as a Literal — unknown values raise.
+        corrected_value: The final value when edited or accepted; ``None``
+            when rejected or deferred. Shape mirrors ``AgentProposal.proposal``.
+        correction_reason: Optional free-text reason the reviewer provided.
+        structured_reason_tags: Machine-readable tags, e.g.
+            ``["tone_too_formal", "wrong_recipient", "missed_context"]``.
+            Powers :func:`cluster_correction_patterns` — pick a small
+            stable tag vocabulary per pocket.
+        edit_distance: Optional similarity score in ``[0.0, 1.0]`` between
+            the proposal and the corrected value. ``None`` when not scored.
+    """
+
+    disposition: Disposition
+    corrected_value: dict | None = None
+    correction_reason: str | None = None
+    structured_reason_tags: list[str] = Field(default_factory=list)
+    edit_distance: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+class DecisionGraduation(BaseModel):
+    """Payload for a ``decision.graduated`` :class:`EventEntry`.
+
+    A pattern of recurring corrections has been promoted from episodic to
+    semantic (or core) memory. Once graduated, the agent should load the
+    pattern as standing guidance — so the same correction does not have to
+    be made again.
+
+    Fields:
+        pattern_summary: Human-readable summary of the learned pattern
+            (e.g. "Use first names, not titles, for internal replies").
+        supporting_correction_ids: Ids of ``human.corrected`` events that
+            this pattern is drawn from. Provides auditability — a reviewer
+            can inspect the raw corrections behind any graduated rule.
+        graduated_to_tier: ``"semantic"`` for general-purpose facts,
+            ``"core"`` for load-on-startup identity-grade guidance.
+        confidence: Confidence in the pattern, in ``[0.0, 1.0]``.
+        applies_to: Scope / context where the pattern applies, e.g.
+            ``{"channel": "email", "recipients": "internal"}``. Opaque
+            to the spec; consumer subsystems interpret the shape.
+    """
+
+    pattern_summary: str = Field(min_length=1)
+    supporting_correction_ids: list[UUID] = Field(min_length=1)
+    graduated_to_tier: Literal["semantic", "core"]
+    confidence: float = Field(ge=0.0, le=1.0)
+    applies_to: dict = Field(default_factory=dict)
+
+
+# ----- Builder helpers -----------------------------------------------------
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def build_proposal_event(
+    *,
+    actor: Actor,
+    scope: list[str],
+    correlation_id: UUID,
+    proposal: AgentProposal,
+    ts: datetime | None = None,
+    event_id: UUID | None = None,
+) -> EventEntry:
+    """Build an ``agent.proposed`` :class:`EventEntry` from a proposal.
+
+    The payload is wrapped via ``AgentProposal.model_dump(mode="json")`` so
+    nested UUIDs serialize cleanly through the journal's JSON transport.
+    """
+    return EventEntry(
+        id=event_id or uuid4(),
+        ts=ts or _now_utc(),
+        actor=actor,
+        action="agent.proposed",
+        scope=scope,
+        correlation_id=correlation_id,
+        causation_id=None,
+        payload=proposal.model_dump(mode="json"),
+    )
+
+
+def build_correction_event(
+    *,
+    actor: Actor,
+    scope: list[str],
+    correlation_id: UUID,
+    causation_id: UUID,
+    correction: HumanCorrection,
+    ts: datetime | None = None,
+    event_id: UUID | None = None,
+) -> EventEntry:
+    """Build a ``human.corrected`` :class:`EventEntry` linked to a proposal.
+
+    ``causation_id`` is required and must point to the ``agent.proposed``
+    event this correction responds to.
+    """
+    return EventEntry(
+        id=event_id or uuid4(),
+        ts=ts or _now_utc(),
+        actor=actor,
+        action="human.corrected",
+        scope=scope,
+        correlation_id=correlation_id,
+        causation_id=causation_id,
+        payload=correction.model_dump(mode="json"),
+    )
+
+
+# ----- Journal queries -----------------------------------------------------
+
+
+def find_corrections_for(journal, proposal_id: UUID) -> list[EventEntry]:
+    """Return every ``human.corrected`` event whose ``causation_id`` is
+    ``proposal_id``.
+
+    A proposal may have more than one correction in practice (e.g. a
+    deferral followed by an eventual accept), so this returns a list. The
+    backend query filters by action; we filter by ``causation_id`` here
+    because not every backend indexes it as a first-class column.
+    """
+    # Pull a generous window — callers with very busy journals should
+    # query the backend directly with a narrower scope / since filter.
+    candidates = journal.query(action="human.corrected", limit=10_000)
+    return [e for e in candidates if e.causation_id == proposal_id]
+
+
+def trace_decision_chain(journal, correlation_id: UUID) -> list[EventEntry]:
+    """Return the ordered proposal/correction events for a given
+    ``correlation_id``.
+
+    Events are ordered by ``ts`` — the journal engine enforces monotonic
+    timestamps, so this is stable across replays. Non-decision events on
+    the same correlation_id are filtered out.
+    """
+    events = journal.query(correlation_id=correlation_id, limit=10_000)
+    decision_actions = {"agent.proposed", "human.corrected", "decision.graduated"}
+    chain = [e for e in events if e.action in decision_actions]
+    chain.sort(key=lambda e: e.ts)
+    return chain
+
+
+# ----- Pattern detection (graduation seed) ---------------------------------
+
+
+def cluster_correction_patterns(
+    journal,
+    *,
+    since: datetime | None = None,
+    min_occurrences: int = 3,
+) -> list[dict]:
+    """Surface candidate graduation patterns by tag co-occurrence.
+
+    Scans ``human.corrected`` events, groups by the sorted tuple of
+    ``structured_reason_tags``, and returns clusters that meet the
+    ``min_occurrences`` threshold. This is the *candidate-surfacing* step
+    only — the actual promotion to semantic/core memory ships in a later
+    slice. Keep the heuristic simple; richer clustering (embedding-based,
+    tag-hierarchy-aware) is a deliberate future enhancement.
+
+    Return shape:
+        ``[{"tags": [...], "count": N,
+           "example_correction_ids": [UUID, ...],
+           "recent_ts": datetime}, ...]``
+    """
+    events = journal.query(action="human.corrected", since=since, limit=10_000)
+
+    buckets: dict[tuple[str, ...], list[EventEntry]] = {}
+    for event in events:
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        tags = payload.get("structured_reason_tags") or []
+        if not tags:
+            continue
+        key = tuple(sorted(tags))
+        buckets.setdefault(key, []).append(event)
+
+    clusters: list[dict] = []
+    for key, bucket in buckets.items():
+        if len(bucket) < min_occurrences:
+            continue
+        bucket_sorted = sorted(bucket, key=lambda e: e.ts)
+        clusters.append(
+            {
+                "tags": list(key),
+                "count": len(bucket),
+                "example_correction_ids": [e.id for e in bucket_sorted[-5:]],
+                "recent_ts": bucket_sorted[-1].ts,
+            }
+        )
+    clusters.sort(key=lambda c: (-c["count"], c["recent_ts"]))
+    return clusters
+
+
+__all__ = [
+    "AgentProposal",
+    "HumanCorrection",
+    "DecisionGraduation",
+    "Disposition",
+    "build_proposal_event",
+    "build_correction_event",
+    "find_corrections_for",
+    "trace_decision_chain",
+    "cluster_correction_patterns",
+]

--- a/tests/test_spec/test_decisions.py
+++ b/tests/test_spec/test_decisions.py
@@ -1,0 +1,433 @@
+# test_spec/test_decisions.py — Tests for the decision-trace spec.
+# Created: feat/decision-traces — Workstream D of Org Architecture RFC (PR #164).
+# Covers: JSON round-trips, disposition Literal enforcement, builder helpers
+# emit the right actions + payload shapes, find_corrections_for filters on
+# causation_id (not correlation_id), trace_decision_chain returns ordered
+# pairs, cluster_correction_patterns respects min_occurrences, optional
+# edit_distance is allowed to be None, empty context_refs is allowed.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from soul_protocol.engine.journal import Journal, open_journal
+from soul_protocol.spec import (
+    ACTION_NAMESPACES,
+    Actor,
+    AgentProposal,
+    DecisionGraduation,
+    HumanCorrection,
+    build_correction_event,
+    build_proposal_event,
+    cluster_correction_patterns,
+    find_corrections_for,
+    trace_decision_chain,
+)
+
+
+# ---------- fixtures -------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path) -> Journal:
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+@pytest.fixture
+def reviewer() -> Actor:
+    return Actor(kind="user", id="user:alice", scope_context=["org:sales"])
+
+
+@pytest.fixture
+def drafter() -> Actor:
+    return Actor(kind="agent", id="did:soul:sales-lead", scope_context=["org:sales"])
+
+
+# ---------- payload round-trips -------------------------------------------
+
+
+def test_agent_proposal_round_trips_json():
+    proposal = AgentProposal(
+        proposal_kind="message_draft",
+        summary="Draft reply to Acme's pricing question.",
+        proposal={"to": "buyer@acme.com", "body": "Thanks for reaching out..."},
+        confidence=0.72,
+        alternatives=[{"body": "Shorter variant."}],
+        context_refs=[uuid4(), uuid4()],
+    )
+    restored = AgentProposal.model_validate_json(proposal.model_dump_json())
+    assert restored == proposal
+
+
+def test_agent_proposal_allows_empty_context_refs_and_no_confidence():
+    proposal = AgentProposal(
+        proposal_kind="tool_call",
+        summary="Call the pricing tool.",
+        proposal={"name": "get_price", "args": {"sku": "X-1"}},
+    )
+    assert proposal.context_refs == []
+    assert proposal.alternatives == []
+    assert proposal.confidence is None
+
+
+def test_agent_proposal_rejects_out_of_range_confidence():
+    with pytest.raises(ValidationError):
+        AgentProposal(
+            proposal_kind="decision",
+            summary="Pick a plan.",
+            proposal={},
+            confidence=1.5,
+        )
+
+
+def test_human_correction_round_trips_json():
+    correction = HumanCorrection(
+        disposition="edited",
+        corrected_value={"body": "Thanks — here's pricing."},
+        correction_reason="too formal",
+        structured_reason_tags=["tone_too_formal", "wrong_length"],
+        edit_distance=0.34,
+    )
+    restored = HumanCorrection.model_validate_json(correction.model_dump_json())
+    assert restored == correction
+
+
+def test_human_correction_edit_distance_is_optional():
+    correction = HumanCorrection(
+        disposition="accepted",
+        corrected_value={"body": "ok"},
+        structured_reason_tags=[],
+    )
+    assert correction.edit_distance is None
+
+
+def test_human_correction_rejects_unknown_disposition():
+    with pytest.raises(ValidationError):
+        HumanCorrection(disposition="mangled")  # type: ignore[arg-type]
+
+
+def test_human_correction_rejected_allows_null_corrected_value():
+    correction = HumanCorrection(
+        disposition="rejected",
+        corrected_value=None,
+        correction_reason="off-brand",
+        structured_reason_tags=["off_brand"],
+    )
+    restored = HumanCorrection.model_validate_json(correction.model_dump_json())
+    assert restored.corrected_value is None
+
+
+def test_decision_graduation_round_trips_json():
+    grad = DecisionGraduation(
+        pattern_summary="Use first names, not titles, for internal replies.",
+        supporting_correction_ids=[uuid4(), uuid4(), uuid4()],
+        graduated_to_tier="semantic",
+        confidence=0.88,
+        applies_to={"channel": "email", "recipients": "internal"},
+    )
+    restored = DecisionGraduation.model_validate_json(grad.model_dump_json())
+    assert restored == grad
+
+
+def test_decision_graduation_requires_supporting_ids():
+    with pytest.raises(ValidationError):
+        DecisionGraduation(
+            pattern_summary="x",
+            supporting_correction_ids=[],
+            graduated_to_tier="semantic",
+            confidence=0.9,
+        )
+
+
+# ---------- builders -------------------------------------------------------
+
+
+def test_namespaces_include_decision_actions():
+    assert "agent.proposed" in ACTION_NAMESPACES
+    assert "human.corrected" in ACTION_NAMESPACES
+    assert "decision.graduated" in ACTION_NAMESPACES
+
+
+def test_build_proposal_event_shape(drafter: Actor):
+    correlation_id = uuid4()
+    proposal = AgentProposal(
+        proposal_kind="message_draft",
+        summary="Draft reply.",
+        proposal={"body": "Hi."},
+        confidence=0.5,
+    )
+    event = build_proposal_event(
+        actor=drafter,
+        scope=["org:sales:pocket:acme"],
+        correlation_id=correlation_id,
+        proposal=proposal,
+    )
+    assert event.action == "agent.proposed"
+    assert event.correlation_id == correlation_id
+    assert event.causation_id is None
+    assert isinstance(event.payload, dict)
+    assert event.payload["summary"] == "Draft reply."
+    assert event.ts.tzinfo is not None
+
+
+def test_build_correction_event_shape(reviewer: Actor):
+    proposal_id = uuid4()
+    correlation_id = uuid4()
+    correction = HumanCorrection(
+        disposition="edited",
+        corrected_value={"body": "Hi Alice."},
+        structured_reason_tags=["tone_too_formal"],
+    )
+    event = build_correction_event(
+        actor=reviewer,
+        scope=["org:sales:pocket:acme"],
+        correlation_id=correlation_id,
+        causation_id=proposal_id,
+        correction=correction,
+    )
+    assert event.action == "human.corrected"
+    assert event.causation_id == proposal_id
+    assert event.correlation_id == correlation_id
+    assert isinstance(event.payload, dict)
+    assert event.payload["disposition"] == "edited"
+
+
+# ---------- journal queries -----------------------------------------------
+
+
+def _seed_proposal_and_correction(
+    journal: Journal,
+    *,
+    drafter: Actor,
+    reviewer: Actor,
+    tags: list[str] | None = None,
+    correlation_id=None,
+    proposal_ts: datetime | None = None,
+    correction_ts: datetime | None = None,
+):
+    correlation_id = correlation_id or uuid4()
+    proposal = AgentProposal(
+        proposal_kind="message_draft",
+        summary="s",
+        proposal={"body": "draft"},
+    )
+    p_event = build_proposal_event(
+        actor=drafter,
+        scope=["org:sales"],
+        correlation_id=correlation_id,
+        proposal=proposal,
+        ts=proposal_ts,
+    )
+    journal.append(p_event)
+    correction = HumanCorrection(
+        disposition="edited",
+        corrected_value={"body": "edited"},
+        structured_reason_tags=tags or [],
+    )
+    c_event = build_correction_event(
+        actor=reviewer,
+        scope=["org:sales"],
+        correlation_id=correlation_id,
+        causation_id=p_event.id,
+        correction=correction,
+        ts=correction_ts,
+    )
+    journal.append(c_event)
+    return p_event, c_event
+
+
+def test_find_corrections_for_matches_only_causation_id(
+    journal: Journal, drafter: Actor, reviewer: Actor
+):
+    p1, c1 = _seed_proposal_and_correction(journal, drafter=drafter, reviewer=reviewer)
+    p2, c2 = _seed_proposal_and_correction(journal, drafter=drafter, reviewer=reviewer)
+
+    hits_for_p1 = find_corrections_for(journal, p1.id)
+    assert [e.id for e in hits_for_p1] == [c1.id]
+
+    hits_for_p2 = find_corrections_for(journal, p2.id)
+    assert [e.id for e in hits_for_p2] == [c2.id]
+
+
+def test_find_corrections_for_ignores_same_correlation_id(
+    journal: Journal, drafter: Actor, reviewer: Actor
+):
+    # Two proposals share one correlation_id (same session) — their
+    # corrections must not cross-pollinate.
+    correlation_id = uuid4()
+    base = datetime.now(UTC)
+    p1, c1 = _seed_proposal_and_correction(
+        journal,
+        drafter=drafter,
+        reviewer=reviewer,
+        correlation_id=correlation_id,
+        proposal_ts=base,
+        correction_ts=base + timedelta(seconds=1),
+    )
+    p2, c2 = _seed_proposal_and_correction(
+        journal,
+        drafter=drafter,
+        reviewer=reviewer,
+        correlation_id=correlation_id,
+        proposal_ts=base + timedelta(seconds=2),
+        correction_ts=base + timedelta(seconds=3),
+    )
+
+    hits = find_corrections_for(journal, p1.id)
+    assert {e.id for e in hits} == {c1.id}
+    assert c2.id not in {e.id for e in hits}
+
+
+def test_trace_decision_chain_orders_by_timestamp(
+    journal: Journal, drafter: Actor, reviewer: Actor
+):
+    correlation_id = uuid4()
+    base = datetime.now(UTC)
+    p1, c1 = _seed_proposal_and_correction(
+        journal,
+        drafter=drafter,
+        reviewer=reviewer,
+        correlation_id=correlation_id,
+        proposal_ts=base,
+        correction_ts=base + timedelta(seconds=1),
+    )
+    p2, c2 = _seed_proposal_and_correction(
+        journal,
+        drafter=drafter,
+        reviewer=reviewer,
+        correlation_id=correlation_id,
+        proposal_ts=base + timedelta(seconds=2),
+        correction_ts=base + timedelta(seconds=3),
+    )
+
+    chain = trace_decision_chain(journal, correlation_id)
+    assert [e.id for e in chain] == [p1.id, c1.id, p2.id, c2.id]
+
+
+def test_trace_decision_chain_filters_non_decision_events(
+    journal: Journal, drafter: Actor, reviewer: Actor
+):
+    from soul_protocol.spec.journal import EventEntry
+
+    correlation_id = uuid4()
+    base = datetime.now(UTC)
+    # Append a non-decision event on the same correlation_id in the middle
+    # of the decision chain — trace_decision_chain should filter it out.
+    p1_proposal = AgentProposal(
+        proposal_kind="message_draft", summary="s", proposal={"body": "draft"}
+    )
+    p1 = build_proposal_event(
+        actor=drafter,
+        scope=["org:sales"],
+        correlation_id=correlation_id,
+        proposal=p1_proposal,
+        ts=base,
+    )
+    journal.append(p1)
+    journal.append(
+        EventEntry(
+            id=uuid4(),
+            ts=base + timedelta(seconds=1),
+            actor=drafter,
+            action="retrieval.query",
+            scope=["org:sales"],
+            correlation_id=correlation_id,
+            payload={"q": "..."},
+        )
+    )
+    c1 = build_correction_event(
+        actor=reviewer,
+        scope=["org:sales"],
+        correlation_id=correlation_id,
+        causation_id=p1.id,
+        correction=HumanCorrection(
+            disposition="edited",
+            corrected_value={"body": "edited"},
+            structured_reason_tags=[],
+        ),
+        ts=base + timedelta(seconds=2),
+    )
+    journal.append(c1)
+
+    chain = trace_decision_chain(journal, correlation_id)
+    actions = [e.action for e in chain]
+    assert actions == ["agent.proposed", "human.corrected"]
+
+
+# ---------- pattern clustering --------------------------------------------
+
+
+def test_cluster_correction_patterns_meets_threshold(
+    journal: Journal, drafter: Actor, reviewer: Actor
+):
+    # Seed 3 corrections with the same tag combo, 1 with a different combo.
+    for _ in range(3):
+        _seed_proposal_and_correction(
+            journal,
+            drafter=drafter,
+            reviewer=reviewer,
+            tags=["tone_too_formal", "wrong_length"],
+        )
+    _seed_proposal_and_correction(
+        journal,
+        drafter=drafter,
+        reviewer=reviewer,
+        tags=["off_brand"],
+    )
+
+    clusters = cluster_correction_patterns(journal, min_occurrences=3)
+    assert len(clusters) == 1
+    cluster = clusters[0]
+    assert sorted(cluster["tags"]) == ["tone_too_formal", "wrong_length"]
+    assert cluster["count"] == 3
+    assert len(cluster["example_correction_ids"]) == 3
+    assert cluster["recent_ts"].tzinfo is not None
+
+
+def test_cluster_correction_patterns_skips_untagged(
+    journal: Journal, drafter: Actor, reviewer: Actor
+):
+    # 5 untagged corrections — should not produce a cluster keyed on ().
+    for _ in range(5):
+        _seed_proposal_and_correction(journal, drafter=drafter, reviewer=reviewer, tags=[])
+    clusters = cluster_correction_patterns(journal, min_occurrences=3)
+    assert clusters == []
+
+
+def test_cluster_correction_patterns_respects_since(
+    journal: Journal, drafter: Actor, reviewer: Actor
+):
+    old_base = datetime.now(UTC) - timedelta(days=30)
+    # Old corrections: will be filtered out by since=.
+    for i in range(3):
+        _seed_proposal_and_correction(
+            journal,
+            drafter=drafter,
+            reviewer=reviewer,
+            tags=["stale_tag"],
+            proposal_ts=old_base + timedelta(seconds=2 * i),
+            correction_ts=old_base + timedelta(seconds=2 * i + 1),
+        )
+    # Recent corrections: should count.
+    for _ in range(3):
+        _seed_proposal_and_correction(
+            journal,
+            drafter=drafter,
+            reviewer=reviewer,
+            tags=["fresh_tag"],
+        )
+
+    clusters = cluster_correction_patterns(
+        journal,
+        since=datetime.now(UTC) - timedelta(days=1),
+        min_occurrences=3,
+    )
+    assert len(clusters) == 1
+    assert clusters[0]["tags"] == ["fresh_tag"]


### PR DESCRIPTION
## What this is

The spec side of Workstream D from RFC #164 — the decision-trace event chain.

Every agent proposal a reviewer edits, accepts, rejects, or defers now has a structured payload type that rides inside a journal `EventEntry`. Over time, recurring corrections can be clustered, and the pattern promoted from raw events into standing guidance the agent loads as memory. That's the loop the gaps doc calls out as the moat: Decisions, as a first-class data type, that neither SAP nor Salesforce are built to carry.

This PR ships only the primitives. The pocketpaw-side emit points — tool-call preview, draft-approval UI hooks, the edit-captured event — land in a follow-up PR in the `pocketpaw` repo.

## Files

- `src/soul_protocol/spec/decisions.py` — three Pydantic payload models (`AgentProposal`, `HumanCorrection`, `DecisionGraduation`), two builders (`build_proposal_event`, `build_correction_event`), two journal queries (`find_corrections_for`, `trace_decision_chain`), and a simple tag-co-occurrence clusterer (`cluster_correction_patterns`) that surfaces graduation candidates.
- `tests/test_spec/test_decisions.py` — 19 tests covering JSON round-trips, `Literal` enforcement on `disposition`, builder output shape, causation-vs-correlation-id filtering, chain ordering and non-decision-event filtering, and clusterer threshold / `since` behavior.
- `docs/decision-traces.md` — concept doc with the three event types, an example flow, why this matters versus raw training data, and what is deliberately out of scope for this slice.
- Re-exports on `soul_protocol.spec` and the top-level `soul_protocol` package.

## What is deliberately not here

- **Promotion logic.** The clusterer surfaces candidate patterns. Writing a `decision.graduated` event, plus choosing between `semantic` and `core` tiers, is a follow-up once the graduation policy is spec'd.
- **Embedding-based clustering.** Current match is exact on the sorted tag tuple. Richer schemes are a future slice.
- **Edit-distance scoring.** The field exists on `HumanCorrection`; no scorer is bundled. Consumers compute what they want and attach it.
- **pocketpaw wire-in.** Follow-up PR in the `pocketpaw` repo.

## Notes for review

- The `ACTION_NAMESPACES` catalog already included `agent.proposed`, `human.corrected`, and `decision.graduated` per the RFC appendix, so no change to `journal.py` was needed.
- Builders accept an optional `ts` / `event_id` so callers can pre-seed for deterministic replay; otherwise UTC-aware `datetime.now(timezone.utc)` and `uuid4()` are used.
- `find_corrections_for` pulls a large window (`limit=10_000`) and filters in-process on `causation_id` rather than pushing it into the backend query — the backend indexes action but not causation_id as a first-class column today. A real busy org will want a scoped `since` filter; callers can drop to the backend query directly if needed.
- `cluster_correction_patterns` is intentionally ~40 LOC. Not a heuristics rabbit hole.

## Base

Targets `feat/journal-engine` (PR #166). Will retarget to `dev` once that merges.

## Test plan

- [x] `uv run pytest tests/test_spec/test_decisions.py -v` — 19 / 19 pass
- [x] `uv run pytest tests/` — 1979 / 1979 pass

Refs #164 (RFC).