### PR TITLE
docs: neutralize PocketPaw examples

### DIFF
--- a/docs/cognitive-engine.md
+++ b/docs/cognitive-engine.md
@@ -179,7 +179,7 @@ The engine identifies people, technologies, projects, and places mentioned in th
 ```json
 [
     {"name": "FastAPI", "type": "technology", "relation": "uses"},
-    {"name": "PocketPaw", "type": "project", "relation": "builds"}
+    {"name": "Acme", "type": "project", "relation": "builds"}
 ]
 ```
 

--- a/docs/memory-architecture.md
+++ b/docs/memory-architecture.md
@@ -105,7 +105,7 @@ Example graph state after a few interactions:
 
 ```
 Python --[uses]--> User
-PocketPaw --[builds]--> User
+Acme --[builds]--> User
 FastAPI --[uses]--> User
 ```
 
@@ -217,7 +217,7 @@ If not significant: the interaction still passes through fact extraction and ent
 | `i (?:prefer\|like\|love) ...` | "I love Python" | 7 |
 | `i (?:hate\|dislike) ...` | "I hate YAML" | 7 |
 | `i (?:use\|work with\|am using) ...` | "I use Docker" | 6 |
-| `i(?:'m\| am) (?:building\|creating) ...` | "I'm building PocketPaw" | 7 |
+| `i(?:'m\| am) (?:building\|creating) ...` | "I'm building Acme" | 7 |
 | `i (?:work at\|work for) ...` | "I work at Qbtrix" | 8 |
 | `i(?:'m\| am) from ...` | "I'm from India" | 7 |
 | `i live in ...` | "I live in NYC" | 7 |


### PR DESCRIPTION
## Summary

Audit flagged three docs examples that used `PocketPaw` as a placeholder in graph and regex snippets. Swapped for `Acme` so the docs read as framework-agnostic.

Scope:
- `docs/cognitive-engine.md`: entity-extraction JSON example
- `docs/memory-architecture.md`: graph state example + fact-extraction regex table row

Left intact:
- `README.md` "Use with PocketPaw" section (real integration reference)
- `CHANGELOG.md` historical mentions
- `docs/guide-soul-inject.md` multi-soul examples (filename examples, not brand positioning)

## Test plan

- [x] `uv run pytest tests/` passes (1911 passed)
- [x] Diff stays tiny (3 insertions, 3 deletions across 2 files)