### PR TITLE
feat(engine): journal SQLite WAL backend

### DIFF
--- a/src/soul_protocol/engine/__init__.py
+++ b/src/soul_protocol/engine/__init__.py
@@ -1,0 +1,4 @@
+# __init__.py — soul_protocol.engine package.
+# Created: feat/journal-engine — Workstream A slice 2 of Org Architecture RFC (#164).
+# Engine-layer modules implement the runtime primitives (journal, fabric, …)
+# behind the spec models in `soul_protocol.spec`.

--- a/src/soul_protocol/engine/journal/__init__.py
+++ b/src/soul_protocol/engine/journal/__init__.py
@@ -1,0 +1,21 @@
+# __init__.py — Public API for the journal engine.
+# Created: feat/journal-engine — Workstream A slice 2 of Org Architecture RFC (#164).
+# Re-exports Journal, JournalBackend, open_journal, and the exception hierarchy.
+
+from __future__ import annotations
+
+from .backend import JournalBackend
+from .exceptions import IntegrityError, JournalError, NotFoundError, SchemaError
+from .journal import Journal, open_journal
+from .sqlite import SQLiteJournalBackend
+
+__all__ = [
+    "IntegrityError",
+    "Journal",
+    "JournalBackend",
+    "JournalError",
+    "NotFoundError",
+    "SQLiteJournalBackend",
+    "SchemaError",
+    "open_journal",
+]

--- a/src/soul_protocol/engine/journal/backend.py
+++ b/src/soul_protocol/engine/journal/backend.py
@@ -1,0 +1,45 @@
+# backend.py — Journal backend Protocol.
+# Created: feat/journal-engine — Workstream A slice 2 of Org Architecture RFC (#164).
+# The Journal class delegates persistence to a JournalBackend. v1 ships a
+# single SQLite implementation; future backends (LMDB, Postgres, pluggable
+# remote) implement the same Protocol.
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+from uuid import UUID
+
+from soul_protocol.spec.journal import Actor, EventEntry
+
+
+@runtime_checkable
+class JournalBackend(Protocol):
+    """Storage contract for journal events. All methods are synchronous."""
+
+    def append(self, entry: EventEntry) -> int:
+        """Persist `entry`, assigning and returning its monotonic seq atomically."""
+
+    def query(
+        self,
+        *,
+        action: str | None = None,
+        actor: Actor | None = None,
+        scope: list[str] | None = None,
+        correlation_id: UUID | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[EventEntry]:
+        """Return events matching the conjunction of filters."""
+
+    def replay_from(self, seq: int = 0) -> Iterator[EventEntry]:
+        """Yield events with seq >= given value in ascending seq order."""
+
+    def last_entry(self) -> tuple[EventEntry, int] | None:
+        """Return (last_entry, last_seq) or None if journal is empty."""
+
+    def close(self) -> None:
+        """Release any resources. Idempotent."""

--- a/src/soul_protocol/engine/journal/exceptions.py
+++ b/src/soul_protocol/engine/journal/exceptions.py
@@ -1,0 +1,22 @@
+# exceptions.py — Journal engine error hierarchy.
+# Created: feat/journal-engine — Workstream A slice 2 of Org Architecture RFC (#164).
+# All journal failures raise a subclass of JournalError so callers can catch
+# a single base class if they don't care which specific failure happened.
+
+from __future__ import annotations
+
+
+class JournalError(Exception):
+    """Base class for all journal engine failures."""
+
+
+class SchemaError(JournalError):
+    """Raised when the on-disk schema version is incompatible with this engine."""
+
+
+class IntegrityError(JournalError):
+    """Raised when an append would violate an invariant (tz, monotonic ts, …)."""
+
+
+class NotFoundError(JournalError):
+    """Raised when a requested event / seq / id is not present."""

--- a/src/soul_protocol/engine/journal/journal.py
+++ b/src/soul_protocol/engine/journal/journal.py
@@ -1,0 +1,129 @@
+# journal.py — Journal high-level class enforcing invariants above a backend.
+# Created: feat/journal-engine — Workstream A slice 2 of Org Architecture RFC (#164).
+# The Journal owns the rules — tz-aware UTC, non-empty scope, monotonic ts,
+# attributed actor, auto-assigned seq, opportunistic hash-chain. Callers
+# never touch the backend directly.
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from soul_protocol.spec.journal import Actor, EventEntry
+
+from .backend import JournalBackend
+from .exceptions import IntegrityError
+from .sqlite import SQLiteJournalBackend
+
+
+def _is_aware(dt: datetime) -> bool:
+    return dt.tzinfo is not None and dt.tzinfo.utcoffset(dt) is not None
+
+
+def _hash_link(prev: EventEntry, prev_seq: int) -> bytes:
+    """Compute the prev_hash link for the *next* event.
+
+    Deliberately simple: sha256 over a canonical string built from the
+    previous event's identifying fields plus its seq. Signing and the
+    full hash-chain will replace this in a later slice.
+    """
+    material = f"{prev.id}|{prev.ts.isoformat()}|{prev.action}|{prev_seq}".encode()
+    return hashlib.sha256(material).digest()
+
+
+class Journal:
+    """High-level append-only journal.
+
+    Invariants enforced here (not in the backend):
+        * ``entry.ts`` must be timezone-aware UTC.
+        * ``entry.scope`` must be non-empty (delegated to model validation).
+        * ``entry.actor.id`` must be non-empty (delegated to model validation).
+        * ``entry.ts`` must be >= the prior event's ts (monotonic per journal).
+        * ``seq`` is assigned by the journal. Any caller-supplied seq is
+          ignored — the EventEntry spec model does not carry one.
+
+    Hash-chain linkage is computed opportunistically: if there is a previous
+    event, the new entry's ``prev_hash`` is overwritten with the chain link
+    unless the caller explicitly supplied one (supporting pre-signed events
+    from a future slice). Failure to hash does not block the append.
+    """
+
+    def __init__(self, backend: JournalBackend) -> None:
+        self._backend = backend
+
+    # -- writes -----------------------------------------------------------
+
+    def append(self, entry: EventEntry) -> None:
+        if not _is_aware(entry.ts):
+            raise IntegrityError("EventEntry.ts must be timezone-aware UTC")
+
+        last = self._backend.last_entry()
+        if last is not None:
+            prev_entry, prev_seq = last
+            if entry.ts < prev_entry.ts:
+                raise IntegrityError(
+                    "EventEntry.ts must be >= previous event's ts "
+                    f"({entry.ts.isoformat()} < {prev_entry.ts.isoformat()})"
+                )
+            if entry.prev_hash is None:
+                try:
+                    entry = entry.model_copy(update={"prev_hash": _hash_link(prev_entry, prev_seq)})
+                except Exception:
+                    # Opportunistic — don't fail the append on a hash hiccup.
+                    pass
+
+        self._backend.append(entry)
+
+    # -- reads ------------------------------------------------------------
+
+    def query(
+        self,
+        *,
+        action: str | None = None,
+        actor: Actor | None = None,
+        scope: list[str] | None = None,
+        correlation_id: UUID | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[EventEntry]:
+        if since is not None and not _is_aware(since):
+            raise IntegrityError("Journal.query(since=...) must be timezone-aware UTC")
+        if until is not None and not _is_aware(until):
+            raise IntegrityError("Journal.query(until=...) must be timezone-aware UTC")
+
+        return self._backend.query(
+            action=action,
+            actor=actor,
+            scope=scope,
+            correlation_id=correlation_id,
+            since=since,
+            until=until,
+            limit=limit,
+            offset=offset,
+        )
+
+    def replay_from(self, seq: int = 0) -> Iterator[EventEntry]:
+        yield from self._backend.replay_from(seq)
+
+    # -- lifecycle --------------------------------------------------------
+
+    def close(self) -> None:
+        self._backend.close()
+
+    def __enter__(self) -> Journal:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.close()
+
+
+def open_journal(path: Path | str) -> Journal:
+    """Open (and migrate on first write) a SQLite-backed journal at `path`."""
+    backend = SQLiteJournalBackend(Path(path))
+    return Journal(backend)

--- a/src/soul_protocol/engine/journal/journal.py
+++ b/src/soul_protocol/engine/journal/journal.py
@@ -1,12 +1,15 @@
 # journal.py — Journal high-level class enforcing invariants above a backend.
-# Created: feat/journal-engine — Workstream A slice 2 of Org Architecture RFC (#164).
-# The Journal owns the rules — tz-aware UTC, non-empty scope, monotonic ts,
-# attributed actor, auto-assigned seq, opportunistic hash-chain. Callers
-# never touch the backend directly.
+# Updated: feat/journal-engine — the ts-monotonicity guard now lives inside
+# the backend's BEGIN IMMEDIATE transaction (see sqlite.py). The Journal still
+# shapes entries (hash-link, tz-aware guard) but no longer reads the tail
+# outside the transaction, because that read-then-insert was racy under
+# concurrent writers. Also log (not swallow) hash-link failures so a silent
+# chain break is at least visible.
 
 from __future__ import annotations
 
 import hashlib
+import logging
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
@@ -18,6 +21,8 @@ from soul_protocol.spec.journal import Actor, EventEntry
 from .backend import JournalBackend
 from .exceptions import IntegrityError
 from .sqlite import SQLiteJournalBackend
+
+logger = logging.getLogger(__name__)
 
 
 def _is_aware(dt: datetime) -> bool:
@@ -61,20 +66,24 @@ class Journal:
         if not _is_aware(entry.ts):
             raise IntegrityError("EventEntry.ts must be timezone-aware UTC")
 
-        last = self._backend.last_entry()
-        if last is not None:
-            prev_entry, prev_seq = last
-            if entry.ts < prev_entry.ts:
-                raise IntegrityError(
-                    "EventEntry.ts must be >= previous event's ts "
-                    f"({entry.ts.isoformat()} < {prev_entry.ts.isoformat()})"
-                )
-            if entry.prev_hash is None:
+        # Opportunistic hash-link. The monotonicity guard lives in the
+        # backend's write transaction now (see sqlite.append); reading the
+        # tail here is best-effort for the hash only. A racing writer may
+        # mean the hash points at a tail that's no longer the immediate
+        # predecessor, which is acceptable for the placeholder chain and
+        # will be replaced once signing ships.
+        if entry.prev_hash is None:
+            last = self._backend.last_entry()
+            if last is not None:
+                prev_entry, prev_seq = last
                 try:
-                    entry = entry.model_copy(update={"prev_hash": _hash_link(prev_entry, prev_seq)})
-                except Exception:
-                    # Opportunistic — don't fail the append on a hash hiccup.
-                    pass
+                    entry = entry.model_copy(
+                        update={"prev_hash": _hash_link(prev_entry, prev_seq)}
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "hash-link skipped for event %s: %s", entry.id, exc
+                    )
 
         self._backend.append(entry)
 

--- a/src/soul_protocol/engine/journal/schema.py
+++ b/src/soul_protocol/engine/journal/schema.py
@@ -1,0 +1,73 @@
+# schema.py — SQLite schema + migration helper for the journal engine.
+# Created: feat/journal-engine — Workstream A slice 2 of Org Architecture RFC (#164).
+# Schema v1 ships with this slice. Future versions bump SCHEMA_VERSION and add a
+# migration branch in `migrate()` — we never drop or rewrite history.
+
+from __future__ import annotations
+
+import sqlite3
+
+from .exceptions import SchemaError
+
+SCHEMA_VERSION = 1
+
+CREATE_EVENTS = """
+CREATE TABLE IF NOT EXISTS events (
+    id TEXT PRIMARY KEY,
+    ts TEXT NOT NULL,
+    actor_kind TEXT NOT NULL,
+    actor_id TEXT NOT NULL,
+    action TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    causation_id TEXT,
+    correlation_id TEXT,
+    payload TEXT NOT NULL,
+    prev_hash BLOB,
+    sig BLOB,
+    seq INTEGER NOT NULL UNIQUE
+);
+"""
+
+CREATE_INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);",
+    "CREATE INDEX IF NOT EXISTS idx_events_action ON events(action);",
+    "CREATE INDEX IF NOT EXISTS idx_events_actor ON events(actor_kind, actor_id);",
+    "CREATE INDEX IF NOT EXISTS idx_events_correlation ON events(correlation_id);",
+    "CREATE INDEX IF NOT EXISTS idx_events_seq ON events(seq);",
+)
+
+CREATE_META = """
+CREATE TABLE IF NOT EXISTS journal_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+"""
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    """Bring a connection's database up to SCHEMA_VERSION.
+
+    Idempotent — safe to call on every open. Raises SchemaError if the
+    on-disk version is newer than what this engine understands.
+    """
+    cur = conn.cursor()
+    cur.execute(CREATE_META)
+    cur.execute("SELECT value FROM journal_meta WHERE key = 'schema_version'")
+    row = cur.fetchone()
+    current = int(row[0]) if row else 0
+
+    if current > SCHEMA_VERSION:
+        raise SchemaError(
+            f"journal schema v{current} is newer than engine v{SCHEMA_VERSION}; "
+            "upgrade soul-protocol"
+        )
+
+    if current < 1:
+        cur.execute(CREATE_EVENTS)
+        for stmt in CREATE_INDEXES:
+            cur.execute(stmt)
+        cur.execute(
+            "INSERT OR REPLACE INTO journal_meta(key, value) VALUES ('schema_version', ?)",
+            (str(SCHEMA_VERSION),),
+        )
+    conn.commit()

--- a/src/soul_protocol/engine/journal/sqlite.py
+++ b/src/soul_protocol/engine/journal/sqlite.py
@@ -1,5 +1,9 @@
 # sqlite.py — SQLite WAL-mode JournalBackend implementation.
-# Created: feat/journal-engine — Workstream A slice 2 of Org Architecture RFC (#164).
+# Updated: feat/journal-engine — move the ts-monotonicity check inside the
+# BEGIN IMMEDIATE transaction so two concurrent writers can't both pass a
+# pre-transaction read and land events with out-of-order timestamps. The
+# previous check-then-insert pattern left a race window between the last_entry
+# read and the INSERT.
 # Uses sqlite3 stdlib only. WAL is enabled on open for concurrent-reader
 # safety and durable append-only writes. Payload is stored as JSON; either a
 # plain dict or a DataRef-tagged object (see _encode_payload).
@@ -18,6 +22,7 @@ from uuid import UUID
 from soul_protocol.spec.journal import Actor, DataRef, EventEntry
 
 from .backend import JournalBackend
+from .exceptions import IntegrityError
 from .schema import migrate
 
 DATAREF_TAG = "__dataref__"
@@ -90,10 +95,34 @@ class SQLiteJournalBackend(JournalBackend):
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
+                # Read the current tail under the write lock so the
+                # monotonicity check cannot race another writer that passed
+                # its own check before the INSERT. Two concurrent writers
+                # will serialize here via BEGIN IMMEDIATE.
                 row = self._conn.execute(
-                    "SELECT COALESCE(MAX(seq), -1) FROM events"
+                    "SELECT ts, seq FROM events ORDER BY seq DESC LIMIT 1"
                 ).fetchone()
-                seq = int(row[0]) + 1
+                if row is not None:
+                    prev_ts = datetime.fromisoformat(row[0])
+                    if entry.ts < prev_ts:
+                        delta = (prev_ts - entry.ts).total_seconds()
+                        if delta >= 0.1:
+                            # More than a second behind the tail: this is a
+                            # real clock error (wall clock jumped backward,
+                            # caller passed a stale ts), not a thread-race
+                            # microsecond overlap. Reject it.
+                            raise IntegrityError(
+                                "EventEntry.ts must be >= previous event's ts "
+                                f"({entry.ts.isoformat()} < {prev_ts.isoformat()})"
+                            )
+                        # Race-window bump: a concurrent writer committed
+                        # between our now() read and our BEGIN IMMEDIATE.
+                        # Stamp at the tail so the combined log stays
+                        # non-decreasing without raising on the caller.
+                        entry = entry.model_copy(update={"ts": prev_ts})
+                    seq = int(row[1]) + 1
+                else:
+                    seq = 0
                 self._conn.execute(
                     """
                     INSERT INTO events (

--- a/src/soul_protocol/engine/journal/sqlite.py
+++ b/src/soul_protocol/engine/journal/sqlite.py
@@ -1,0 +1,227 @@
+# sqlite.py — SQLite WAL-mode JournalBackend implementation.
+# Created: feat/journal-engine — Workstream A slice 2 of Org Architecture RFC (#164).
+# Uses sqlite3 stdlib only. WAL is enabled on open for concurrent-reader
+# safety and durable append-only writes. Payload is stored as JSON; either a
+# plain dict or a DataRef-tagged object (see _encode_payload).
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from soul_protocol.spec.journal import Actor, DataRef, EventEntry
+
+from .backend import JournalBackend
+from .schema import migrate
+
+DATAREF_TAG = "__dataref__"
+
+
+def _encode_payload(payload: DataRef | dict[str, Any]) -> str:
+    if isinstance(payload, DataRef):
+        body = payload.model_dump(mode="json")
+        return json.dumps({DATAREF_TAG: True, **body})
+    return json.dumps(payload)
+
+
+def _decode_payload(raw: str) -> DataRef | dict[str, Any]:
+    obj = json.loads(raw)
+    if isinstance(obj, dict) and obj.get(DATAREF_TAG) is True:
+        data = {k: v for k, v in obj.items() if k != DATAREF_TAG}
+        return DataRef.model_validate(data)
+    return obj
+
+
+def _scope_matches(event_scopes: list[str], query_scopes: list[str]) -> bool:
+    """Prefix + wildcard match. An event matches if any event scope satisfies
+    any query pattern.
+
+    Semantics (colon-delimited segments):
+      - ``"org:sales"`` matches exactly ``org:sales``.
+      - ``"org:sales:*"`` matches ``org:sales:leads``, ``org:sales:deals``,
+        ``org:sales:leads:priority``, but NOT bare ``org:sales``.
+      - ``"org:*"`` matches ``org:sales`` and ``org:hr`` but NOT bare ``org``.
+      - ``"org:*:leads"`` matches ``org:sales:leads`` and ``org:hr:leads``.
+
+    This is a placeholder until ``spec.scope`` from #162 lands; the grammar
+    described in the RFC is a superset of what we implement here. See the
+    PR description for the deferred-work note.
+    """
+    for pat in query_scopes:
+        pat_parts = pat.split(":")
+        for scope in event_scopes:
+            scope_parts = scope.split(":")
+            if len(pat_parts) != len(scope_parts):
+                continue
+            if all(p == "*" or p == s for p, s in zip(pat_parts, scope_parts)):
+                return True
+    return False
+
+
+class SQLiteJournalBackend(JournalBackend):
+    """SQLite-backed journal with WAL mode and a single serialized writer."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        # check_same_thread=False so a Journal can be handed across threads;
+        # we serialize writes through self._lock ourselves.
+        self._conn = sqlite3.connect(
+            str(path),
+            check_same_thread=False,
+            isolation_level=None,  # autocommit; we manage transactions explicitly
+            timeout=30.0,
+        )
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        migrate(self._conn)
+
+    # -- writes -----------------------------------------------------------
+
+    def append(self, entry: EventEntry) -> int:
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    "SELECT COALESCE(MAX(seq), -1) FROM events"
+                ).fetchone()
+                seq = int(row[0]) + 1
+                self._conn.execute(
+                    """
+                    INSERT INTO events (
+                        id, ts, actor_kind, actor_id, action, scope,
+                        causation_id, correlation_id, payload,
+                        prev_hash, sig, seq
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        str(entry.id),
+                        entry.ts.isoformat(),
+                        entry.actor.kind,
+                        entry.actor.id,
+                        entry.action,
+                        json.dumps(entry.scope),
+                        str(entry.causation_id) if entry.causation_id else None,
+                        str(entry.correlation_id) if entry.correlation_id else None,
+                        _encode_payload(entry.payload),
+                        entry.prev_hash,
+                        entry.sig,
+                        seq,
+                    ),
+                )
+                self._conn.execute("COMMIT")
+                return seq
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
+
+    def last_entry(self) -> tuple[EventEntry, int] | None:
+        row = self._conn.execute(
+            "SELECT * FROM events ORDER BY seq DESC LIMIT 1"
+        ).fetchone()
+        if row is None:
+            return None
+        entry, seq = self._row_to_entry(row)
+        return entry, seq
+
+    # -- reads ------------------------------------------------------------
+
+    def query(
+        self,
+        *,
+        action: str | None = None,
+        actor: Actor | None = None,
+        scope: list[str] | None = None,
+        correlation_id: UUID | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[EventEntry]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if action is not None:
+            clauses.append("action = ?")
+            params.append(action)
+        if actor is not None:
+            clauses.append("actor_kind = ? AND actor_id = ?")
+            params.extend([actor.kind, actor.id])
+        if correlation_id is not None:
+            clauses.append("correlation_id = ?")
+            params.append(str(correlation_id))
+        if since is not None:
+            clauses.append("ts >= ?")
+            params.append(since.isoformat())
+        if until is not None:
+            clauses.append("ts <= ?")
+            params.append(until.isoformat())
+
+        sql = "SELECT * FROM events"
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY seq ASC"
+
+        rows = self._conn.execute(sql, params).fetchall()
+        results: list[EventEntry] = []
+        for row in rows:
+            entry, _seq = self._row_to_entry(row)
+            if scope is not None and not _scope_matches(entry.scope, scope):
+                continue
+            results.append(entry)
+
+        return results[offset : offset + limit]
+
+    def replay_from(self, seq: int = 0) -> Iterator[EventEntry]:
+        cur = self._conn.execute(
+            "SELECT * FROM events WHERE seq >= ? ORDER BY seq ASC", (seq,)
+        )
+        for row in cur:
+            entry, _seq = self._row_to_entry(row)
+            yield entry
+
+    def close(self) -> None:
+        with self._lock:
+            try:
+                self._conn.close()
+            except sqlite3.ProgrammingError:
+                pass  # already closed
+
+    # -- internals --------------------------------------------------------
+
+    def _row_to_entry(self, row: sqlite3.Row | tuple) -> tuple[EventEntry, int]:
+        # Column order matches CREATE TABLE in schema.py.
+        (
+            id_,
+            ts,
+            actor_kind,
+            actor_id,
+            action,
+            scope_json,
+            causation_id,
+            correlation_id,
+            payload_json,
+            prev_hash,
+            sig,
+            seq,
+        ) = row
+        entry = EventEntry(
+            id=UUID(id_),
+            ts=datetime.fromisoformat(ts),
+            actor=Actor(kind=actor_kind, id=actor_id),
+            action=action,
+            scope=json.loads(scope_json),
+            causation_id=UUID(causation_id) if causation_id else None,
+            correlation_id=UUID(correlation_id) if correlation_id else None,
+            payload=_decode_payload(payload_json),
+            prev_hash=prev_hash,
+            sig=sig,
+        )
+        return entry, int(seq)

--- a/src/soul_protocol/engine/journal/sqlite.py
+++ b/src/soul_protocol/engine/journal/sqlite.py
@@ -92,6 +92,25 @@ class SQLiteJournalBackend(JournalBackend):
     # -- writes -----------------------------------------------------------
 
     def append(self, entry: EventEntry) -> int:
+        """Persist an event with atomic seq assignment and monotonic-ts check.
+
+        Monotonicity policy — worth knowing before relying on exact ts ordering:
+
+        - Events whose ts is >= the tail's ts are accepted as-is.
+        - Events whose ts is LESS than tail ts by more than 100ms raise
+          ``IntegrityError``. This catches real clock errors (wall clock
+          jumped back, caller passed a stale ts from minutes ago, etc).
+        - Events whose ts is less than tail by <= 100ms get their ts bumped
+          up to the tail's ts. This tolerates the sub-100ms clock races
+          that occur when two threads call ``datetime.now(UTC)`` and then
+          race into ``BEGIN IMMEDIATE``. The combined log stays
+          non-decreasing; seq ordering (the actual event-order invariant)
+          is unaffected. Users reading journal events in seq order see
+          monotonic ts without occasional flakes under concurrent load.
+
+        Net effect: seq is strictly monotonic; ts is monotonic to within
+        100ms of tolerance for concurrent writers on coarse clocks.
+        """
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
@@ -107,18 +126,18 @@ class SQLiteJournalBackend(JournalBackend):
                     if entry.ts < prev_ts:
                         delta = (prev_ts - entry.ts).total_seconds()
                         if delta >= 0.1:
-                            # More than a second behind the tail: this is a
-                            # real clock error (wall clock jumped backward,
-                            # caller passed a stale ts), not a thread-race
+                            # More than 100ms behind the tail: a real
+                            # clock error (caller passed a stale ts, wall
+                            # clock jumped backward), not a thread-race
                             # microsecond overlap. Reject it.
                             raise IntegrityError(
                                 "EventEntry.ts must be >= previous event's ts "
                                 f"({entry.ts.isoformat()} < {prev_ts.isoformat()})"
                             )
-                        # Race-window bump: a concurrent writer committed
+                        # Sub-100ms race: a concurrent writer committed
                         # between our now() read and our BEGIN IMMEDIATE.
                         # Stamp at the tail so the combined log stays
-                        # non-decreasing without raising on the caller.
+                        # non-decreasing. See docstring for the policy.
                         entry = entry.model_copy(update={"ts": prev_ts})
                     seq = int(row[1]) + 1
                 else:

--- a/tests/test_engine/__init__.py
+++ b/tests/test_engine/__init__.py
@@ -1,0 +1,2 @@
+# __init__.py — Engine test package.
+# Created: feat/journal-engine — Workstream A slice 2 of Org Architecture RFC (#164).

--- a/tests/test_engine/test_journal.py
+++ b/tests/test_engine/test_journal.py
@@ -1,0 +1,354 @@
+# test_journal.py — Journal engine test suite.
+# Created: feat/journal-engine — Workstream A slice 2 of Org Architecture RFC (#164).
+# Covers: round-trip append/query, every filter dimension, scope prefix +
+# wildcard semantics, tz-aware enforcement on append and query, scope-empty
+# rejection, monotonic ts, seq auto-assignment, replay ordering, DataRef
+# round-trip, concurrent WAL writers, and the zero->v1 migration path.
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from soul_protocol.engine.journal import (
+    IntegrityError,
+    Journal,
+    SQLiteJournalBackend,
+    open_journal,
+)
+from soul_protocol.engine.journal.schema import SCHEMA_VERSION
+from soul_protocol.engine.journal.sqlite import _scope_matches
+from soul_protocol.spec.journal import Actor, DataRef, EventEntry
+
+
+def _make_entry(
+    *,
+    action: str = "memory.remembered",
+    actor: Actor | None = None,
+    scope: list[str] | None = None,
+    ts: datetime | None = None,
+    correlation_id: UUID | None = None,
+    payload: dict | DataRef | None = None,
+) -> EventEntry:
+    return EventEntry(
+        id=uuid4(),
+        ts=ts or datetime.now(UTC),
+        actor=actor or Actor(kind="agent", id="did:soul:test-agent"),
+        action=action,
+        scope=scope or ["org:test"],
+        correlation_id=correlation_id,
+        payload=payload if payload is not None else {"note": "hello"},
+    )
+
+
+@pytest.fixture
+def journal(tmp_path: Path) -> Journal:
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+# ---------- round-trip -------------------------------------------------
+
+
+def test_append_query_roundtrip(journal: Journal) -> None:
+    entry = _make_entry()
+    journal.append(entry)
+    results = journal.query()
+    assert len(results) == 1
+    assert results[0].id == entry.id
+    assert results[0].action == entry.action
+    assert results[0].scope == entry.scope
+    assert results[0].payload == entry.payload
+
+
+# ---------- filter dimensions -----------------------------------------
+
+
+def test_query_by_action(journal: Journal) -> None:
+    journal.append(_make_entry(action="memory.remembered"))
+    journal.append(_make_entry(action="memory.forgotten"))
+    results = journal.query(action="memory.forgotten")
+    assert len(results) == 1
+    assert results[0].action == "memory.forgotten"
+
+
+def test_query_by_actor(journal: Journal) -> None:
+    a = Actor(kind="agent", id="did:soul:a")
+    b = Actor(kind="user", id="user:bob")
+    journal.append(_make_entry(actor=a))
+    journal.append(_make_entry(actor=b))
+    journal.append(_make_entry(actor=a))
+    results = journal.query(actor=a)
+    assert len(results) == 2
+    assert all(r.actor.id == "did:soul:a" for r in results)
+
+
+def test_query_by_correlation_id(journal: Journal) -> None:
+    cid = uuid4()
+    journal.append(_make_entry(correlation_id=cid))
+    journal.append(_make_entry(correlation_id=uuid4()))
+    journal.append(_make_entry(correlation_id=cid))
+    results = journal.query(correlation_id=cid)
+    assert len(results) == 2
+
+
+def test_query_by_time_window(journal: Journal) -> None:
+    base = datetime.now(UTC)
+    journal.append(_make_entry(ts=base))
+    journal.append(_make_entry(ts=base + timedelta(seconds=5)))
+    journal.append(_make_entry(ts=base + timedelta(seconds=10)))
+    results = journal.query(
+        since=base + timedelta(seconds=1),
+        until=base + timedelta(seconds=9),
+    )
+    assert len(results) == 1
+
+
+def test_query_combined_filters(journal: Journal) -> None:
+    cid = uuid4()
+    a = Actor(kind="agent", id="did:soul:a")
+    journal.append(_make_entry(actor=a, action="memory.remembered", correlation_id=cid))
+    journal.append(_make_entry(actor=a, action="memory.forgotten", correlation_id=cid))
+    journal.append(_make_entry(action="memory.remembered"))
+    results = journal.query(actor=a, action="memory.remembered", correlation_id=cid)
+    assert len(results) == 1
+
+
+# ---------- scope prefix + wildcards ----------------------------------
+
+
+def test_scope_wildcard_matcher_unit() -> None:
+    # Exact
+    assert _scope_matches(["org:sales"], ["org:sales"])
+    assert not _scope_matches(["org:sales"], ["org:hr"])
+
+    # Leaf wildcard — same arity required
+    assert _scope_matches(["org:sales:leads"], ["org:sales:*"])
+    assert not _scope_matches(["org:sales"], ["org:sales:*"])  # bare parent NOT matched
+
+    # Intermediate wildcard
+    assert _scope_matches(["org:sales:leads"], ["org:*:leads"])
+    assert _scope_matches(["org:hr:leads"], ["org:*:leads"])
+    assert not _scope_matches(["org:sales:deals"], ["org:*:leads"])
+
+    # Single-segment wildcard — does NOT match parent (the paw-enterprise #70 bug)
+    assert _scope_matches(["org:sales"], ["org:*"])
+    assert not _scope_matches(["org"], ["org:*"])
+
+
+def test_query_scope_wildcard(journal: Journal) -> None:
+    journal.append(_make_entry(scope=["org:sales:leads"]))
+    journal.append(_make_entry(scope=["org:hr:leads"]))
+    journal.append(_make_entry(scope=["org:sales:deals"]))
+    results = journal.query(scope=["org:*:leads"])
+    assert len(results) == 2
+    scopes = sorted(r.scope[0] for r in results)
+    assert scopes == ["org:hr:leads", "org:sales:leads"]
+
+
+# ---------- tz enforcement --------------------------------------------
+
+
+def test_append_rejects_naive_datetime() -> None:
+    # The spec model rejects naive datetimes at validation time — we never
+    # reach the engine layer. That is the intended behavior.
+    with pytest.raises(ValidationError):
+        EventEntry(
+            id=uuid4(),
+            ts=datetime.now(),  # naive — no tz
+            actor=Actor(kind="agent", id="x"),
+            action="memory.remembered",
+            scope=["org:test"],
+        )
+
+
+def test_query_rejects_naive_since(journal: Journal) -> None:
+    with pytest.raises(IntegrityError):
+        journal.query(since=datetime.now())
+
+
+def test_query_rejects_naive_until(journal: Journal) -> None:
+    with pytest.raises(IntegrityError):
+        journal.query(until=datetime.now())
+
+
+# ---------- scope emptiness -------------------------------------------
+
+
+def test_append_rejects_empty_scope() -> None:
+    with pytest.raises(ValidationError):
+        EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=Actor(kind="agent", id="x"),
+            action="memory.remembered",
+            scope=[],
+        )
+
+
+# ---------- monotonic ts ----------------------------------------------
+
+
+def test_monotonic_ts_enforced(journal: Journal) -> None:
+    base = datetime.now(UTC)
+    journal.append(_make_entry(ts=base))
+    with pytest.raises(IntegrityError):
+        journal.append(_make_entry(ts=base - timedelta(seconds=1)))
+
+
+# ---------- seq auto-assignment ---------------------------------------
+
+
+def test_seq_auto_assigned_gap_free(tmp_path: Path) -> None:
+    path = tmp_path / "journal.db"
+    j = open_journal(path)
+    for _ in range(5):
+        j.append(_make_entry())
+    j.close()
+
+    # Peek at the raw rows to verify seq went 0,1,2,3,4.
+    conn = sqlite3.connect(str(path))
+    seqs = [row[0] for row in conn.execute("SELECT seq FROM events ORDER BY seq")]
+    conn.close()
+    assert seqs == [0, 1, 2, 3, 4]
+
+
+# ---------- replay ordering -------------------------------------------
+
+
+def test_replay_from_iterates_in_order(journal: Journal) -> None:
+    base = datetime.now(UTC)
+    ids = []
+    for i in range(5):
+        e = _make_entry(ts=base + timedelta(seconds=i))
+        ids.append(e.id)
+        journal.append(e)
+
+    replayed = list(journal.replay_from(seq=0))
+    assert [r.id for r in replayed] == ids
+
+    from_two = list(journal.replay_from(seq=2))
+    assert [r.id for r in from_two] == ids[2:]
+
+
+# ---------- DataRef payload round-trip --------------------------------
+
+
+def test_dataref_payload_roundtrip(journal: Journal) -> None:
+    ref = DataRef(
+        source="salesforce",
+        query="SELECT Id FROM Lead WHERE Status='Open'",
+        point_in_time=datetime.now(UTC),
+        cache_policy="ttl",
+        cache_ttl_s=600,
+    )
+    entry = _make_entry(payload=ref)
+    journal.append(entry)
+
+    (got,) = journal.query()
+    assert isinstance(got.payload, DataRef)
+    assert got.payload.source == "salesforce"
+    assert got.payload.query == ref.query
+    assert got.payload.cache_ttl_s == 600
+
+
+def test_dict_payload_roundtrip(journal: Journal) -> None:
+    entry = _make_entry(payload={"note": "hi", "nested": {"k": [1, 2]}})
+    journal.append(entry)
+    (got,) = journal.query()
+    assert isinstance(got.payload, dict)
+    assert got.payload == {"note": "hi", "nested": {"k": [1, 2]}}
+
+
+# ---------- WAL concurrent writers ------------------------------------
+
+
+def test_concurrent_writers_wal_no_data_loss(tmp_path: Path) -> None:
+    path = tmp_path / "journal.db"
+    # Two separate journal instances pointing at the same DB — each holds
+    # its own connection with WAL mode. Serialized by SQLite's lock.
+    ja = open_journal(path)
+    jb = open_journal(path)
+
+    N = 25
+    errors: list[Exception] = []
+    barrier = threading.Barrier(2)
+    # Shared monotonic clock so the two writers don't violate ts monotonicity
+    # purely by racing each other's datetime.now() reads.
+    clock_lock = threading.Lock()
+    clock = [datetime.now(UTC)]
+
+    def tick() -> datetime:
+        with clock_lock:
+            clock[0] = clock[0] + timedelta(microseconds=1)
+            return clock[0]
+
+    def writer(j: Journal, tag: str) -> None:
+        barrier.wait()
+        try:
+            for _ in range(N):
+                j.append(
+                    _make_entry(
+                        actor=Actor(kind="agent", id=f"did:soul:{tag}"),
+                        ts=tick(),
+                    )
+                )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    ta = threading.Thread(target=writer, args=(ja, "a"))
+    tb = threading.Thread(target=writer, args=(jb, "b"))
+    ta.start()
+    tb.start()
+    ta.join()
+    tb.join()
+
+    assert not errors, f"writer errors: {errors}"
+
+    ja.close()
+    jb.close()
+
+    reader = open_journal(path)
+    all_events = reader.query(limit=10_000)
+    reader.close()
+    assert len(all_events) == 2 * N
+
+    by_tag: dict[str, int] = {}
+    for e in all_events:
+        by_tag[e.actor.id] = by_tag.get(e.actor.id, 0) + 1
+    assert by_tag["did:soul:a"] == N
+    assert by_tag["did:soul:b"] == N
+
+
+# ---------- schema migration ------------------------------------------
+
+
+def test_schema_migrates_from_zero_on_first_write(tmp_path: Path) -> None:
+    path = tmp_path / "journal.db"
+    assert not path.exists()
+    j = open_journal(path)
+    j.append(_make_entry())
+    j.close()
+
+    conn = sqlite3.connect(str(path))
+    row = conn.execute(
+        "SELECT value FROM journal_meta WHERE key='schema_version'"
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    assert int(row[0]) == SCHEMA_VERSION
+
+
+def test_backend_protocol_conformance(tmp_path: Path) -> None:
+    from soul_protocol.engine.journal.backend import JournalBackend
+
+    backend = SQLiteJournalBackend(tmp_path / "journal.db")
+    assert isinstance(backend, JournalBackend)
+    backend.close()

--- a/tests/test_engine/test_journal.py
+++ b/tests/test_engine/test_journal.py
@@ -280,26 +280,26 @@ def test_concurrent_writers_wal_no_data_loss(tmp_path: Path) -> None:
     N = 25
     errors: list[Exception] = []
     barrier = threading.Barrier(2)
-    # Shared monotonic clock so the two writers don't violate ts monotonicity
-    # purely by racing each other's datetime.now() reads.
+    # Shared clock + shared tick-and-append lock. The ts allocation and the
+    # append have to be held together, otherwise thread A can tick=10, get
+    # descheduled, thread B ticks=11 and commits, and A's ts=10 commit is
+    # rightly rejected. That's the point of the monotonicity check.
     clock_lock = threading.Lock()
     clock = [datetime.now(UTC)]
-
-    def tick() -> datetime:
-        with clock_lock:
-            clock[0] = clock[0] + timedelta(microseconds=1)
-            return clock[0]
 
     def writer(j: Journal, tag: str) -> None:
         barrier.wait()
         try:
             for _ in range(N):
-                j.append(
-                    _make_entry(
-                        actor=Actor(kind="agent", id=f"did:soul:{tag}"),
-                        ts=tick(),
+                with clock_lock:
+                    clock[0] = clock[0] + timedelta(microseconds=1)
+                    ts = clock[0]
+                    j.append(
+                        _make_entry(
+                            actor=Actor(kind="agent", id=f"did:soul:{tag}"),
+                            ts=ts,
+                        )
                     )
-                )
         except Exception as exc:  # noqa: BLE001
             errors.append(exc)
 
@@ -325,6 +325,68 @@ def test_concurrent_writers_wal_no_data_loss(tmp_path: Path) -> None:
         by_tag[e.actor.id] = by_tag.get(e.actor.id, 0) + 1
     assert by_tag["did:soul:a"] == N
     assert by_tag["did:soul:b"] == N
+
+
+def test_concurrent_writers_real_clocks_preserve_ts_monotonicity(tmp_path: Path) -> None:
+    """Two threads appending with independent datetime.now(UTC) calls — no
+    shared clock. Asserts that (a) no exceptions, (b) all events land with
+    unique seqs, and (c) ts is monotonic across the combined log. This is
+    the case the existing shared-tick test can't surface: the ts-monotonicity
+    check has to happen inside the write transaction, not before it."""
+    path = tmp_path / "journal.db"
+    ja = open_journal(path)
+    jb = open_journal(path)
+
+    N = 25
+    errors: list[tuple[str, Exception]] = []
+    barrier = threading.Barrier(2)
+
+    def writer(j: Journal, tag: str) -> None:
+        barrier.wait()
+        try:
+            for _ in range(N):
+                j.append(
+                    EventEntry(
+                        id=uuid4(),
+                        ts=datetime.now(UTC),
+                        actor=Actor(
+                            kind="system",
+                            id=f"system:{tag}",
+                            scope_context=["org:*"],
+                        ),
+                        action="retrieval.query",
+                        scope=["org:*"],
+                        payload={},
+                    )
+                )
+        except Exception as exc:  # noqa: BLE001
+            errors.append((tag, exc))
+
+    ta = threading.Thread(target=writer, args=(ja, "t1"))
+    tb = threading.Thread(target=writer, args=(jb, "t2"))
+    ta.start()
+    tb.start()
+    ta.join()
+    tb.join()
+
+    ja.close()
+    jb.close()
+
+    assert errors == [], f"concurrent writes raised: {errors}"
+
+    reader = open_journal(path)
+    events = reader.query(limit=10_000)
+    reader.close()
+
+    # All 50 events landed.
+    assert len(events) == 2 * N
+    # seq is unique and gap-free (query returns in seq order).
+    # ts is monotonic across the combined log.
+    prev_ts: datetime | None = None
+    for e in events:
+        if prev_ts is not None:
+            assert e.ts >= prev_ts, f"ts not monotonic: {prev_ts} -> {e.ts}"
+        prev_ts = e.ts
 
 
 # ---------- schema migration ------------------------------------------


### PR DESCRIPTION
## Summary

SQLite WAL-backed journal engine implementing the EventEntry invariants from #165.

Replaces PR #166 which was auto-closed when its base branch (feat/journal-spec) was deleted during the #165 merge.

## What ships

- `Journal` + `JournalBackend` protocol + `SQLiteJournalBackend` implementation
- Atomic `seq` assignment via `BEGIN IMMEDIATE` transaction (concurrent-writer safe)
- Monotonic ts check inside the transaction, with a 100ms race-tolerance policy documented in the append docstring
- Opportunistic hash-chain (optional in v1)
- Exception taxonomy in `exceptions.py`
- 21 engine tests, all green

## Test plan

- [x] Engine tests pass
- [x] Full suite unaffected
- [ ] Captain review