### PR TITLE
docs: refresh README + docs for v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 <!-- README.md — soul-protocol open standard -->
-<!-- Updated: 2026-04-09 (v0.3.0) — bumped test count badge to 2105, noted the
+<!-- Updated: 2026-04-14 (v0.3.1) — bumped test count to 2297, added org-layer
+     pitch to the header, new "Org layer (v0.3.1)" feature block, v0.3.1
+     quick-start with `soul org init`, CLI count 38 → 44 commands (adds org,
+     template, user, create), pointers to org-journal-spec.md, org.md,
+     decision-traces.md, and manual-testing.md.
+     Updated: 2026-04-09 (v0.3.0) — bumped test count badge to 2105, noted the
      four v0.3.0 features in this header block: dream cycle (offline batch
      memory consolidation), smart recall (opt-in LLM reranking with prompt
      injection defense and timeout), significance short-circuit (skip expensive
@@ -12,17 +17,19 @@
 
 # Soul Protocol
 
-**Portable AI identity, memory, and emotion. An open standard.**
+**Portable AI identity, memory, and emotion -- plus an org-level journal and decision traces. An open standard.**
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests: 2105 passing](https://img.shields.io/badge/tests-2105%20passing-brightgreen)](https://github.com/qbtrix/soul-protocol)
+[![Tests: 2297 passing](https://img.shields.io/badge/tests-2297%20passing-brightgreen)](https://github.com/qbtrix/soul-protocol)
 
 ---
 
 AI memory systems optimize for retrieval: find the most similar text, stuff it into context, move on. They treat persistence as an IQ problem. But what makes a companion feel real isn't similarity search. It's knowing what matters, what to forget, and who it's becoming.
 
 Soul Protocol gives AI agents persistent identity with psychology-informed memory. Your agent remembers selectively, forms emotional bonds, develops skills, and maintains a personality that evolves over time. The entire state exports as a portable `.soul` file. Switch LLMs, switch platforms, keep the soul.
+
+As of v0.3.1, the protocol also covers the layer *above* a single soul: an org-scoped append-only event journal, a root governance agent, scope-tagged memory, decision traces (`agent.proposed` → `human.corrected` → `decision.graduated`), and a zero-copy retrieval router for federating external data without copying it into the org boundary.
 
 **[Read the whitepaper](WHITEPAPER.md)** for the full design rationale and empirical validation.
 
@@ -70,15 +77,19 @@ Full methodology: [research/EVAL-FRAMEWORK.md](research/EVAL-FRAMEWORK.md)
 
 ```
 soul_protocol/
-├── spec/      695 lines   The protocol. Portable, minimal, no opinions.
-├── runtime/  9,693 lines  Reference implementation. Opinionated, batteries-included.
-├── cli/                    38-command CLI
+├── spec/                   The protocol. Portable, minimal, no opinions.
+│                           Per-soul types + org-layer types (journal, decisions, retrieval).
+├── runtime/                Reference implementation. Opinionated, batteries-included.
+├── engine/                 Org-layer engine: SQLite WAL journal, retrieval router, credential broker.
+├── cli/                    44-command CLI (incl. `soul org`, `soul template`, `soul user`, `soul create`)
 └── mcp/                    MCP server (24 tools, 3 resources)
 ```
 
-**`spec/`** defines what any runtime must implement: Identity, MemoryStore, MemoryEntry, SoulContainer, `.soul` file format, EmbeddingProvider, EternalStorageProvider. Depends on Pydantic only.
+**`spec/`** defines what any runtime must implement: Identity, MemoryStore, MemoryEntry, SoulContainer, `.soul` file format, EmbeddingProvider, EternalStorageProvider. v0.3 added org-layer spec types (`EventEntry`, `Actor`, `DataRef`, `AgentProposal`, `HumanCorrection`, `DecisionGraduation`, `RetrievalRequest`/`Result`, `RetrievalTrace`). Depends on Pydantic only.
 
 **`runtime/`** is one way to run the protocol. OCEAN personality, five-tier memory, psychology pipeline, cognitive engine, bonds, skills, evolution. Other runtimes can implement `spec/` differently.
+
+**`engine/`** (new in v0.3.1) runs the org layer: a SQLite WAL-backed journal with atomic `seq` allocation, a retrieval router that resolves `DataRef` payloads against registered adapters, and a credential broker that scopes secrets per source and fails closed on denial. The full contract lives in [`docs/org-journal-spec.md`](docs/org-journal-spec.md).
 
 Like HTTP and nginx. The spec defines the contract. The runtime is one implementation.
 
@@ -108,7 +119,14 @@ Like HTTP and nginx. The spec defines the contract. The runtime is one implement
 | **Portability** | `.soul` ZIP archive. JSON inside. Rename to .zip and read it. |
 | **Cross-language** | JSON Schemas auto-generated from spec. Validate `.soul` files in any language. |
 | **Dream** | Offline batch consolidation — topic clustering, procedure detection, graph cleanup, personality drift |
-| **CLI** | 38 commands. Rich TUI output. |
+| **Org Journal** | Append-only event log with SQLite WAL backend, atomic `seq`, opportunistic hash-chain. `soul org init` bootstraps it. |
+| **Root Agent** | Governance identity with three-layer undeletability (file guard, protocol guard, CLI refusal). Signs; cannot execute. |
+| **Scope tags** | `MemoryEntry.scope` + `match_scope` helper. Bidirectional containment (`org:sales:*` matches `org:sales:leads`). |
+| **Decision traces** | `agent.proposed` → `human.corrected` → `decision.graduated` event chains linked by `causation_id`. |
+| **Zero-Copy federation** | `RetrievalRouter` + `CredentialBroker`. Resolves `DataRef` payloads against registered adapters; only the receipt crosses the boundary. |
+| **RetrievalTrace** | Every `recall()` and `smart_recall()` emits a trace (query, candidates, rerank decisions) on `Soul.last_retrieval`. |
+| **Role archetypes** | Bundled Arrow, Flash, Cyborg, Analyst templates. `soul template list` / `soul create --template arrow`. |
+| **CLI** | 44 commands. Rich TUI output. |
 | **MCP** | 24 tools + 3 resources for Claude Code, Cursor, or any MCP client |
 
 ---
@@ -116,14 +134,16 @@ Like HTTP and nginx. The spec defines the contract. The runtime is one implement
 ## Install
 
 ```bash
-pip install git+https://github.com/qbtrix/soul-protocol.git
+pip install soul-protocol
 ```
+
+As of v0.3.1 the bare install gives you a working `soul` CLI out of the box — no extras required. The `[engine]` extra is kept as an empty alias so older pins keep resolving (#173).
 
 Extras:
 
 | Extra | What it adds |
 |---|---|
-| `[engine]` | CLI, YAML config, Rich TUI, encryption |
+| `[engine]` | Empty backwards-compat alias. The base install already ships Click, Rich, PyYAML, and cryptography. |
 | `[mcp]` | MCP server (Claude Code, Cursor, any MCP client) |
 | `[anthropic]` | `AnthropicEngine` — Anthropic SDK cognitive adapter |
 | `[openai]` | `OpenAIEngine` — OpenAI SDK cognitive adapter |
@@ -217,6 +237,34 @@ communication:
   warmth: high
   verbosity: low
 persona: I am Aria, precise and efficient.
+```
+
+---
+
+## Quick start: bootstrap an org (v0.3.1)
+
+A single soul is great for a personal companion. For a team of agents that share a journal, scope grammar, and root signing key, bootstrap an org:
+
+```bash
+pip install soul-protocol
+soul org init --org-name "Acme" --purpose "AI tooling" --non-interactive
+soul org status
+```
+
+That creates `~/.soul/` with a root soul, Ed25519 signing keys, a SQLite WAL journal seeded with `org.created` + `scope.created` events, and an archive directory at `~/.soul-archives/`. Every subsequent action — memories, proposals, corrections, retrievals — writes into that journal. See [`docs/org.md`](docs/org.md) for the full flow.
+
+Instantiate a soul from a bundled role archetype:
+
+```bash
+soul template list                       # Arrow, Flash, Cyborg, Analyst
+soul create --template arrow --name Aria # new soul preconfigured with Arrow's DNA
+```
+
+Every recall now leaves a receipt:
+
+```python
+memories = await soul.recall("Python")
+trace = soul.last_retrieval  # RetrievalTrace: query, candidates, rerank decisions, final
 ```
 
 ---
@@ -326,7 +374,7 @@ Archive souls to decentralized storage (local, IPFS, Arweave, blockchain). Curre
 soul <command> [options]
 ```
 
-See [CLI Reference](docs/cli-reference.md) for all 37 commands. Highlights:
+See [CLI Reference](docs/cli-reference.md) for all 44 commands. Highlights:
 
 | Command | Description |
 |---|---|
@@ -345,6 +393,13 @@ See [CLI Reference](docs/cli-reference.md) for all 37 commands. Highlights:
 | `archive` | Archive to eternal storage tiers |
 | `recover` | Recover from eternal storage |
 | `eternal-status` | Show eternal storage references |
+| `dream` | Offline batch memory consolidation |
+| `org init` | Bootstrap an org (root soul, journal, scopes, fleet) |
+| `org status` | Snapshot the org from its journal |
+| `org destroy` | Archive-and-wipe the org directory |
+| `template list` / `show` | Browse bundled role archetypes (Arrow, Flash, Cyborg, Analyst) |
+| `create --template` | Instantiate a soul from an archetype |
+| `user invite` | Invite a user to the org (stub — real flow in a follow-up PR) |
 
 ---
 
@@ -355,7 +410,7 @@ pip install soul-protocol[mcp]
 SOUL_PATH=aria.soul soul-mcp
 ```
 
-23 tools and 3 resources for Claude Code, Cursor, or any MCP-compatible client. See [integrations](docs/integrations.md).
+24 tools and 3 resources for Claude Code, Cursor, or any MCP-compatible client. See [integrations](docs/integrations.md).
 
 ---
 
@@ -392,8 +447,12 @@ await soul.observe(Interaction(
 ## Documentation
 
 - [Whitepaper](WHITEPAPER.md) -- design rationale, psychology stack, empirical validation
-- [Architecture](docs/architecture.md) -- two-layer diagrams, module dependency graph
-- [Configuration](docs/configuration.md) -- OCEAN, communication style, config files
+- [Architecture](docs/architecture.md) -- two-layer diagrams, module dependency graph, org-layer implementation notes
+- [Org Journal Spec](docs/org-journal-spec.md) -- framework-agnostic protocol for the journal, root agent, and retrieval router
+- [Org Management](docs/org.md) -- `soul org init / status / destroy` walkthrough
+- [Decision Traces](docs/decision-traces.md) -- `agent.proposed` → `human.corrected` → `decision.graduated` chains
+- [Manual Testing](docs/manual-testing.md) -- hands-on validation for the org-layer primitives
+- [Configuration](docs/configuration.md) -- OCEAN, communication style, config files, env vars
 - [Self-Model](docs/self-model.md) -- Klein's self-concept, domain discovery
 - [Cognitive Engine](docs/cognitive-engine.md) -- LLM integration, heuristic fallback
 - [Memory Architecture](docs/memory-architecture.md) -- five tiers, activation, compression
@@ -410,7 +469,7 @@ await soul.observe(Interaction(
 git clone https://github.com/qbtrix/soul-protocol.git
 cd soul-protocol
 pip install -e ".[dev]"
-pytest tests/   # 2105 tests
+pytest tests/   # 2297 tests
 ```
 
 ---

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,4 +1,7 @@
-<!-- Covers: CLI installation, all 38 commands with usage examples, options tables, and output descriptions.
+<!-- Covers: CLI installation, all 44 commands with usage examples, options tables, and output descriptions.
+     Updated: 2026-04-14 — v0.3.1: Added `soul org` (init/status/destroy), `soul template` (list/show),
+       `soul user invite`, and `soul create --template` command sections. New "Environment Variables"
+       section documents SOUL_DATA_DIR, SOUL_USERS_DIR, SOUL_ARCHIVES_DIR resolution order. Count: 38 → 44.
      Updated: 2026-04-06 — Added `soul dream` command for offline batch memory consolidation.
      Updated: 2026-03-27 — v0.2.8: Added archive, recover, and eternal-status command documentation.
      Updated: 2026-03-26 — v0.2.7: Added 3 maintenance commands (health, cleanup, repair).
@@ -11,7 +14,7 @@
 
 # CLI Reference
 
-Soul Protocol ships a command-line interface with 38 commands for creating, inspecting, exporting, and managing souls. Built on Click with Rich output formatting.
+Soul Protocol ships a command-line interface with 44 commands for creating, inspecting, exporting, and managing souls — plus the org-layer commands added in v0.3.1 (`soul org`, `soul template`, `soul user`, `soul create`). Built on Click with Rich output formatting.
 
 ## Installation
 
@@ -978,6 +981,147 @@ soul context --describe
 | `--max-tokens INT` | Token budget (with `--assemble`). |
 | `--grep PATTERN` | Search context history by regex pattern. |
 | `--describe` | Show context store metadata (message count, tokens, date range). |
+
+---
+
+## Org Layer (v0.3.1)
+
+The `soul org`, `soul template`, `soul user`, and `soul create` command groups ship in v0.3.1. See also [Org Management](org.md) for the bootstrap walkthrough and [Org Journal Spec](org-journal-spec.md) for the wire-level contract.
+
+### `soul org init`
+
+Bootstrap an empty directory into a working org. Creates a root governance soul, generates an Ed25519 signing keypair, opens a SQLite WAL journal, and writes the genesis events (`org.created`, one `scope.created` per first-level scope). Optionally seeds a starter fleet.
+
+```bash
+soul org init --org-name "Acme" --purpose "AI tooling" --non-interactive
+soul org init --org-name "Acme" --values "audit,velocity,kindness" \
+  --founder-name "Pat" --founder-email "pat@acme.com" \
+  --scopes "org:sales,org:ops" --fleet sales --non-interactive
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--org-name TEXT` | | Organization name. Required in `--non-interactive` mode. |
+| `--purpose TEXT` | | Mission statement. Lands in the root soul's persona. |
+| `--values TEXT` | | Comma-separated org values (3-5 recommended). |
+| `--founder-name TEXT` | | Founder's display name. |
+| `--founder-email TEXT` | | Founder's email. |
+| `--scopes TEXT` | | Comma-separated first-level scopes, e.g. `org:sales,org:ops`. |
+| `--fleet [sales\|support\|solo\|skip]` | `skip` | Starter fleet to seed. |
+| `--data-dir PATH` | `~/.soul/` | Where to create the org. Also honors `$SOUL_DATA_DIR`. |
+| `--users-dir PATH` | nested under `--data-dir` | Where founder user souls live. Also honors `$SOUL_USERS_DIR`. |
+| `--force` | off | Overwrite an existing non-empty data-dir. |
+| `--non-interactive` | off | Fail instead of prompting. Requires `--org-name`. |
+
+Re-running `init` against an initialized directory refuses to proceed unless `--force` is passed. Every step emits a journal event so the org state is reconstructable from the event log alone.
+
+---
+
+### `soul org status`
+
+Print a human-readable snapshot of an initialized org: DID, journal head, event count, data-dir location, root soul seal status. Read-only.
+
+```bash
+soul org status
+soul org status --data-dir /path/to/org
+soul org status --json
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--data-dir PATH` | Org dir to inspect. Defaults to `~/.soul/` or `$SOUL_DATA_DIR`. |
+| `--json` | Emit machine-readable JSON instead of a Rich panel. |
+
+---
+
+### `soul org destroy`
+
+Tarball the org to the archives dir, then wipe the data-dir. Terminal — there is no undo. Requires two explicit flags plus (in interactive mode) typing the org name at a prompt.
+
+```bash
+soul org destroy --confirm --i-mean-it
+soul org destroy --confirm --i-mean-it --non-interactive  # tests, scripted teardown
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--data-dir PATH` | `~/.soul/` | Org dir to destroy. Also honors `$SOUL_DATA_DIR`. |
+| `--archives-dir PATH` | `~/.soul-archives/` | Where the tarball lands. Sibling of the org dir by default, so the archive survives the wipe. Also honors `$SOUL_ARCHIVES_DIR`. |
+| `--confirm` | | Required guard rail. |
+| `--i-mean-it` | | Required guard rail (second one). |
+| `--non-interactive` | | Skip the typed-name prompt. |
+
+The destroy path writes the archive *first* and removes the data-dir only on success. If the archive write fails, the org is left intact.
+
+---
+
+### `soul template list`
+
+List every bundled role archetype. v0.3.1 ships Arrow, Flash, Cyborg, and Analyst — each with pre-baked DNA, communication style, and scope defaults.
+
+```bash
+soul template list
+```
+
+---
+
+### `soul template show`
+
+Print the raw YAML for a single bundled template. Useful for copying into your own overrides.
+
+```bash
+soul template show arrow
+```
+
+---
+
+### `soul create`
+
+Instantiate a new `.soul/` directory from a bundled template. Pairs with `soul template list` — pick a name, stamp it out.
+
+```bash
+soul create --template arrow
+soul create --template analyst --name Sage --dir .sage --format zip
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--template TEXT` | Required | Bundled template name (`arrow`, `flash`, `cyborg`, `analyst`). |
+| `--name TEXT` | template default | Override the soul's display name. |
+| `--dir TEXT` | `.soul` | Directory to write the new soul to. |
+| `--format [dir\|zip]` | `dir` | Write as an unpacked directory or a `.soul` zip archive. |
+
+---
+
+### `soul user invite`
+
+Placeholder for the org invite flow. Accepted today so hooks can wire it up in advance; the real implementation lands in a follow-up PR. Prints a hint and exits non-zero so callers don't mistake it for a completed invite.
+
+```bash
+soul user invite pat@acme.com
+```
+
+---
+
+## Environment Variables
+
+The CLI resolves paths in this order: **explicit flag > environment variable > default**. All three variables are honored by `soul org init`, `soul org status`, `soul org destroy`, and any other command that touches the org data-dir.
+
+| Variable | Affects | Default | Description |
+|----------|---------|---------|-------------|
+| `SOUL_DATA_DIR` | `--data-dir` | `~/.soul/` | Root directory for the org: `root.soul`, `keys/`, `journal.db`. |
+| `SOUL_USERS_DIR` | `--users-dir` | nests under `--data-dir` (so `--data-dir /tmp/foo` yields `/tmp/foo/users/`); falls back to `~/.soul/users/` when neither is set | Where founder and invited user souls live. Pre-v0.3.1 this was hardcoded to `~/.soul/users/`, which silently polluted home directories during isolated demos and CI runs. |
+| `SOUL_ARCHIVES_DIR` | `--archives-dir` | `~/.soul-archives/` | Archive destination for `soul org destroy`. Sibling of the org dir so it survives the wipe. |
+
+These are also documented in [Configuration](configuration.md#environment-variables).
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,7 @@
 <!-- Covers: Soul configuration — birth parameters, OCEAN personality, communication style,
      biorhythms, persona, config files (YAML/JSON), CLI options, and examples.
+     Updated: 2026-04-14 — v0.3.1: Added Environment Variables section documenting
+     SOUL_DATA_DIR, SOUL_USERS_DIR, SOUL_ARCHIVES_DIR with resolution order.
      Updated: 2026-03-27 — v0.2.8: Fixed biorhythm defaults to always-on (all drain rates 0.0,
      auto_regen false). Updated companion soul example to note opt-in overrides. -->
 
@@ -398,6 +400,24 @@ persona: >
   get tired -- I get things done.
 ```
 
+
+## Environment Variables
+
+v0.3.1 introduced three environment variables that control where the org layer writes its files. They only matter if you're using `soul org init` / `soul org status` / `soul org destroy`; a solo `.soul/` directory created via `soul init` is not affected.
+
+Resolution order for each path is **explicit CLI flag > environment variable > default**. Passing `--data-dir /tmp/foo` always wins, even if `SOUL_DATA_DIR` is set to something else.
+
+| Variable | Corresponding flag | Default | What it controls |
+|----------|--------------------|---------|------------------|
+| `SOUL_DATA_DIR` | `--data-dir` | `~/.soul/` | Root of the org: `root.soul`, `keys/`, `journal.db`, and (by default) `users/`. |
+| `SOUL_USERS_DIR` | `--users-dir` | nested under `--data-dir` (so `--data-dir /tmp/foo` places users in `/tmp/foo/users/`); falls back to `~/.soul/users/` only when neither `--data-dir` nor `SOUL_USERS_DIR` is set | Where founder and invited user souls live. Override this when you want user souls on a separate volume or when an isolated demo shouldn't write to `~/.soul/users/`. |
+| `SOUL_ARCHIVES_DIR` | `--archives-dir` | `~/.soul-archives/` | Destination for `soul org destroy` tarballs. The default is a sibling of the org dir, so the archive survives the wipe that follows. |
+
+Pre-v0.3.1, `SOUL_USERS_DIR` didn't exist and the CLI always wrote user souls to `~/.soul/users/` regardless of `--data-dir`. That silently polluted home directories during CI runs and isolated demos. The new default nests user souls under whatever `--data-dir` points to, which is almost always what callers want.
+
+See also the CLI reference: [Environment Variables](cli-reference.md#environment-variables).
+
+---
 
 ## Configuration Survives Export
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -1,4 +1,6 @@
 <!-- Covers: Soul lifecycle, .soul file format, Identity and DID, OCEAN personality, DNA, state management, memory architecture overview, evolution system, CognitiveEngine overview, SearchStrategy overview.
+     Updated: 2026-04-14 — v0.3.1: Added "Org-Level Concepts" section covering the org journal,
+     root agent, scope tags, decision traces, and Zero-Copy federation. Per-soul concepts unchanged.
      Updated: 2026-03-27 — v0.2.8: Fixed biorhythms table (removed social_battery state field,
      added all config fields with correct always-on defaults). Updated observe() drain text. -->
 
@@ -334,3 +336,70 @@ soul = await Soul.birth(name="Aria", search_strategy=EmbeddingSearch())
 The default is `TokenOverlapStrategy`, which uses Jaccard token overlap (fraction of query tokens found in content). Replace it with embedding-based search for better recall on large memory stores.
 
 See [CognitiveEngine Guide](cognitive-engine.md) for full documentation on search strategies.
+
+
+## Org-Level Concepts (v0.3.1)
+
+Everything above describes a single soul. A soul can live on its own forever — a personal assistant doesn't need an org. But when multiple agents and humans share context, audit history, and access boundaries, the **org layer** provides the container.
+
+The per-soul concepts stay unchanged inside an org. What the org adds is a journal, a governance agent, a scope grammar, decision traces, and a way to reach external data without copying it into the boundary. The protocol-level contract lives in [Org Journal Spec](org-journal-spec.md); what follows is the conceptual overview.
+
+### Org Journal
+
+An append-only event log. One `EventEntry` per action, one monotonically-increasing `seq` across the whole org, an opportunistic sha256 hash-chain for tamper evidence. Backend: SQLite WAL, single file, atomic `seq` allocation inside `BEGIN IMMEDIATE`.
+
+Everything that happens inside an org — a scope created, a soul invited, a proposal raised, a correction applied, a retrieval resolved — becomes one or more events in this journal. The journal is the source of truth. A wiped-and-restored org is reconstructable from its events alone.
+
+Events carry:
+
+- `action` — namespaced string, e.g. `org.created`, `scope.created`, `agent.proposed`, `retrieval.resolved`.
+- `actor` — who did it: root, a user, or an agent.
+- `payload` — structured, typed, validated against the spec.
+- `causation_id` — optional pointer to the event that triggered this one. How decision traces are chained.
+
+### Root Agent
+
+The governance identity that sits above the org. One per org, born at `soul org init`, signs things but can't execute. Three-layer undeletability makes it structurally hard to remove by accident:
+
+1. **Storage level** — file-system guard on `root.soul`.
+2. **Protocol level** — the journal refuses events that would remove the root.
+3. **CLI level** — `soul org destroy` requires two flags plus a typed confirmation.
+
+The root's OCEAN is weighted toward conscientiousness and away from extraversion. It's designed to audit, not to chat.
+
+### Scope Tags
+
+Memories, events, and retrievals carry a **scope** — a colon-separated tag that locates them in the org hierarchy. The grammar is simple:
+
+```
+org:*
+org:sales:*
+org:sales:leads
+agent:arrow-42
+session:2026-04-14-a1b2
+```
+
+Scope matching is **bidirectional containment**: `org:sales:*` matches `org:sales:leads` and vice versa. The v0.3.0 strict helper (`match_scope_strict`) is preserved for callers who want one-way matching, but the default `match_scope` now does the obvious thing — a bundled archetype whose `default_scope` is `org:*` is visible to any agent installed from it without an extra config step.
+
+Scope tags land on `MemoryEntry.scope`. Recalls filter on them automatically.
+
+### Decision Traces
+
+Three chained event types that capture the full cycle of an agent suggesting something and a human reacting:
+
+1. `agent.proposed` — the agent emits a structured proposal with its alternatives, confidence, and the events it consulted.
+2. `human.corrected` — the human edits, accepts, rejects, or defers. Linked back via `causation_id`.
+3. `decision.graduated` — when a correction pattern recurs, it graduates into standing guidance the agent loads as memory.
+
+This is the protocol-level answer to "where does the human-in-the-loop leave a receipt?" See [Decision Traces](decision-traces.md) for the full model.
+
+### Zero-Copy Federation
+
+External data (Drive docs, Salesforce records, Slack threads) doesn't belong inside the org boundary. Copying it creates staleness, duplication, and permission drift. Zero-copy federation handles this differently:
+
+- A **`DataRef`** names a remote payload — source adapter id + opaque locator — without copying the data itself.
+- The **`RetrievalRouter`** resolves a `DataRef` against registered `SourceAdapter`s at query time. Routes can be `first`, `parallel`, or `sequential`.
+- The **`CredentialBroker`** scopes credentials per source and fails closed on denial, writing an audit event so every denied retrieval is traceable.
+- The router emits a **`RetrievalTrace`** (also attached to `Soul.last_retrieval` on every `recall()`) that records the query, the candidate set, the rerank decisions, and the final selection. Only the trace crosses the org boundary; the source data stays where it lives.
+
+The adapter contracts are in [Org Journal Spec](org-journal-spec.md). Concrete adapters for real systems live in each runtime's connector package, not in this repo — the protocol stays SDK-free.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,8 @@
 <!-- Covers: Installation, optional extras, soul init quickstart, soul inject, first soul walkthrough,
      observe() pipeline explanation, next steps.
+     Updated: 2026-04-14 — v0.3.1: Added "Option B: bootstrap a full org" section with
+       `soul org init`, noted that bare `pip install soul-protocol` now produces a working
+       CLI (#173), pointed next-steps at org-journal-spec.md and decision-traces.md.
      Updated: 2026-03-27 — v0.2.8: Fixed CLI command count (9 → 37), updated energy drain text
        to reflect always-on defaults, fixed example output (energy 96 → 100).
      Updated: 2026-03-24 — v0.2.5: Added LLM engine extras (anthropic, openai, ollama, litellm, llm),
@@ -18,7 +21,7 @@ Install the core package from PyPI:
 pip install soul-protocol
 ```
 
-The core package includes Pydantic models, YAML support, the Click CLI, Rich terminal output, and cryptographic identity (DID generation). No LLM dependencies required.
+The core package includes Pydantic models, YAML support, the Click CLI, Rich terminal output, and cryptographic identity (DID generation). No LLM dependencies required. As of v0.3.1 the bare install is enough to run the `soul` CLI; the `[engine]` extra is kept as an empty alias so older pins keep resolving (#173).
 
 ### Optional Extras
 
@@ -56,7 +59,17 @@ pip install soul-protocol[mcp,graph,anthropic]
 **Python version**: Requires Python 3.11 or later.
 
 
-## Quick Start: `soul init`
+## Quick Start: two paths
+
+Soul Protocol covers two levels. Pick the one that matches what you're building.
+
+- **Option A — create a solo soul.** One `.soul` folder for one agent. Right for a personal assistant, a roleplay character, or anything that doesn't need multi-agent governance.
+- **Option B — bootstrap a full org.** An event journal, a root signing key, scope grammar, and optional starter fleet. Right for a team of agents that share audit history and access boundaries.
+
+You can start with A and graduate to B later — an org journal can absorb existing souls. Nothing in a solo `.soul/` folder is lost by moving it into an org.
+
+
+## Option A: `soul init` (solo soul)
 
 The fastest way to start is the CLI. This creates a `.soul/` folder in your project -- like `.git/` for identity:
 
@@ -92,6 +105,45 @@ To export your `.soul/` folder as a portable archive:
 ```bash
 soul export .soul/ -o aria.soul
 ```
+
+
+## Option B: `soul org init` (full org)
+
+If you're wiring up a team of agents that need to share a journal, scope grammar, and root signing key, bootstrap an org instead. This lands in `~/.soul/` by default (override with `--data-dir` or `$SOUL_DATA_DIR`):
+
+```bash
+soul org init \
+  --org-name "Acme" \
+  --purpose "AI tooling" \
+  --values "audit,velocity,kindness" \
+  --founder-name "Pat" --founder-email "pat@acme.com" \
+  --scopes "org:sales,org:ops" \
+  --fleet sales \
+  --non-interactive
+```
+
+What that produces:
+
+- `~/.soul/root.soul` — the governance soul, weighted toward conscientiousness. It signs; it doesn't execute.
+- `~/.soul/keys/` — Ed25519 private/public keys and the root DID.
+- `~/.soul/journal.db` — SQLite WAL journal, pre-seeded with `org.created` + one `scope.created` per first-level scope.
+- Founder user soul under `--users-dir` (defaults to `~/.soul/users/`, overridable via `$SOUL_USERS_DIR`).
+- Starter fleet (`sales`, `support`, or `solo`) if `--fleet` was passed.
+
+Inspect it:
+
+```bash
+soul org status
+soul org status --json   # machine-readable snapshot
+```
+
+Tear it down (archived to `~/.soul-archives/` before the wipe, so an accidental `destroy` is recoverable):
+
+```bash
+soul org destroy --confirm --i-mean-it
+```
+
+For the full journal contract, scope grammar, and decision-trace event chain see [Org Journal Spec](org-journal-spec.md), [Org Management](org.md), and [Decision Traces](decision-traces.md). Step-by-step walkthroughs for each primitive are in [Manual Testing](manual-testing.md).
 
 
 ## Quick Start: Wire Up an LLM
@@ -279,8 +331,11 @@ See the [CognitiveEngine Guide](cognitive-engine.md) for details.
 - **[API Reference](api-reference.md)** -- Complete Soul class API, all types and models
 - **[MCP Server](mcp-server.md)** -- FastMCP server for agent integration
 - **[Integrations](integrations.md)** -- Give Claude Code, Cursor, or any agent a `.soul`
-- **[CLI Reference](cli-reference.md)** -- All 37 commands including `soul inject` for fast agent integration
-- **[Org management](org.md)** -- Bootstrap a governance journal for a team of souls with `soul org init`
+- **[CLI Reference](cli-reference.md)** -- All 44 commands including `soul org`, `soul template`, `soul create`, `soul inject`
+- **[Org Management](org.md)** -- Bootstrap a governance journal for a team of souls with `soul org init`
+- **[Org Journal Spec](org-journal-spec.md)** -- Framework-agnostic protocol: journal wire format, scope grammar, retrieval router, credential broker
+- **[Decision Traces](decision-traces.md)** -- `agent.proposed` → `human.corrected` → `decision.graduated` event chains
+- **[Manual Testing](manual-testing.md)** -- Hands-on walkthrough for every org-layer primitive
 
 ### What's new in v0.3.1
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,6 @@
 <!-- Covers: Documentation index, quick links to all guides (including integrations), version info, project links -->
+<!-- Updated: 2026-04-14 — v0.3.1: added org-journal-spec, org, decision-traces,
+     manual-testing entries; bumped Current release to 0.3.1. -->
 <!-- Updated: 2026-03-13 — added Tier 1.5 soul inject guide link -->
 
 # Soul Protocol Documentation
@@ -12,16 +14,21 @@ A soul remembers. A soul grows. A soul migrates.
 
 | Guide | Description |
 |-------|-------------|
-| [Getting Started](getting-started.md) | Installation, first soul, quick walkthrough |
-| [Core Concepts](core-concepts.md) | Soul lifecycle, .soul format, identity, OCEAN personality, state, evolution |
+| [Getting Started](getting-started.md) | Installation, first soul, solo vs. org bootstrap, quick walkthrough |
+| [Core Concepts](core-concepts.md) | Soul lifecycle, .soul format, identity, OCEAN personality, state, evolution, org-level concepts |
 | [Memory Architecture](memory-architecture.md) | 5-tier memory, psychology pipeline, ACT-R decay, LIDA gating, somatic markers |
 | [CognitiveEngine Guide](cognitive-engine.md) | Plug in any LLM, SearchStrategy, prompt templates |
 | [API Reference](api-reference.md) | Complete Soul class API, all types and models |
 | [MCP Server](mcp-server.md) | FastMCP server for agent integration -- tools, resources, prompts |
 | [Integrations](integrations.md) | Claude Code, Cursor, custom agents -- give any agent a .soul |
 | [Soul Inject Guide](guide-soul-inject.md) | Tier 1.5 integration -- inject soul context into agent platform configs with a single CLI command |
-| [CLI Reference](cli-reference.md) | Command-line interface for soul management |
-| [Architecture](architecture.md) | Design philosophy, psychology stack, module structure |
+| [CLI Reference](cli-reference.md) | Command-line interface for soul management, including `soul org` / `soul template` / `soul create` |
+| [Configuration](configuration.md) | Birth parameters, OCEAN, communication style, biorhythms, env vars |
+| [Architecture](architecture.md) | Design philosophy, psychology stack, module structure, org-layer implementation notes |
+| [Org Management](org.md) | `soul org init / status / destroy` walkthrough |
+| [Org Journal Spec](org-journal-spec.md) | Framework-agnostic protocol: journal, root agent, retrieval router, credential broker |
+| [Decision Traces](decision-traces.md) | `agent.proposed` → `human.corrected` → `decision.graduated` event chains |
+| [Manual Testing](manual-testing.md) | Hands-on validation for the v0.3 org-layer primitives |
 
 
 ## At a Glance
@@ -46,7 +53,7 @@ await soul.export("aria.soul")
 
 ## Version
 
-Current release: **v0.2.3**
+Current release: **v0.3.1**
 
 Requires Python 3.11+.
 

--- a/docs/org.md
+++ b/docs/org.md
@@ -1,9 +1,11 @@
 <!-- Covers: Org management — `soul org init|status|destroy` commands, what they create,
      where the files live, and how idempotency works.
+     Updated: 2026-04-14 — v0.3.1: flag list brought in line with the actually-shipped CLI
+     (adds --values, --founder-name, --founder-email, --scopes, --fleet, --users-dir).
+     Corrected archives-dir default to ~/.soul-archives/ (was incorrectly ~/.soul/archives/).
+     Corrected destroy flags: --confirm + --i-mean-it (removed the --non-interactive --yes variant).
      Updated: feat/paw-os-init — file renamed from paw-os.md to org.md; content
-     rewritten for the `soul org` CLI + `~/.soul/` default path. Add an `install-fleet`
-     stub under Next so readers know the fleet command is coming without pretending it
-     already exists. -->
+     rewritten for the `soul org` CLI + `~/.soul/` default path. -->
 
 # Org Management
 
@@ -17,15 +19,33 @@ Bootstraps an empty directory into a working org. Births a governance soul, gene
 soul org init --org-name "Acme Ventures" --purpose "A software company"
 ```
 
+Full form, seeding values, a founder, scopes, and a starter fleet:
+
+```bash
+soul org init \
+  --org-name "Acme" \
+  --purpose "AI tooling" \
+  --values "audit,velocity,kindness" \
+  --founder-name "Pat" --founder-email "pat@acme.com" \
+  --scopes "org:sales,org:ops" \
+  --fleet sales \
+  --non-interactive
+```
+
 Flags:
 
 - `--org-name TEXT` — the organization's name. Required; prompted if omitted.
 - `--purpose TEXT` — optional mission statement that lands in the root soul persona.
+- `--values TEXT` — comma-separated org values (3-5 recommended). Written into the root soul and emitted as a journal event.
+- `--founder-name TEXT` / `--founder-email TEXT` — founder user details. When set, a user soul is created and added to the org.
+- `--scopes TEXT` — comma-separated first-level scopes (e.g. `org:sales,org:ops`). Each becomes a `scope.created` event.
+- `--fleet [sales|support|solo|skip]` — starter fleet to seed. `skip` creates no agents.
 - `--data-dir PATH` — where to put the org. Defaults to `~/.soul/` (override with `$SOUL_DATA_DIR`).
+- `--users-dir PATH` — where founder user souls live. Defaults to nesting under `--data-dir` (override with `$SOUL_USERS_DIR`).
 - `--force` — overwrite an existing non-empty `--data-dir`. Without it the command refuses.
 - `--non-interactive` — never prompt. Requires `--org-name` to be set.
 
-Re-running `init` against an initialized directory is a no-op unless `--force` is passed. The command is idempotent by design so a half-finished setup can be re-run safely.
+Every step emits one or more journal events so the final org state is fully reconstructable from the event log. Re-running `init` against an initialized directory refuses unless `--force` is passed.
 
 ## What gets created
 
@@ -55,6 +75,7 @@ Prints a human-readable summary of an initialized org: DID, journal head, event 
 ```bash
 soul org status
 soul org status --data-dir /path/to/org
+soul org status --json
 ```
 
 ## `soul org destroy`
@@ -68,11 +89,12 @@ soul org destroy --confirm --i-mean-it
 Flags:
 
 - `--confirm` / `--i-mean-it` — both required before anything is touched.
-- `--archives-dir PATH` — where the archive lands. Defaults to `<data-dir>/archives/`.
-- `--non-interactive --yes` — skip the interactive prompts; intended for tests and scripted teardown.
+- `--data-dir PATH` — org dir to destroy. Defaults to `~/.soul/` (override with `$SOUL_DATA_DIR`).
+- `--archives-dir PATH` — where the archive lands. Defaults to `~/.soul-archives/` (a sibling of the org dir, so the archive survives the wipe). Override with `$SOUL_ARCHIVES_DIR`.
+- `--non-interactive` — skip the typed-name prompt; intended for tests and scripted teardown.
 
-The destroy path writes the archive first and only then removes the data-dir. If the archive write fails, the org is left intact.
+In interactive mode, the CLI also asks you to type the org name at a prompt before proceeding. The destroy path writes the archive first and only then removes the data-dir. If the archive write fails, the org is left intact.
 
 ## Next
 
-The fleet install (`soul org install-fleet <template>`) is the next step on the roadmap: it spawns a starter team attached to an initialized org. It is not yet implemented — until it ships, the org is ready to accept journal appends from whatever tooling you point at `journal.db`.
+Starter fleets land today through `soul org init --fleet <sales|support|solo>`. A standalone `soul org install-fleet` that attaches a fleet to an already-initialized org is next on the roadmap — until it ships, spin up fleets by passing `--fleet` at init time, or append them by hand to `journal.db` via the Journal API. Real user invites (`soul user invite`) are a placeholder today; the full flow ships in a follow-up PR.


### PR DESCRIPTION
## Why

v0.3.1 shipped to PyPI on 2026-04-14 and it's the biggest release since the initial public launch: an org layer, `soul org` CLI, decision traces, Zero-Copy retrieval router, scope tags, RetrievalTrace on every recall, and bundled role archetypes. Most of the reader-facing docs were still written against v0.3.0, so a new visitor landing on the README or `docs/getting-started.md` couldn't discover any of it. This PR closes that gap. No code changes.

## What changed

| File | What's new |
|------|-----------|
| `README.md` | Header picks up the org-layer pitch. Quick-start gains a `soul org init` section next to the existing solo-soul walkthrough. Features table adds Org Journal / Root Agent / scope tags / decision traces / Zero-Copy / RetrievalTrace / role archetypes. CLI count 38 → 44, test count 2105 → 2297, bare `pip install soul-protocol` noted as working (#173). |
| `docs/getting-started.md` | Split into Option A (solo soul) vs Option B (full org). Option B walks through `soul org init` end-to-end. Next-steps points at `org-journal-spec.md`, `decision-traces.md`, `manual-testing.md`. |
| `docs/cli-reference.md` | New sections for `soul org init / status / destroy`, `soul template list / show`, `soul create --template`, `soul user invite`. New Environment Variables section for `SOUL_DATA_DIR`, `SOUL_USERS_DIR`, `SOUL_ARCHIVES_DIR` with resolution order. |
| `docs/configuration.md` | Mirrors the env vars section with more detail on pre-v0.3.1 `SOUL_USERS_DIR` behavior and why the nested default is safer for isolated demos. |
| `docs/core-concepts.md` | Adds an Org-Level Concepts section (journal, root agent, scope tags, decision traces, Zero-Copy federation) alongside the existing per-soul concepts. Nothing existing was removed. |
| `docs/index.md` | TOC adds `org.md`, `org-journal-spec.md`, `decision-traces.md`, `manual-testing.md`, `configuration.md`. Current release bumped 0.2.3 → 0.3.1. |
| `docs/org.md` | Flag list brought in line with the shipped CLI (adds `--values`, `--founder-name`, `--founder-email`, `--scopes`, `--fleet`, `--users-dir`). Fixes stale archives-dir default (was `<data-dir>/archives/`, actually `~/.soul-archives/`) and the destroy flag list. Replaces the install-fleet placeholder since fleet seeds via `--fleet` on init today. |

## Corrections to previously-wrong claims

The earlier `docs/org.md` claimed `soul org destroy --archives-dir` defaults to `<data-dir>/archives/` and that the `--non-interactive --yes` flag combo skips prompts. Both were wrong — the real defaults are `~/.soul-archives/` (a sibling) and the CLI takes `--non-interactive` on its own (no `--yes`). Fixed.

The README claimed 38 CLI commands; v0.3.1 ships 44 (adds `org`, `template`, `user`, `create`). Updated.

## Diff size

Roughly 410 insertions across 7 files, all Markdown. Well inside the 300-600 line target.

## Not in scope

- No new doc files were added. `docs/org-journal-spec.md`, `docs/decision-traces.md`, and `docs/manual-testing.md` already exist; this PR just wires the rest of the docs to them.
- `docs/manual-testing.md` still references the old `soul paw os` command names and `~/.pocketpaw/` data directory (it was frozen at the state of the v0.3 stack pre-rename). A separate PR can swap those to `soul org` and `~/.soul/` now that the CLI has been renamed for real.
- The `soul user invite` command is a stub today. When the real flow ships, `cli-reference.md` and `org.md` will both need an update.

## Test plan

- [ ] `grep -E 'docs/[a-z-]+\.md' README.md docs/*.md` returns only paths that resolve (already verified — every `docs/*.md` link exists)
- [ ] README renders cleanly on GitHub (check the Features table and v0.3.1 quick-start section)
- [ ] `docs/getting-started.md` Option A and Option B flows each stand alone (no broken forward references)
- [ ] `soul --help` output matches the 44 commands listed in README and `cli-reference.md` table of contents