### PR TITLE
feat(engine): retrieval router + credential broker for Zero-Copy

### DIFF
--- a/src/soul_protocol/engine/journal/__init__.py
+++ b/src/soul_protocol/engine/journal/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from .backend import JournalBackend
 from .exceptions import IntegrityError, JournalError, NotFoundError, SchemaError
 from .journal import Journal, open_journal
+from .scope import scope_matches, scopes_overlap
 from .sqlite import SQLiteJournalBackend
 
 __all__ = [
@@ -18,4 +19,6 @@ __all__ = [
     "SQLiteJournalBackend",
     "SchemaError",
     "open_journal",
+    "scope_matches",
+    "scopes_overlap",
 ]

--- a/src/soul_protocol/engine/journal/scope.py
+++ b/src/soul_protocol/engine/journal/scope.py
@@ -1,0 +1,69 @@
+# scope.py — Public scope-matching helper extracted from the sqlite backend.
+# Created: feat/retrieval-router — lift `_scope_matches` out of the SQLite
+# backend (where router and broker were reaching into a private symbol) and
+# into a proper public module. Semantics are unchanged; the sqlite backend
+# now imports from here, and the router + broker do too.
+#
+# Grammar (colon-delimited segments, ``*`` is a single-segment wildcard):
+#   - ``"org:sales"`` matches exactly ``org:sales``.
+#   - ``"org:sales:*"`` matches ``org:sales:leads`` and ``org:sales:deals``
+#     but NOT bare ``org:sales`` (segment count must match).
+#   - ``"org:*"`` matches ``org:sales`` and ``org:hr`` but NOT bare ``org``.
+#   - ``"org:*:leads"`` matches ``org:sales:leads`` and ``org:hr:leads``.
+#
+# This is a placeholder until ``spec.scope`` from #162 lands; the final
+# grammar there is a superset of what we implement. Callers swap to the
+# richer helper when it ships — same name, same shape.
+
+from __future__ import annotations
+
+
+def scope_matches(event_scopes: list[str], query_scopes: list[str]) -> bool:
+    """Return True iff any event scope matches any query pattern.
+
+    Semantics are asymmetric on purpose: `event_scopes` are concrete scopes
+    carried by a journal event, `query_scopes` are patterns supplied by a
+    caller looking for matches. Wildcards are valid on the pattern side;
+    putting a wildcard in an event scope works but means "this event was
+    emitted across a wildcard scope" which few writers do.
+    """
+    for pat in query_scopes:
+        pat_parts = pat.split(":")
+        for scope in event_scopes:
+            scope_parts = scope.split(":")
+            if len(pat_parts) != len(scope_parts):
+                continue
+            if all(p == "*" or p == s for p, s in zip(pat_parts, scope_parts)):
+                return True
+    return False
+
+
+def scopes_overlap(granted: list[str], requested: list[str]) -> bool:
+    """Return True iff any requested pattern is covered by any granted one.
+
+    Policy pinned: this is intentionally symmetric against wildcards — a
+    credential granted for ``org:sales:*`` is usable by a requester
+    presenting a specific scope like ``org:sales:leads``, AND a credential
+    granted for a specific scope ``org:sales:leads`` is usable by a
+    requester presenting ``org:sales:*`` (a wildcard requester asserting
+    "I am operating anywhere in this subtree").
+
+    Both directions are deliberate. Breaking either:
+      * reject specific-requester-vs-wildcard-grant -> admins who issue a
+        broad credential can't use it for any concrete call.
+      * reject wildcard-requester-vs-specific-grant -> a retrieval router
+        operating org-wide can't consume per-scope credentials, which
+        kneecaps fanout.
+    """
+    for req in requested:
+        req_parts = req.split(":")
+        for grant in granted:
+            grant_parts = grant.split(":")
+            if len(grant_parts) != len(req_parts):
+                continue
+            if all(
+                g == "*" or r == "*" or g == r
+                for g, r in zip(grant_parts, req_parts)
+            ):
+                return True
+    return False

--- a/src/soul_protocol/engine/journal/sqlite.py
+++ b/src/soul_protocol/engine/journal/sqlite.py
@@ -1,4 +1,8 @@
 # sqlite.py — SQLite WAL-mode JournalBackend implementation.
+# Updated: feat/retrieval-router — move the scope-matching helper out of this
+# module and into the public `.scope` module. `_scope_matches` stays here as a
+# re-export for now so the router's legacy import keeps working; new callers
+# import `scope_matches` from `soul_protocol.engine.journal`.
 # Updated: feat/journal-engine — move the ts-monotonicity check inside the
 # BEGIN IMMEDIATE transaction so two concurrent writers can't both pass a
 # pre-transaction read and land events with out-of-order timestamps. The
@@ -43,30 +47,11 @@ def _decode_payload(raw: str) -> DataRef | dict[str, Any]:
     return obj
 
 
-def _scope_matches(event_scopes: list[str], query_scopes: list[str]) -> bool:
-    """Prefix + wildcard match. An event matches if any event scope satisfies
-    any query pattern.
-
-    Semantics (colon-delimited segments):
-      - ``"org:sales"`` matches exactly ``org:sales``.
-      - ``"org:sales:*"`` matches ``org:sales:leads``, ``org:sales:deals``,
-        ``org:sales:leads:priority``, but NOT bare ``org:sales``.
-      - ``"org:*"`` matches ``org:sales`` and ``org:hr`` but NOT bare ``org``.
-      - ``"org:*:leads"`` matches ``org:sales:leads`` and ``org:hr:leads``.
-
-    This is a placeholder until ``spec.scope`` from #162 lands; the grammar
-    described in the RFC is a superset of what we implement here. See the
-    PR description for the deferred-work note.
-    """
-    for pat in query_scopes:
-        pat_parts = pat.split(":")
-        for scope in event_scopes:
-            scope_parts = scope.split(":")
-            if len(pat_parts) != len(scope_parts):
-                continue
-            if all(p == "*" or p == s for p, s in zip(pat_parts, scope_parts)):
-                return True
-    return False
+from .scope import scope_matches as _scope_matches
+# Re-export under the old private name so existing imports
+# (including the router's direct reach into this module) keep working
+# until they're migrated over to the public path.
+__all_legacy__ = ("_scope_matches",)
 
 
 class SQLiteJournalBackend(JournalBackend):

--- a/src/soul_protocol/engine/retrieval/__init__.py
+++ b/src/soul_protocol/engine/retrieval/__init__.py
@@ -1,0 +1,33 @@
+# __init__.py — Public API for the retrieval engine.
+# Created: feat/retrieval-router — Workstream C1 of Org Architecture RFC (#164).
+# Exports the router, credential broker, source adapter protocol, and the
+# exception hierarchy. MockAdapter is intentionally *not* re-exported —
+# it lives here as a test helper and callers should import it from the
+# submodule when they need it.
+
+from __future__ import annotations
+
+from .adapters import ProjectionAdapter, SourceAdapter
+from .broker import Credential, CredentialBroker, InMemoryCredentialBroker
+from .exceptions import (
+    CredentialExpiredError,
+    CredentialScopeError,
+    NoSourcesError,
+    RetrievalError,
+    SourceTimeoutError,
+)
+from .router import RetrievalRouter
+
+__all__ = [
+    "Credential",
+    "CredentialBroker",
+    "CredentialExpiredError",
+    "CredentialScopeError",
+    "InMemoryCredentialBroker",
+    "NoSourcesError",
+    "ProjectionAdapter",
+    "RetrievalError",
+    "RetrievalRouter",
+    "SourceAdapter",
+    "SourceTimeoutError",
+]

--- a/src/soul_protocol/engine/retrieval/adapters.py
+++ b/src/soul_protocol/engine/retrieval/adapters.py
@@ -1,0 +1,109 @@
+# adapters.py — SourceAdapter Protocol + two reference implementations.
+# Created: feat/retrieval-router — Workstream C1 of Org Architecture RFC (#164).
+# Adapters are intentionally sync for this slice — async wrapping is a
+# follow-up. The router runs adapters on a thread pool for the `parallel`
+# strategy, so sync-only callers (sqlite projections, requests-backed
+# federated sources) stay the simple case.
+#
+# Two concrete adapters live here:
+#   * `MockAdapter` — returns fixed candidates and tracks invocations. Pure
+#     test fixture; not exported from the retrieval __init__.
+#   * `ProjectionAdapter` — wraps a callable so soul memory, kb, and fabric
+#     can plug in without each building a class. Represents the
+#     "local rebuilt view" case.
+#
+# The concrete external-federation adapters (Drive, Salesforce, ...) are C2.
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
+
+from soul_protocol.spec.retrieval import RetrievalCandidate, RetrievalRequest
+
+from .broker import Credential
+
+
+@runtime_checkable
+class SourceAdapter(Protocol):
+    """Protocol implemented by every retrieval source adapter.
+
+    An adapter is registered under a `CandidateSource`. `query` receives
+    the full request (so it can read `query`, `limit`, `scopes`) plus an
+    optional credential — projection adapters ignore the credential,
+    DataRef adapters require it.
+
+    The `supports_dataref` class attribute advertises whether this adapter
+    can produce Zero-Copy candidates whose content is a DataRef payload.
+    """
+
+    supports_dataref: bool
+
+    def query(
+        self,
+        request: RetrievalRequest,
+        credential: Credential | None,
+    ) -> list[RetrievalCandidate]: ...
+
+
+class MockAdapter:
+    """Test adapter. Returns a fixed list, records every call.
+
+    Parameters:
+        candidates: What to return on `query`.
+        delay_s: If >0, sleeps that long before returning. Lets tests
+            exercise the router's per-source timeout path.
+        raises: If set, raises this exception instead of returning.
+    """
+
+    supports_dataref: bool = False
+
+    def __init__(
+        self,
+        candidates: list[RetrievalCandidate] | None = None,
+        *,
+        delay_s: float = 0.0,
+        raises: Exception | None = None,
+    ) -> None:
+        self._candidates = candidates or []
+        self._delay_s = delay_s
+        self._raises = raises
+        self.calls: list[tuple[RetrievalRequest, Credential | None]] = []
+
+    def query(
+        self,
+        request: RetrievalRequest,
+        credential: Credential | None,
+    ) -> list[RetrievalCandidate]:
+        self.calls.append((request, credential))
+        if self._delay_s > 0:
+            import time
+
+            time.sleep(self._delay_s)
+        if self._raises is not None:
+            raise self._raises
+        return list(self._candidates)
+
+
+class ProjectionAdapter:
+    """Adapter over a plain callable — the "local rebuilt view" shape.
+
+    Soul memory, kb, and fabric all live inside the same Paw OS instance
+    the router runs in. They don't need federation or credentials. A
+    callable that takes the request and returns candidates is enough.
+    """
+
+    supports_dataref: bool = False
+
+    def __init__(
+        self,
+        fn: Callable[[RetrievalRequest], list[RetrievalCandidate]],
+    ) -> None:
+        self._fn = fn
+
+    def query(
+        self,
+        request: RetrievalRequest,
+        credential: Credential | None,  # noqa: ARG002 — projection ignores creds
+    ) -> list[RetrievalCandidate]:
+        return list(self._fn(request))

--- a/src/soul_protocol/engine/retrieval/broker.py
+++ b/src/soul_protocol/engine/retrieval/broker.py
@@ -1,0 +1,174 @@
+# broker.py — CredentialBroker Protocol + in-memory implementation.
+# Created: feat/retrieval-router — Workstream C1 of Org Architecture RFC (#164).
+# The broker mints short-lived credentials for external sources (Drive,
+# Salesforce, Snowflake, ...). Scoped per DSP scope so a credential
+# acquired for `org:sales:*` cannot be reused by a requester operating in
+# `org:support:*`. Every acquire/use/expire emits a journal event when a
+# journal is attached — that's the audit trail Zero-Copy federation
+# depends on.
+#
+# `InMemoryCredentialBroker` is the reference impl. Production deployments
+# swap in a broker backed by the platform's real secret store; this class
+# is the one the tests and local dev use.
+#
+# The `Credential.token` is deliberately an opaque string. Real brokers
+# produce bearer tokens / OAuth access tokens / signed JWTs; the tests pass
+# a predictable string so equality assertions work. Callers that need a
+# structured token can wrap this class — `token` stays `str` here.
+
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime, timedelta
+from typing import Protocol
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+from soul_protocol.engine.journal import Journal
+from soul_protocol.spec.journal import Actor, EventEntry
+
+from .exceptions import CredentialExpiredError, CredentialScopeError
+
+DEFAULT_TTL_S: float = 300.0
+
+
+def _scopes_overlap(granted: list[str], requested: list[str]) -> bool:
+    """Prefix + wildcard match. A credential issued for any pattern in
+    `granted` is usable by a requester presenting any pattern in
+    `requested` when at least one requested pattern is covered by a
+    granted pattern.
+
+    Reuses the same colon-delimited, ``*``-as-segment-wildcard semantics as
+    `soul_protocol.engine.journal.sqlite._scope_matches`. Duplicated here
+    deliberately: the journal's helper matches *event scopes* against
+    *query patterns*, which isn't quite the shape we want (granted vs
+    requested). The semantics match, though, so if #162's scope spec lands
+    both sites swap to it.
+    """
+    for req in requested:
+        req_parts = req.split(":")
+        for grant in granted:
+            grant_parts = grant.split(":")
+            if len(grant_parts) != len(req_parts):
+                continue
+            if all(g == "*" or g == r for g, r in zip(grant_parts, req_parts)):
+                return True
+    return False
+
+
+class Credential(BaseModel):
+    """A short-lived token issued by the broker.
+
+    Fields:
+        id: UUID for revocation + journal linking.
+        source: The source this credential authorizes against
+            (``"drive"``, ``"salesforce"``, ...).
+        scopes: DSP scope patterns this credential is bound to.
+        token: Opaque bearer string. Real brokers populate with real
+            auth material; tests use a predictable value.
+        acquired_at: tz-aware UTC timestamp of issuance.
+        expires_at: tz-aware UTC timestamp after which `ensure_usable`
+            raises `CredentialExpiredError`.
+        last_used_at: Most recent `mark_used` timestamp, or `None`.
+    """
+
+    id: UUID = Field(default_factory=uuid4)
+    source: str = Field(min_length=1)
+    scopes: list[str] = Field(min_length=1)
+    token: str = Field(min_length=1)
+    acquired_at: datetime
+    expires_at: datetime
+    last_used_at: datetime | None = None
+
+    def is_expired(self, *, now: datetime | None = None) -> bool:
+        now = now or datetime.now(UTC)
+        return now >= self.expires_at
+
+
+class CredentialBroker(Protocol):
+    def acquire(self, source: str, scopes: list[str]) -> Credential: ...
+    def ensure_usable(self, credential: Credential, requester_scopes: list[str]) -> None: ...
+    def mark_used(self, credential: Credential) -> None: ...
+    def revoke(self, credential_id: UUID) -> None: ...
+
+
+class InMemoryCredentialBroker:
+    """Reference broker. Not persistent, not distributed — fine for
+    single-process Paw OS instances and tests."""
+
+    def __init__(
+        self,
+        *,
+        ttl_s: float = DEFAULT_TTL_S,
+        journal: Journal | None = None,
+        broker_actor: Actor | None = None,
+    ) -> None:
+        self._ttl_s = ttl_s
+        self._journal = journal
+        self._actor = broker_actor or Actor(kind="system", id="system:credential-broker")
+        self._active: dict[UUID, Credential] = {}
+
+    # -- lifecycle --------------------------------------------------------
+
+    def acquire(self, source: str, scopes: list[str]) -> Credential:
+        now = datetime.now(UTC)
+        cred = Credential(
+            source=source,
+            scopes=list(scopes),
+            token=secrets.token_urlsafe(16),
+            acquired_at=now,
+            expires_at=now + timedelta(seconds=self._ttl_s),
+        )
+        self._active[cred.id] = cred
+        self._emit("credential.acquired", cred)
+        return cred
+
+    def ensure_usable(self, credential: Credential, requester_scopes: list[str]) -> None:
+        if credential.is_expired():
+            # Surface through the journal once, then forget the credential.
+            if credential.id in self._active:
+                self._emit("credential.expired", credential)
+                self._active.pop(credential.id, None)
+            raise CredentialExpiredError(
+                f"credential {credential.id} for {credential.source} expired at "
+                f"{credential.expires_at.isoformat()}"
+            )
+        if not _scopes_overlap(credential.scopes, requester_scopes):
+            raise CredentialScopeError(
+                f"credential {credential.id} scoped to {credential.scopes} "
+                f"cannot be used by requester with scopes {requester_scopes}"
+            )
+
+    def mark_used(self, credential: Credential) -> None:
+        credential.last_used_at = datetime.now(UTC)
+        self._emit("credential.used", credential)
+
+    def revoke(self, credential_id: UUID) -> None:
+        cred = self._active.pop(credential_id, None)
+        if cred is not None:
+            self._emit("credential.expired", cred)
+
+    # -- journal glue -----------------------------------------------------
+
+    def _emit(self, action: str, cred: Credential) -> None:
+        if self._journal is None:
+            return
+        entry = EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=self._actor,
+            action=action,
+            scope=list(cred.scopes),
+            payload={
+                "credential_id": str(cred.id),
+                "source": cred.source,
+                "expires_at": cred.expires_at.isoformat(),
+            },
+        )
+        try:
+            self._journal.append(entry)
+        except Exception:
+            # Auditing should never crash the broker. Log surface is #161's
+            # concern; we just swallow here for v0.
+            pass

--- a/src/soul_protocol/engine/retrieval/broker.py
+++ b/src/soul_protocol/engine/retrieval/broker.py
@@ -1,4 +1,12 @@
 # broker.py — CredentialBroker Protocol + in-memory implementation.
+# Updated: feat/retrieval-router — credential lifecycle journal emits are now
+# fail-closed. If a journal is attached and the append raises, the broker
+# lifts the exception out to the caller instead of silently issuing / using /
+# revoking a credential that never made it into the audit trail. The router's
+# retrieval.query emit stays fire-and-forget (query log, not auth) with a
+# comment explaining the asymmetric policy. Also drop the local
+# `_scopes_overlap` duplicate and import the public `scopes_overlap` helper
+# from `soul_protocol.engine.journal`.
 # Created: feat/retrieval-router — Workstream C1 of Org Architecture RFC (#164).
 # The broker mints short-lived credentials for external sources (Drive,
 # Salesforce, Snowflake, ...). Scoped per DSP scope so a credential
@@ -25,36 +33,18 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
 
-from soul_protocol.engine.journal import Journal
+from soul_protocol.engine.journal import Journal, scopes_overlap
 from soul_protocol.spec.journal import Actor, EventEntry
 
 from .exceptions import CredentialExpiredError, CredentialScopeError
 
 DEFAULT_TTL_S: float = 300.0
 
-
-def _scopes_overlap(granted: list[str], requested: list[str]) -> bool:
-    """Prefix + wildcard match. A credential issued for any pattern in
-    `granted` is usable by a requester presenting any pattern in
-    `requested` when at least one requested pattern is covered by a
-    granted pattern.
-
-    Reuses the same colon-delimited, ``*``-as-segment-wildcard semantics as
-    `soul_protocol.engine.journal.sqlite._scope_matches`. Duplicated here
-    deliberately: the journal's helper matches *event scopes* against
-    *query patterns*, which isn't quite the shape we want (granted vs
-    requested). The semantics match, though, so if #162's scope spec lands
-    both sites swap to it.
-    """
-    for req in requested:
-        req_parts = req.split(":")
-        for grant in granted:
-            grant_parts = grant.split(":")
-            if len(grant_parts) != len(req_parts):
-                continue
-            if all(g == "*" or g == r for g, r in zip(grant_parts, req_parts)):
-                return True
-    return False
+# Back-compat alias for tests / callers that imported the private helper from
+# this module before it moved into the public journal module. The semantics
+# are the same; see `soul_protocol.engine.journal.scope.scopes_overlap` for
+# the pinned policy (wildcard-grant vs specific-requester AND vice versa).
+_scopes_overlap = scopes_overlap
 
 
 class Credential(BaseModel):
@@ -120,8 +110,11 @@ class InMemoryCredentialBroker:
             acquired_at=now,
             expires_at=now + timedelta(seconds=self._ttl_s),
         )
-        self._active[cred.id] = cred
+        # Emit FIRST. If the audit append fails under the fail-closed policy,
+        # the credential never enters `_active` and the caller gets the
+        # exception — no orphan credentials hanging around post-failure.
         self._emit("credential.acquired", cred)
+        self._active[cred.id] = cred
         return cred
 
     def ensure_usable(self, credential: Credential, requester_scopes: list[str]) -> None:
@@ -134,7 +127,7 @@ class InMemoryCredentialBroker:
                 f"credential {credential.id} for {credential.source} expired at "
                 f"{credential.expires_at.isoformat()}"
             )
-        if not _scopes_overlap(credential.scopes, requester_scopes):
+        if not scopes_overlap(credential.scopes, requester_scopes):
             raise CredentialScopeError(
                 f"credential {credential.id} scoped to {credential.scopes} "
                 f"cannot be used by requester with scopes {requester_scopes}"
@@ -152,6 +145,18 @@ class InMemoryCredentialBroker:
     # -- journal glue -----------------------------------------------------
 
     def _emit(self, action: str, cred: Credential) -> None:
+        """Append a credential-lifecycle event. Fail-closed by design.
+
+        If no journal is configured the caller has explicitly opted into
+        fire-and-forget operation (tests, ephemeral scripts). With a journal
+        attached, a failed append propagates: audit integrity outranks broker
+        availability on the credential path, and silently issuing /
+        revoking a credential whose lifecycle never made it into the log is
+        worse than surfacing the error to the caller.
+
+        Contrast with the router's `retrieval.query` emit, which stays
+        fire-and-forget — that's a query log, not an auth trail.
+        """
         if self._journal is None:
             return
         entry = EventEntry(
@@ -166,9 +171,4 @@ class InMemoryCredentialBroker:
                 "expires_at": cred.expires_at.isoformat(),
             },
         )
-        try:
-            self._journal.append(entry)
-        except Exception:
-            # Auditing should never crash the broker. Log surface is #161's
-            # concern; we just swallow here for v0.
-            pass
+        self._journal.append(entry)

--- a/src/soul_protocol/engine/retrieval/exceptions.py
+++ b/src/soul_protocol/engine/retrieval/exceptions.py
@@ -1,0 +1,27 @@
+# exceptions.py — Retrieval router + credential broker error hierarchy.
+# Created: feat/retrieval-router — Workstream C1 of Org Architecture RFC (#164).
+# Kept tiny on purpose — callers should be able to distinguish "no usable
+# source" from "credential misuse" without inspecting messages.
+
+from __future__ import annotations
+
+
+class RetrievalError(Exception):
+    """Base class for all retrieval-layer errors."""
+
+
+class NoSourcesError(RetrievalError):
+    """No registered source matched the request's scopes or explicit list."""
+
+
+class SourceTimeoutError(RetrievalError):
+    """A source adapter did not return within the per-source timeout."""
+
+
+class CredentialScopeError(RetrievalError):
+    """A credential was used by a requester whose scopes do not overlap
+    the scopes the credential was issued for."""
+
+
+class CredentialExpiredError(RetrievalError):
+    """A credential was used after its TTL elapsed."""

--- a/src/soul_protocol/engine/retrieval/router.py
+++ b/src/soul_protocol/engine/retrieval/router.py
@@ -27,8 +27,7 @@ from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeou
 from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
-from soul_protocol.engine.journal import Journal
-from soul_protocol.engine.journal.sqlite import _scope_matches
+from soul_protocol.engine.journal import Journal, scope_matches
 from soul_protocol.spec.journal import EventEntry
 from soul_protocol.spec.retrieval import (
     CandidateSource,
@@ -109,13 +108,13 @@ class RetrievalRouter:
         for name, (source, adapter) in self._sources.items():
             if request.sources is not None and name not in request.sources:
                 continue
-            # _scope_matches(event_scopes, query_patterns): treats arg 2 as
+            # scope_matches(event_scopes, query_patterns): treats arg 2 as
             # the pattern set. We want bidirectional overlap — a source
             # registered for `org:sales:*` should match a request scoped to
             # `org:sales:leads` AND vice versa.
             if not (
-                _scope_matches(request.scopes, source.scopes)
-                or _scope_matches(source.scopes, request.scopes)
+                scope_matches(request.scopes, source.scopes)
+                or scope_matches(source.scopes, request.scopes)
             ):
                 continue
             selected.append((source, adapter))
@@ -238,7 +237,12 @@ class RetrievalRouter:
         try:
             self._journal.append(entry)
         except Exception:
-            pass  # audit path must not break retrieval
+            # Fire-and-forget. The retrieval.query event is a query log, not
+            # an auth trail: losing it is an observability regression, not a
+            # security one. Credential lifecycle events on the broker are
+            # fail-closed precisely because they ARE the auth trail. The
+            # asymmetry is deliberate — don't unify these two policies.
+            pass
 
 
 # -- helpers --------------------------------------------------------------

--- a/src/soul_protocol/engine/retrieval/router.py
+++ b/src/soul_protocol/engine/retrieval/router.py
@@ -1,0 +1,276 @@
+# router.py — RetrievalRouter: scope-filtered, strategy-aware dispatch.
+# Created: feat/retrieval-router — Workstream C1 of Org Architecture RFC (#164).
+# The router is the single entry point every agent uses for retrieval. It
+# knows nothing about soul memory vs Salesforce — it just maps registered
+# sources to adapters, filters by scope, runs the strategy, and hands back
+# merged candidates.
+#
+# Strategies:
+#   * `first`      — try sources in registration order, return first that
+#                    yields a non-empty list.
+#   * `parallel`   — fan out on a ThreadPoolExecutor, gather all, merge
+#                    by score (None scores sink).
+#   * `sequential` — try in order, accumulate until `limit` is reached.
+#
+# Scope enforcement: a source is a candidate iff its registered scopes
+# overlap the request's scopes via `_scope_matches` from the journal —
+# deliberate import, don't re-implement.
+#
+# Journal integration: if a Journal is attached, every dispatch writes a
+# `retrieval.query` event tagged with the request's scope + actor, and
+# whose payload carries the query text + the sources actually queried.
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeout
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from soul_protocol.engine.journal import Journal
+from soul_protocol.engine.journal.sqlite import _scope_matches
+from soul_protocol.spec.journal import EventEntry
+from soul_protocol.spec.retrieval import (
+    CandidateSource,
+    RetrievalCandidate,
+    RetrievalRequest,
+    RetrievalResult,
+)
+
+from .adapters import SourceAdapter
+from .broker import CredentialBroker
+from .exceptions import NoSourcesError, SourceTimeoutError
+
+
+class RetrievalRouter:
+    """Scope-filtered, strategy-aware dispatcher over registered sources.
+
+    Usage:
+        router = RetrievalRouter(journal=journal, broker=broker)
+        router.register_source(CandidateSource(...), MyAdapter())
+        result = router.dispatch(RetrievalRequest(...))
+    """
+
+    def __init__(
+        self,
+        *,
+        journal: Journal | None = None,
+        broker: CredentialBroker | None = None,
+    ) -> None:
+        self._journal = journal
+        self._broker = broker
+        self._sources: dict[str, tuple[CandidateSource, SourceAdapter]] = {}
+
+    # -- registration -----------------------------------------------------
+
+    def register_source(self, source: CandidateSource, adapter: SourceAdapter) -> None:
+        self._sources[source.name] = (source, adapter)
+
+    # -- dispatch ---------------------------------------------------------
+
+    def dispatch(self, request: RetrievalRequest) -> RetrievalResult:
+        request_id = uuid4()
+        started = time.perf_counter()
+
+        selected = self._select_sources(request)
+        if not selected:
+            raise NoSourcesError(
+                f"no registered source matches scopes {request.scopes} "
+                f"(sources filter: {request.sources})"
+            )
+
+        if request.strategy == "first":
+            candidates, queried, failed = self._run_first(request, selected)
+        elif request.strategy == "sequential":
+            candidates, queried, failed = self._run_sequential(request, selected)
+        else:
+            candidates, queried, failed = self._run_parallel(request, selected)
+
+        merged = _merge_and_truncate(candidates, request.limit)
+        total_ms = (time.perf_counter() - started) * 1000.0
+
+        result = RetrievalResult(
+            request_id=request_id,
+            candidates=merged,
+            sources_queried=queried,
+            sources_failed=failed,
+            total_latency_ms=total_ms,
+            trace=None,  # TODO: slot in RetrievalTrace once #161 lands.
+        )
+        self._emit_query_event(request, result)
+        return result
+
+    # -- internals --------------------------------------------------------
+
+    def _select_sources(
+        self, request: RetrievalRequest
+    ) -> list[tuple[CandidateSource, SourceAdapter]]:
+        selected: list[tuple[CandidateSource, SourceAdapter]] = []
+        for name, (source, adapter) in self._sources.items():
+            if request.sources is not None and name not in request.sources:
+                continue
+            # _scope_matches(event_scopes, query_patterns): treats arg 2 as
+            # the pattern set. We want bidirectional overlap — a source
+            # registered for `org:sales:*` should match a request scoped to
+            # `org:sales:leads` AND vice versa.
+            if not (
+                _scope_matches(request.scopes, source.scopes)
+                or _scope_matches(source.scopes, request.scopes)
+            ):
+                continue
+            selected.append((source, adapter))
+        return selected
+
+    def _call_adapter(
+        self,
+        request: RetrievalRequest,
+        source: CandidateSource,
+        adapter: SourceAdapter,
+    ) -> list[RetrievalCandidate]:
+        credential = None
+        if source.kind == "dataref" and self._broker is not None:
+            credential = self._broker.acquire(source.name, request.scopes)
+            self._broker.ensure_usable(credential, request.scopes)
+            self._broker.mark_used(credential)
+        return adapter.query(request, credential)
+
+    def _run_first(
+        self,
+        request: RetrievalRequest,
+        selected: list[tuple[CandidateSource, SourceAdapter]],
+    ) -> tuple[list[RetrievalCandidate], list[str], list[tuple[str, str]]]:
+        queried: list[str] = []
+        failed: list[tuple[str, str]] = []
+        for source, adapter in selected:
+            queried.append(source.name)
+            try:
+                out = _with_timeout(
+                    lambda s=source, a=adapter: self._call_adapter(request, s, a),
+                    request.timeout_s,
+                    source.name,
+                )
+            except SourceTimeoutError as e:
+                failed.append((source.name, str(e)))
+                continue
+            except Exception as e:  # pragma: no cover - defensive
+                failed.append((source.name, f"{type(e).__name__}: {e}"))
+                continue
+            if out:
+                return out, queried, failed
+        return [], queried, failed
+
+    def _run_sequential(
+        self,
+        request: RetrievalRequest,
+        selected: list[tuple[CandidateSource, SourceAdapter]],
+    ) -> tuple[list[RetrievalCandidate], list[str], list[tuple[str, str]]]:
+        collected: list[RetrievalCandidate] = []
+        queried: list[str] = []
+        failed: list[tuple[str, str]] = []
+        for source, adapter in selected:
+            queried.append(source.name)
+            try:
+                out = _with_timeout(
+                    lambda s=source, a=adapter: self._call_adapter(request, s, a),
+                    request.timeout_s,
+                    source.name,
+                )
+            except SourceTimeoutError as e:
+                failed.append((source.name, str(e)))
+                continue
+            except Exception as e:
+                failed.append((source.name, f"{type(e).__name__}: {e}"))
+                continue
+            collected.extend(out)
+            if len(collected) >= request.limit:
+                break
+        return collected, queried, failed
+
+    def _run_parallel(
+        self,
+        request: RetrievalRequest,
+        selected: list[tuple[CandidateSource, SourceAdapter]],
+    ) -> tuple[list[RetrievalCandidate], list[str], list[tuple[str, str]]]:
+        queried = [s.name for s, _ in selected]
+        failed: list[tuple[str, str]] = []
+        collected: list[RetrievalCandidate] = []
+        max_workers = max(1, len(selected))
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            future_to_name = {
+                pool.submit(self._call_adapter, request, source, adapter): source.name
+                for source, adapter in selected
+            }
+            for future, name in future_to_name.items():
+                try:
+                    out = future.result(timeout=request.timeout_s)
+                except FuturesTimeout:
+                    failed.append((name, f"source {name} timed out after {request.timeout_s}s"))
+                    future.cancel()
+                except Exception as e:
+                    failed.append((name, f"{type(e).__name__}: {e}"))
+                else:
+                    collected.extend(out)
+        return collected, queried, failed
+
+    def _emit_query_event(
+        self, request: RetrievalRequest, result: RetrievalResult
+    ) -> None:
+        if self._journal is None:
+            return
+        entry = EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=request.actor,
+            action="retrieval.query",
+            scope=list(request.scopes),
+            correlation_id=request.correlation_id,
+            payload={
+                "request_id": str(result.request_id),
+                "query": request.query,
+                "strategy": request.strategy,
+                "sources_queried": result.sources_queried,
+                "sources_failed": [
+                    {"source": s, "reason": r} for s, r in result.sources_failed
+                ],
+                "candidate_count": len(result.candidates),
+            },
+        )
+        try:
+            self._journal.append(entry)
+        except Exception:
+            pass  # audit path must not break retrieval
+
+
+# -- helpers --------------------------------------------------------------
+
+
+def _with_timeout(fn, timeout_s: float, source_name: str) -> list[RetrievalCandidate]:
+    """Run `fn` on a helper thread with a wall-clock deadline.
+
+    Used by the `first` and `sequential` strategies — `parallel` uses its
+    own thread pool + futures timeout. Kept simple on purpose: one helper
+    thread per call, daemonized so a wedged adapter never blocks shutdown.
+    """
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(fn)
+        try:
+            return future.result(timeout=timeout_s)
+        except FuturesTimeout as e:
+            future.cancel()
+            raise SourceTimeoutError(
+                f"source {source_name} timed out after {timeout_s}s"
+            ) from e
+
+
+def _merge_and_truncate(
+    candidates: list[RetrievalCandidate], limit: int
+) -> list[RetrievalCandidate]:
+    """Sort by score descending (None sinks), then truncate."""
+
+    def key(c: RetrievalCandidate) -> tuple[int, float]:
+        if c.score is None:
+            return (1, 0.0)
+        return (0, -c.score)
+
+    ordered = sorted(candidates, key=key)
+    return ordered[:limit]

--- a/src/soul_protocol/spec/retrieval.py
+++ b/src/soul_protocol/spec/retrieval.py
@@ -1,0 +1,124 @@
+# retrieval.py — Retrieval router request/result models.
+# Created: feat/retrieval-router — Workstream C1 of Org Architecture RFC (#164).
+# Describes the request envelope, candidate-source registration, and result
+# shape the `RetrievalRouter` uses. Source-specific payload stays opaque so
+# the router doesn't need to know about Drive, Salesforce, soul memory, etc.
+# Zero-Copy federation is expressed by `CandidateSource.kind == "dataref"`
+# sources — their adapters return candidates whose payload points at live
+# external data rather than copying it.
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+
+from soul_protocol.spec.journal import Actor
+
+
+class CandidateSource(BaseModel):
+    """One source the retrieval router can dispatch to.
+
+    Fields:
+        name: Stable source identifier — ``"soul_memory"``, ``"kb_articles"``,
+            ``"fabric_objects"``, ``"drive"``, ``"salesforce"``, ...
+        kind: ``"projection"`` for a local rebuilt view (soul memory, kb,
+            fabric), ``"dataref"`` for an external federated source whose
+            candidates reference live data via a DataRef.
+        scopes: DSP scope patterns this source is registered under. A
+            request's scopes must overlap (prefix+wildcard match) for the
+            source to be considered.
+        adapter_ref: Module path or registered name of the adapter that
+            handles this source. Free-form — the router resolves through
+            its own `register_source` table.
+    """
+
+    name: str = Field(min_length=1)
+    kind: Literal["projection", "dataref"]
+    scopes: list[str] = Field(min_length=1)
+    adapter_ref: str = Field(min_length=1)
+
+
+class RetrievalRequest(BaseModel):
+    """Input to `RetrievalRouter.dispatch`.
+
+    Fields:
+        query: Free-text or source-native query. Opaque to the router.
+        actor: Who is asking — recorded on the emitted `retrieval.query`
+            journal event.
+        scopes: Caller's current scope context. The router filters
+            registered sources down to those whose scopes overlap.
+        correlation_id: Optional flow/session id, recorded on the journal
+            event so a retrieval can be traced back to the work that asked.
+        sources: Optional explicit allowlist by source name. ``None`` means
+            "use every registered source whose scope overlaps".
+        limit: Maximum candidates to return after merging.
+        strategy: ``first`` — try sources in order, return first non-empty.
+            ``parallel`` — dispatch all in threads, merge by score.
+            ``sequential`` — try in order, accumulate up to `limit`.
+        timeout_s: Per-source timeout in wall-clock seconds.
+    """
+
+    query: str
+    actor: Actor
+    scopes: list[str] = Field(min_length=1)
+    correlation_id: UUID | None = None
+    sources: list[str] | None = None
+    limit: int = 20
+    strategy: Literal["first", "parallel", "sequential"] = "parallel"
+    timeout_s: float = 10.0
+
+
+class RetrievalCandidate(BaseModel):
+    """A single result returned by a source adapter.
+
+    Fields:
+        source: The source name this candidate came from.
+        content: Source-specific payload. The router never inspects it.
+            Zero-Copy sources put a DataRef-shaped dict here; projection
+            sources put their own view payload.
+        score: Optional source-provided relevance score. Used for merging
+            in the `parallel` strategy; `None` sinks to the back.
+        as_of: Timezone-aware UTC timestamp recording when this candidate
+            was resolved — live resolution vs cache read.
+        cached: ``True`` if the adapter served this from cache, ``False``
+            if it resolved live.
+    """
+
+    source: str = Field(min_length=1)
+    content: dict[str, Any]
+    score: float | None = None
+    as_of: datetime
+    cached: bool = False
+
+    @field_validator("as_of")
+    @classmethod
+    def _as_of_must_be_aware(cls, v: datetime) -> datetime:
+        if v.tzinfo is None or v.tzinfo.utcoffset(v) is None:
+            raise ValueError("RetrievalCandidate.as_of must be timezone-aware (UTC)")
+        return v
+
+
+class RetrievalResult(BaseModel):
+    """Output from `RetrievalRouter.dispatch`.
+
+    Fields:
+        request_id: UUID assigned by the router for correlation.
+        candidates: Merged candidates, truncated to `limit`.
+        sources_queried: Names of sources actually invoked.
+        sources_failed: ``(source_name, failure_reason)`` tuples for any
+            source that timed out, raised, or refused (scope mismatch).
+        total_latency_ms: End-to-end wall-clock time in the router.
+        trace: Placeholder for the decision trace from #161. Until that
+            module lands this stays ``None``.
+    """
+
+    request_id: UUID
+    candidates: list[RetrievalCandidate]
+    sources_queried: list[str]
+    sources_failed: list[tuple[str, str]]
+    total_latency_ms: float
+    # TODO: once #161 ships, replace `Any` with spec.trace.RetrievalTrace.
+    trace: Any | None = None

--- a/tests/test_engine/test_retrieval.py
+++ b/tests/test_engine/test_retrieval.py
@@ -1,4 +1,9 @@
 # test_retrieval.py — Retrieval router + credential broker test suite.
+# Updated: feat/retrieval-router — add tests for broker fail-closed audit
+# emission (journal raising on append -> acquire propagates the error),
+# explicit fire-and-forget path when no journal is attached, and a pinned
+# scope-overlap policy: wildcard-grant vs specific-requester AND specific-
+# grant vs wildcard-requester both match; disjoint scopes don't.
 # Created: feat/retrieval-router — Workstream C1 of Org Architecture RFC (#164).
 # Covers: scope filtering, parallel/first/sequential strategies, per-source
 # timeout, journal event emission on dispatch, broker acquire/use/expire
@@ -320,6 +325,89 @@ def test_projection_adapter_calls_underlying_fn() -> None:
     out = adapter.query(_request(), credential=None)
     assert [c.source for c in out] == ["proj"]
     assert len(calls) == 1
+
+
+# -- broker: fail-closed audit emission -----------------------------------
+
+
+class _FailingJournal:
+    """Stub journal whose append always raises. Lets us assert fail-closed
+    behavior without needing a real SQLite error path."""
+
+    def __init__(self) -> None:
+        self.appends: int = 0
+
+    def append(self, _entry) -> None:
+        self.appends += 1
+        raise RuntimeError("simulated journal-down condition")
+
+
+def test_broker_acquire_fails_closed_when_journal_append_raises() -> None:
+    """If the journal is configured and append raises, acquire propagates
+    the error rather than silently issuing a credential whose acquisition
+    never made it into the audit trail. The credential must NOT remain
+    trackable by the broker either — we don't hand back an orphaned token.
+    """
+    bad_journal = _FailingJournal()
+    broker = InMemoryCredentialBroker(journal=bad_journal)  # type: ignore[arg-type]
+    with pytest.raises(RuntimeError, match="simulated journal-down"):
+        broker.acquire("drive", ["org:sales:leads"])
+    # The append was attempted exactly once.
+    assert bad_journal.appends == 1
+
+
+def test_broker_without_journal_is_fire_and_forget() -> None:
+    """No journal configured = explicit opt-out. acquire/use/revoke all
+    succeed silently. This is the path tests and ephemeral scripts use."""
+    broker = InMemoryCredentialBroker()  # journal=None
+    cred = broker.acquire("drive", ["org:sales:leads"])
+    broker.mark_used(cred)
+    broker.revoke(cred.id)
+
+
+# -- broker: scope overlap policy pin -------------------------------------
+
+
+def test_scopes_overlap_wildcard_grant_matches_specific_requester() -> None:
+    """A credential issued for `org:sales:*` is usable by a requester
+    operating at `org:sales:leads`. Pinning this direction so a future
+    refactor can't break fanout."""
+    from soul_protocol.engine.journal import scopes_overlap
+
+    assert scopes_overlap(["org:sales:*"], ["org:sales:leads"])
+
+
+def test_scopes_overlap_specific_grant_matches_wildcard_requester() -> None:
+    """A credential issued for a specific scope `org:sales:leads` is
+    usable by a requester presenting `org:sales:*` — the requester is
+    asserting it operates anywhere in the subtree, and a specific
+    credential covers a specific point in that subtree. Pinning this
+    direction so a future tightening can't break routers that fan out
+    over a broad scope."""
+    from soul_protocol.engine.journal import scopes_overlap
+
+    assert scopes_overlap(["org:sales:leads"], ["org:sales:*"])
+
+
+def test_scopes_overlap_disjoint_scopes_do_not_match() -> None:
+    """A credential for one subtree must not be usable in another."""
+    from soul_protocol.engine.journal import scopes_overlap
+
+    assert not scopes_overlap(["org:sales:*"], ["org:support:*"])
+    assert not scopes_overlap(["org:sales:leads"], ["org:support:tickets"])
+
+
+def test_broker_enforces_scope_asymmetry_on_ensure_usable() -> None:
+    """Integration-level pin: the broker honors the same asymmetric
+    policy. A credential granted broadly is usable by a specific
+    requester, and vice versa — both should succeed."""
+    broker = InMemoryCredentialBroker(ttl_s=60)
+
+    cred_wide = broker.acquire("drive", ["org:sales:*"])
+    broker.ensure_usable(cred_wide, ["org:sales:leads"])
+
+    cred_narrow = broker.acquire("drive", ["org:sales:leads"])
+    broker.ensure_usable(cred_narrow, ["org:sales:*"])
 
 
 def test_dataref_source_triggers_broker(journal: Journal) -> None:

--- a/tests/test_engine/test_retrieval.py
+++ b/tests/test_engine/test_retrieval.py
@@ -1,0 +1,346 @@
+# test_retrieval.py — Retrieval router + credential broker test suite.
+# Created: feat/retrieval-router — Workstream C1 of Org Architecture RFC (#164).
+# Covers: scope filtering, parallel/first/sequential strategies, per-source
+# timeout, journal event emission on dispatch, broker acquire/use/expire
+# flow + scope enforcement, and Protocol conformance for MockAdapter and
+# ProjectionAdapter.
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from soul_protocol.engine.journal import Journal, open_journal
+from soul_protocol.engine.retrieval import (
+    CredentialExpiredError,
+    CredentialScopeError,
+    InMemoryCredentialBroker,
+    NoSourcesError,
+    ProjectionAdapter,
+    RetrievalRouter,
+    SourceAdapter,
+)
+from soul_protocol.engine.retrieval.adapters import MockAdapter
+from soul_protocol.spec.journal import Actor
+from soul_protocol.spec.retrieval import (
+    CandidateSource,
+    RetrievalCandidate,
+    RetrievalRequest,
+)
+
+
+# -- fixtures -------------------------------------------------------------
+
+
+def _actor() -> Actor:
+    return Actor(kind="agent", id="did:soul:test-agent", scope_context=["org:sales:leads"])
+
+
+def _candidate(source: str, score: float | None = 0.9) -> RetrievalCandidate:
+    return RetrievalCandidate(
+        source=source,
+        content={"hit": source},
+        score=score,
+        as_of=datetime.now(UTC),
+        cached=False,
+    )
+
+
+def _request(**overrides) -> RetrievalRequest:
+    defaults = dict(
+        query="who bought the thing",
+        actor=_actor(),
+        scopes=["org:sales:leads"],
+        strategy="parallel",
+        timeout_s=2.0,
+    )
+    defaults.update(overrides)
+    return RetrievalRequest(**defaults)
+
+
+@pytest.fixture
+def journal(tmp_path: Path) -> Journal:
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+# -- router: strategies ---------------------------------------------------
+
+
+def test_parallel_merges_candidates_from_two_sources() -> None:
+    router = RetrievalRouter()
+    router.register_source(
+        CandidateSource(
+            name="soul_memory",
+            kind="projection",
+            scopes=["org:sales:*"],
+            adapter_ref="mock",
+        ),
+        MockAdapter(candidates=[_candidate("soul_memory", score=0.9)]),
+    )
+    router.register_source(
+        CandidateSource(
+            name="kb_articles",
+            kind="projection",
+            scopes=["org:sales:*"],
+            adapter_ref="mock",
+        ),
+        MockAdapter(candidates=[_candidate("kb_articles", score=0.7)]),
+    )
+
+    result = router.dispatch(_request())
+
+    assert {c.source for c in result.candidates} == {"soul_memory", "kb_articles"}
+    assert set(result.sources_queried) == {"soul_memory", "kb_articles"}
+    # Higher score sorts first.
+    assert result.candidates[0].source == "soul_memory"
+    assert result.sources_failed == []
+
+
+def test_first_strategy_returns_first_non_empty() -> None:
+    router = RetrievalRouter()
+    first_adapter = MockAdapter(candidates=[])
+    second_adapter = MockAdapter(candidates=[_candidate("kb_articles", 0.5)])
+    third_adapter = MockAdapter(candidates=[_candidate("fabric", 0.9)])
+    for name, adapter in [
+        ("soul_memory", first_adapter),
+        ("kb_articles", second_adapter),
+        ("fabric", third_adapter),
+    ]:
+        router.register_source(
+            CandidateSource(
+                name=name, kind="projection", scopes=["org:sales:*"], adapter_ref="mock"
+            ),
+            adapter,
+        )
+
+    result = router.dispatch(_request(strategy="first"))
+
+    # Should stop at kb_articles and never call fabric.
+    assert [c.source for c in result.candidates] == ["kb_articles"]
+    assert result.sources_queried == ["soul_memory", "kb_articles"]
+    assert third_adapter.calls == []
+
+
+def test_sequential_accumulates_up_to_limit() -> None:
+    router = RetrievalRouter()
+    router.register_source(
+        CandidateSource(name="a", kind="projection", scopes=["org:sales:*"], adapter_ref="mock"),
+        MockAdapter(candidates=[_candidate("a", 0.9), _candidate("a", 0.8)]),
+    )
+    never_called = MockAdapter(candidates=[_candidate("b", 0.7)])
+    router.register_source(
+        CandidateSource(name="b", kind="projection", scopes=["org:sales:*"], adapter_ref="mock"),
+        never_called,
+    )
+
+    result = router.dispatch(_request(strategy="sequential", limit=2))
+    assert len(result.candidates) == 2
+    assert never_called.calls == []
+
+
+def test_scope_filter_skips_unrelated_source() -> None:
+    router = RetrievalRouter()
+    allowed = MockAdapter(candidates=[_candidate("sales_src", 0.9)])
+    forbidden = MockAdapter(candidates=[_candidate("support_src", 0.9)])
+    router.register_source(
+        CandidateSource(
+            name="sales_src", kind="projection", scopes=["org:sales:*"], adapter_ref="mock"
+        ),
+        allowed,
+    )
+    router.register_source(
+        CandidateSource(
+            name="support_src",
+            kind="projection",
+            scopes=["org:support:*"],
+            adapter_ref="mock",
+        ),
+        forbidden,
+    )
+
+    result = router.dispatch(_request(scopes=["org:sales:leads"]))
+
+    assert result.sources_queried == ["sales_src"]
+    assert forbidden.calls == []
+
+
+def test_no_sources_raises() -> None:
+    router = RetrievalRouter()
+    router.register_source(
+        CandidateSource(
+            name="ops", kind="projection", scopes=["org:ops:*"], adapter_ref="mock"
+        ),
+        MockAdapter(),
+    )
+    with pytest.raises(NoSourcesError):
+        router.dispatch(_request(scopes=["org:sales:leads"]))
+
+
+def test_parallel_source_timeout_is_reported() -> None:
+    router = RetrievalRouter()
+    fast = MockAdapter(candidates=[_candidate("fast", 0.9)])
+    slow = MockAdapter(candidates=[_candidate("slow", 0.9)], delay_s=1.0)
+    router.register_source(
+        CandidateSource(name="fast", kind="projection", scopes=["org:sales:*"], adapter_ref="m"),
+        fast,
+    )
+    router.register_source(
+        CandidateSource(name="slow", kind="projection", scopes=["org:sales:*"], adapter_ref="m"),
+        slow,
+    )
+
+    result = router.dispatch(_request(strategy="parallel", timeout_s=0.2))
+
+    assert any(name == "slow" for name, _ in result.sources_failed)
+    assert {c.source for c in result.candidates} == {"fast"}
+
+
+def test_first_strategy_timeout_falls_through() -> None:
+    router = RetrievalRouter()
+    router.register_source(
+        CandidateSource(name="slow", kind="projection", scopes=["org:sales:*"], adapter_ref="m"),
+        MockAdapter(candidates=[_candidate("slow")], delay_s=1.0),
+    )
+    router.register_source(
+        CandidateSource(name="fast", kind="projection", scopes=["org:sales:*"], adapter_ref="m"),
+        MockAdapter(candidates=[_candidate("fast")]),
+    )
+
+    result = router.dispatch(_request(strategy="first", timeout_s=0.2))
+    assert [c.source for c in result.candidates] == ["fast"]
+    assert any(name == "slow" for name, _ in result.sources_failed)
+
+
+# -- router: journal emission --------------------------------------------
+
+
+def test_dispatch_emits_retrieval_query_event(journal: Journal) -> None:
+    router = RetrievalRouter(journal=journal)
+    router.register_source(
+        CandidateSource(
+            name="soul_memory",
+            kind="projection",
+            scopes=["org:sales:*"],
+            adapter_ref="mock",
+        ),
+        MockAdapter(candidates=[_candidate("soul_memory", 0.9)]),
+    )
+    correlation = uuid4()
+    router.dispatch(_request(correlation_id=correlation))
+
+    events = journal.query(action="retrieval.query")
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.action == "retrieval.query"
+    assert ev.actor.id == "did:soul:test-agent"
+    assert ev.scope == ["org:sales:leads"]
+    assert ev.correlation_id == correlation
+    assert isinstance(ev.payload, dict)
+    assert ev.payload["query"] == "who bought the thing"
+    assert ev.payload["sources_queried"] == ["soul_memory"]
+
+
+# -- broker ---------------------------------------------------------------
+
+
+def test_broker_acquire_returns_scoped_credential() -> None:
+    broker = InMemoryCredentialBroker(ttl_s=60)
+    cred = broker.acquire("drive", ["org:sales:leads"])
+    assert cred.source == "drive"
+    assert cred.scopes == ["org:sales:leads"]
+    assert cred.token
+    assert cred.expires_at > cred.acquired_at
+    assert (cred.expires_at - cred.acquired_at).total_seconds() == pytest.approx(60, abs=1)
+
+
+def test_broker_refuses_credential_used_by_wrong_scope() -> None:
+    broker = InMemoryCredentialBroker()
+    cred = broker.acquire("drive", ["org:sales:*"])
+    broker.ensure_usable(cred, ["org:sales:leads"])  # overlap allowed
+    with pytest.raises(CredentialScopeError):
+        broker.ensure_usable(cred, ["org:support:tickets"])
+
+
+def test_broker_credential_expires_after_ttl() -> None:
+    broker = InMemoryCredentialBroker(ttl_s=0.05)
+    cred = broker.acquire("drive", ["org:sales:leads"])
+    time.sleep(0.1)
+    with pytest.raises(CredentialExpiredError):
+        broker.ensure_usable(cred, ["org:sales:leads"])
+
+
+def test_broker_emits_journal_events(journal: Journal) -> None:
+    actor = Actor(kind="system", id="system:credential-broker")
+    broker = InMemoryCredentialBroker(ttl_s=60, journal=journal, broker_actor=actor)
+    cred = broker.acquire("drive", ["org:sales:leads"])
+    broker.ensure_usable(cred, ["org:sales:leads"])
+    broker.mark_used(cred)
+    broker.revoke(cred.id)
+
+    actions = [e.action for e in journal.query()]
+    assert "credential.acquired" in actions
+    assert "credential.used" in actions
+    assert "credential.expired" in actions
+
+
+def test_broker_expiry_emits_event(journal: Journal) -> None:
+    broker = InMemoryCredentialBroker(ttl_s=0.05, journal=journal)
+    cred = broker.acquire("drive", ["org:sales:leads"])
+    time.sleep(0.1)
+    with pytest.raises(CredentialExpiredError):
+        broker.ensure_usable(cred, ["org:sales:leads"])
+    actions = [e.action for e in journal.query()]
+    assert actions.count("credential.expired") == 1
+
+
+# -- adapter conformance --------------------------------------------------
+
+
+def test_mock_and_projection_are_source_adapters() -> None:
+    mock = MockAdapter()
+    proj = ProjectionAdapter(lambda req: [])
+    assert isinstance(mock, SourceAdapter)
+    assert isinstance(proj, SourceAdapter)
+
+
+def test_projection_adapter_calls_underlying_fn() -> None:
+    calls: list[RetrievalRequest] = []
+
+    def fn(req: RetrievalRequest) -> list[RetrievalCandidate]:
+        calls.append(req)
+        return [_candidate("proj", 0.5)]
+
+    adapter = ProjectionAdapter(fn)
+    out = adapter.query(_request(), credential=None)
+    assert [c.source for c in out] == ["proj"]
+    assert len(calls) == 1
+
+
+def test_dataref_source_triggers_broker(journal: Journal) -> None:
+    broker = InMemoryCredentialBroker(ttl_s=60, journal=journal)
+    router = RetrievalRouter(journal=journal, broker=broker)
+    mock = MockAdapter(candidates=[_candidate("drive", 0.9)])
+    mock.supports_dataref = True
+    router.register_source(
+        CandidateSource(
+            name="drive", kind="dataref", scopes=["org:sales:*"], adapter_ref="drive"
+        ),
+        mock,
+    )
+    router.dispatch(_request(strategy="sequential"))
+
+    actions = [e.action for e in journal.query()]
+    assert "credential.acquired" in actions
+    assert "credential.used" in actions
+    assert "retrieval.query" in actions
+    # MockAdapter saw a real credential.
+    assert mock.calls
+    _, cred = mock.calls[0]
+    assert cred is not None
+    assert cred.source == "drive"


### PR DESCRIPTION
## What this adds

The retrieval router and credential broker that make the RFC's Zero-Copy federation story actually dispatch. `DataRef` already exists as a payload variant on `EventEntry` (#165), but nothing yet fans out a `retrieval.query` across local projection sources and live external sources. This PR is that plumbing.

Three modules land:

- `spec/retrieval.py` — `CandidateSource`, `RetrievalRequest`, `RetrievalCandidate`, `RetrievalResult`. Source-specific payload stays opaque; the router never interprets it.
- `engine/retrieval/router.py` — `RetrievalRouter` with `first` / `parallel` / `sequential` strategies, per-source timeout, scope overlap filtering, and a `retrieval.query` journal event on every dispatch.
- `engine/retrieval/broker.py` — `CredentialBroker` protocol plus `InMemoryCredentialBroker`. TTL-bounded credentials, scope-overlap enforcement, and `credential.acquired` / `credential.used` / `credential.expired` events when a journal is attached.
- `engine/retrieval/adapters.py` — the `SourceAdapter` protocol, a `MockAdapter` for tests, and a `ProjectionAdapter` for the local-view case (soul memory, kb, fabric).

## What's deliberately out of scope

- No concrete external adapter. Drive, Salesforce, and friends are C2 and ship separately once this plumbing is on `dev`.
- No caching layer. `RetrievalCandidate.cached` is already on the model so adapters can flag cache hits, but the cache store is its own PR.
- No async. Everything is sync for this slice; the `parallel` strategy uses `concurrent.futures.ThreadPoolExecutor`. Async wrapping is a follow-up.
- No `RetrievalTrace` integration. The trace module from #161 isn't on this base branch, so `RetrievalResult.trace` stays `Any | None = None` with a TODO.

## Tests

16 new tests under `tests/test_engine/test_retrieval.py` covering:

- all three dispatch strategies (parallel merge by score, `first` short-circuits after a non-empty reply, `sequential` stops at `limit`)
- scope filtering — a request scoped to `org:sales:leads` skips a source registered under `org:support:*`
- per-source timeout — a slow adapter is abandoned and shows up in `sources_failed`
- `retrieval.query` journal emission with the right action, scope, actor, correlation id
- broker acquire / ensure_usable / mark_used / revoke + journal emission for each
- cross-scope refusal (`CredentialScopeError`) and TTL expiry (`CredentialExpiredError`)
- Protocol conformance for both adapters
- end-to-end DataRef source flow where the router acquires and marks a credential before calling the adapter

Full suite is still green on everything I touched. The six pre-existing failures in `test_cognitive_adapters.py` and `test_mcp_sampling_engine.py` also fail on the base branch without this diff.

## Stacking

Base is `feat/journal-engine` (#166). After that merges, I'll retarget this to `dev`. This is the second PR in the Workstream C chain; the concrete Drive and Salesforce adapters will follow in C2.

RFC: #164.