### PR TITLE
fix: match_scope containment + smart_recall trace (v0.3.1 polish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Bare `pip install soul-protocol` now produces a working `soul` CLI. The CLI's required dependencies (`click`, `rich`, `pyyaml`, `cryptography`) have moved from the `[engine]` extra into base `dependencies`, so `soul --help` no longer raises `ImportError` on a minimal install. The `[engine]` extra is kept as an empty backwards-compat alias so existing `pip install soul-protocol[engine]` pins continue to resolve. Fixes #157.
+- `match_scope` is now bidirectional containment: a caller with scope `org:sales:leads` matches a memory tagged `org:sales:*` (and vice versa). The previous asymmetric behaviour made bundled archetypes' core memories invisible to agents installed from them, since the glob-style `default_scope` on Arrow, Flash, Cyborg, and Analyst seeds into memory but the installed agent usually presents a narrower concrete caller scope. The strict one-way variant is preserved as `match_scope_strict` for callers that need the old semantic.
 
 ---
 

--- a/src/soul_protocol/engine/journal/scope.py
+++ b/src/soul_protocol/engine/journal/scope.py
@@ -14,6 +14,16 @@
 # This is a placeholder until ``spec.scope`` from #162 lands; the final
 # grammar there is a superset of what we implement. Callers swap to the
 # richer helper when it ships — same name, same shape.
+#
+# v0.3.1 note (2026-04-14): `spec.scope.match_scope` now implements
+# hierarchical containment (a concrete scope matches its ancestor glob).
+# The journal's `scope_matches` stays with its stricter segment-count
+# grammar on purpose: it answers a different question. Here we ask "does
+# this event belong to the set of events the query pattern names", which
+# is a set-membership check where `org:sales` and `org:sales:leads` are
+# genuinely different sets. The router calls this helper twice
+# (both directions) to get the overlap it wants for fanout, so moving to
+# containment would change event fan-out semantics. Leaving as-is.
 
 from __future__ import annotations
 

--- a/src/soul_protocol/spec/scope.py
+++ b/src/soul_protocol/spec/scope.py
@@ -3,43 +3,101 @@
 # imports beyond stdlib. The same matcher is used by soul recall, fabric
 # queries, kb retrievals, and pocket visibility checks. Centralised here
 # so behaviour is identical across every retrieval path.
+# Updated: 2026-04-14 (v0.3.1 follow-up to #163) — match_scope is now
+# bidirectional containment. A concrete scope like `org:sales:leads`
+# matches a glob scope like `org:sales:*` (and vice versa), because the
+# former is a descendant of the latter. The old asymmetric behaviour made
+# bundled archetypes' core memories invisible to agents installed from
+# them — the template declares `default_scope: [org:sales:*]`, the agent
+# gets installed with a concrete caller scope like `org:sales:leads`, and
+# the call site used `match_scope(entity_scopes=memory.scope,
+# allowed_scopes=caller.scopes)` which returned False for the common
+# descendant-of-glob case. The strict one-directional helper is kept as
+# `match_scope_strict` for callers that need the old semantic.
 
 from __future__ import annotations
 
 
 def match_scope(entity_scopes: list[str] | None, allowed_scopes: list[str] | None) -> bool:
-    """Return True when at least one of ``entity_scopes`` is granted by
-    ``allowed_scopes`` (or when either side is empty).
+    """Return True when ``entity_scopes`` and ``allowed_scopes`` overlap
+    by hierarchical containment in either direction.
 
     Empty ``entity_scopes`` is treated as "no scope assigned" — visible
     to any caller. Empty ``allowed_scopes`` is treated as "caller has no
     scope filter" — sees everything. This matches the lean default that
     pre-scope memories continue to surface unchanged.
 
-    Hierarchical glob: ``"org:sales:*"`` matches ``"org:sales:leads"``
-    and ``"org:sales"`` itself. ``"*"`` matches anything. Comparison is
-    case-sensitive — scope tags are namespaced ASCII identifiers, not
-    free-form labels.
+    Bidirectional containment: a scope ``A`` is said to contain a scope
+    ``B`` when either they are equal, or ``A`` is a glob ``"<prefix>:*"``
+    and ``B`` equals ``<prefix>`` or starts with ``<prefix>:``. The match
+    returns True when at least one pair ``(entity, allowed)`` has one
+    side contain the other.
+
+    Examples:
+        >>> match_scope(["org:sales:leads"], ["org:sales:*"])   # descendant in glob
+        True
+        >>> match_scope(["org:sales:*"], ["org:sales:leads"])   # caller inside glob entity
+        True
+        >>> match_scope(["org:sales:*"], ["org:*"])             # glob nested under broader glob
+        True
+        >>> match_scope(["org:sales:leads"], ["org:support:*"]) # different subtree
+        False
+        >>> match_scope(["org:sales:leads"], ["org:sales:leads"])  # exact
+        True
+
+    Hierarchical glob syntax: ``"org:sales:*"`` matches any descendant
+    under ``org:sales`` and ``org:sales`` itself. ``"*"`` matches
+    anything. Comparison is case-sensitive — scope tags are namespaced
+    ASCII identifiers, not free-form labels.
     """
     if not entity_scopes:
         return True
     if not allowed_scopes:
         return True
     return any(
-        _granted(entity, allowed)
+        _contains(entity, allowed) or _contains(allowed, entity)
         for entity in entity_scopes
         for allowed in allowed_scopes
     )
 
 
-def _granted(entity: str, allowed: str) -> bool:
-    if allowed == "*":
+def match_scope_strict(
+    entity_scopes: list[str] | None, allowed_scopes: list[str] | None
+) -> bool:
+    """One-directional variant: the caller's ``allowed_scopes`` must
+    grant at least one ``entity_scope``.
+
+    Retained for callers that genuinely want the asymmetric semantic —
+    "is this memory's scope within what the caller is explicitly
+    allowed?". Most RBAC call sites want :func:`match_scope` instead, so
+    a caller with a narrow concrete scope can still see memories tagged
+    with a wider glob the caller sits inside.
+    """
+    if not entity_scopes:
         return True
-    if allowed == entity:
+    if not allowed_scopes:
         return True
-    if allowed.endswith(":*"):
-        prefix = allowed[:-2]
-        return entity == prefix or entity.startswith(prefix + ":")
+    return any(
+        _contains(allowed, entity)
+        for entity in entity_scopes
+        for allowed in allowed_scopes
+    )
+
+
+def _contains(outer: str, inner: str) -> bool:
+    """True when ``outer`` contains ``inner`` by hierarchical glob rules.
+
+    A ``*`` glob contains everything. A ``<prefix>:*`` glob contains
+    ``<prefix>`` itself and any ``<prefix>:...`` descendant. Equal
+    strings contain each other.
+    """
+    if outer == "*":
+        return True
+    if outer == inner:
+        return True
+    if outer.endswith(":*"):
+        prefix = outer[:-2]
+        return inner == prefix or inner.startswith(prefix + ":")
     return False
 
 

--- a/tests/test_bundled_templates.py
+++ b/tests/test_bundled_templates.py
@@ -161,6 +161,22 @@ class TestInstantiation:
         assert all(match_scope(e.scope, sales_admin) for e in entries)
         assert not any(match_scope(e.scope, hr_admin) for e in entries)
 
+    @pytest.mark.asyncio
+    async def test_arrow_core_memories_visible_to_concrete_sales_caller(self) -> None:
+        """v0.3.1 follow-up: a sales agent installed from Arrow with a
+        concrete caller scope (`org:sales:leads`) must still see the
+        template's core memories tagged with the glob `org:sales:*`.
+        Before the match_scope containment fix this returned no results."""
+        arrow = SoulFactory.load_bundled("arrow")
+        soul = await SoulFactory.from_template(arrow)
+
+        from soul_protocol.spec.scope import match_scope
+
+        entries = list(soul._memory._semantic._facts.values())
+        assert entries
+        concrete_caller = ["org:sales:leads"]
+        assert all(match_scope(e.scope, concrete_caller) for e in entries)
+
 
 # ---------------------------------------------------------------------------
 # Module helpers

--- a/tests/test_scope_tags.py
+++ b/tests/test_scope_tags.py
@@ -2,6 +2,9 @@
 
 Created: 2026-04-13 — Hierarchical RBAC/ABAC matching, MemoryEntry shape
 preservation across export/awaken, and Soul.recall scope-filter semantics.
+Updated: 2026-04-14 — match_scope is now bidirectional containment, so
+a caller scope that sits inside a memory's glob scope (and vice versa)
+matches. Tests cover both directions plus the strict one-way variant.
 """
 
 from __future__ import annotations
@@ -11,7 +14,7 @@ import pytest
 from soul_protocol import Soul
 from soul_protocol.runtime.types import MemoryType
 from soul_protocol.spec.memory import MemoryEntry
-from soul_protocol.spec.scope import match_scope, normalise_scopes
+from soul_protocol.spec.scope import match_scope, match_scope_strict, normalise_scopes
 
 # ---------------------------------------------------------------------------
 # match_scope
@@ -58,6 +61,52 @@ class TestMatchScope:
     def test_unknown_pattern_does_not_grant(self) -> None:
         # Patterns must be exact or end with `:*`; arbitrary substrings don't.
         assert not match_scope(["org:sales:leads"], ["sales"])
+
+    # ---- bidirectional containment (v0.3.1 follow-up to #163) ----------
+
+    def test_concrete_caller_matches_glob_entity(self) -> None:
+        """A caller with scope `org:sales:leads` sees memories tagged
+        `org:sales:*`. This is the bundled-archetype use case."""
+        assert match_scope(["org:sales:*"], ["org:sales:leads"])
+
+    def test_glob_entity_matches_broader_glob_caller(self) -> None:
+        """A broader-glob caller sees a nested-glob entity."""
+        assert match_scope(["org:sales:*"], ["org:*"])
+        assert match_scope(["org:*"], ["org:sales:*"])
+
+    def test_sibling_subtrees_do_not_match(self) -> None:
+        assert not match_scope(["org:sales:leads"], ["org:support:*"])
+        assert not match_scope(["org:sales:*"], ["org:support:leads"])
+
+    def test_star_caller_sees_everything(self) -> None:
+        assert match_scope(["org:anything:deep:here"], ["*"])
+        assert match_scope(["*"], ["org:anything:deep:here"])
+
+    def test_empty_edges(self) -> None:
+        # Either empty side → permissive pass-through.
+        assert match_scope([], [])
+        assert match_scope(None, None)
+        assert match_scope(["org:sales:*"], [])
+        assert match_scope([], ["org:sales:*"])
+
+
+class TestMatchScopeStrict:
+    """The one-directional variant preserves the pre-v0.3.1 behaviour for
+    callers that genuinely need `allowed_scopes` to contain `entity_scopes`."""
+
+    def test_asymmetric_direction(self) -> None:
+        # Caller's glob grants the memory's concrete scope.
+        assert match_scope_strict(["org:sales:leads"], ["org:sales:*"])
+        # Memory's glob is NOT granted by a narrower caller under the old rule.
+        assert not match_scope_strict(["org:sales:*"], ["org:sales:leads"])
+
+    def test_exact_and_star(self) -> None:
+        assert match_scope_strict(["org:sales:leads"], ["org:sales:leads"])
+        assert match_scope_strict(["org:sales:leads"], ["*"])
+
+    def test_empty_pass_through(self) -> None:
+        assert match_scope_strict([], ["org:sales:*"])
+        assert match_scope_strict(["org:sales:*"], [])
 
 
 class TestNormaliseScopes:


### PR DESCRIPTION
## What this changes

Two v0.3.1 polish fixes surfaced while prepping release PR #174.

### 1. `match_scope` bidirectional containment (on this branch)

`spec.scope.match_scope` used to be one-directional: the caller's `allowed_scopes` had to contain the memory's `entity_scopes`. That broke the bundled archetypes — Arrow, Flash, Cyborg, and Analyst declare glob `default_scope` values like `org:sales:*` that seed into every core memory, but a real agent installed from those templates usually presents a narrower concrete scope like `org:sales:leads`. The old matcher returned False for that pair, so the agent saw zero core memories on first recall.

The helper now treats a pair as matching when either side contains the other (equal, or one is a `prefix:*` glob that includes the other as a descendant). The strict one-way variant lives on as `match_scope_strict` for callers that genuinely want the old semantic.

The journal's own `scope_matches` stays as-is. It answers a different question (event set membership, not RBAC containment) and the retrieval router already calls it twice for the bidirectional overlap it wants. A note in `engine/journal/scope.py` records why.

### 2. `smart_recall` RetrievalTrace instrumentation (applied on the release branch)

`Soul.recall()` was wired up with a RetrievalTrace receipt in #161, but `Soul.smart_recall()` was not — #161 landed against dev, which predates the smart_recall feature from main. Dev still does not carry smart_recall, so the instrumentation has to land where smart_recall actually exists: the `chore/release-0.3.1` branch (which inherits smart_recall from main and cherry-picks v0.3.1 features). That commit will be added directly on the release branch during the rebase step for PR #174, since there is no sensible way to put it on `dev` without also porting smart_recall there.

## Why this matters for v0.3.1

Both are known-bug scenarios that bite first contact. The scope containment fix turns the bundled archetypes from "technically ship" into "actually usable on install", and the trace instrumentation closes a gap that would have shown up as `Soul.last_retrieval` unexpectedly going stale whenever a caller opted into `smart_recall`. Neither deserved to ride in a point release with them still broken.

## Tests

- Added descendant-matches-parent-glob, glob-nested-under-broader-glob, sibling-subtree-rejection, and empty-edge cases to `tests/test_scope_tags.py`.
- Added a dedicated `TestMatchScopeStrict` suite so the legacy semantic stays honest.
- Added an end-to-end integration test in `tests/test_bundled_templates.py` that loads Arrow, seeds core memories with `org:sales:*`, and asserts a concrete caller scope `org:sales:leads` sees them.
- Full dev suite green: 2046 passed locally (`--ignore=tests/test_cognitive_adapters.py --ignore=tests/test_mcp_sampling_engine.py`).

## Follow-up

After this merges to dev, I will rebase `chore/release-0.3.1` on dev, apply the smart_recall RetrievalTrace commit, force-push with `--force-with-lease`, and update release PR #174's `[0.3.1]` CHANGELOG section to cover both fixes.