### PR TITLE
feat(cli): backup-before-cleanup safety net, dry-run by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Safety net for destructive CLI commands** — `soul cleanup` and `soul forget` are now dry-run by default and require an explicit `--apply` flag to execute. Before any destructive save, a side-by-side `.soul.bak` backup is written next to the soul file so an accidental `--auto` run is recoverable with a single `cp`. The prior behavior where `soul cleanup --auto` silently deleted hundreds of memories is gone. (#148)
+
+### Changed
+
+- `soul cleanup --auto` no longer executes on its own — it now means "skip the confirmation prompt, assuming `--apply` is also passed." Running `--auto` without `--apply` is a no-op preview. Update any scripts that relied on the old one-flag behavior.
+- `soul forget` gains an `--apply` flag with the same semantics: dry-run by default, `--apply --confirm` to execute non-interactively.
+
 ---
 
 ## [0.3.2] -- unreleased

--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -1836,34 +1836,40 @@ def prompt_cmd(path):
 @click.option("--entity", type=str, default=None, help="Delete by entity name instead of query")
 @click.option("--before", type=str, default=None, help="Delete before ISO timestamp")
 @click.option(
-    "--confirm", "skip_confirm", is_flag=True, default=False, help="Skip confirmation prompt"
+    "--apply",
+    "apply_changes",
+    is_flag=True,
+    help="Actually execute the deletion. Without this flag, forget is a preview only.",
 )
-def forget_cmd(path, query, entity, before, skip_confirm):
+@click.option(
+    "--confirm",
+    "skip_confirm",
+    is_flag=True,
+    default=False,
+    help="Skip confirmation prompt (requires --apply)",
+)
+def forget_cmd(path, query, entity, before, apply_changes, skip_confirm):
     """Delete memories by query, entity, or timestamp (GDPR-compliant).
 
-    Searches and deletes matching memories across all tiers. Records
-    a deletion audit entry without storing deleted content.
+    Dry-run by default — shows what would be deleted without touching the
+    soul. Pass --apply to actually execute. A .soul.bak backup is written
+    before any destructive save.
 
     \b
     Examples:
-      soul forget .soul/ "credit card"
-      soul forget aria.soul --entity "John Doe"
-      soul forget .soul/ --before 2026-01-01T00:00:00 --confirm
+      soul forget .soul/ "credit card"                      # preview
+      soul forget .soul/ "credit card" --apply              # prompt + delete
+      soul forget aria.soul --entity "John Doe" --apply --confirm
     """
 
     async def _forget():
         from soul_protocol.runtime.soul import Soul
 
         soul = await Soul.awaken(path)
+        timestamp = None
 
         if entity:
             description = f"entity '{entity}'"
-            if not skip_confirm and not click.confirm(
-                f"Delete all memories related to {description}?"
-            ):
-                console.print("[dim]Cancelled.[/dim]")
-                return
-            result = await soul.forget_entity(entity)
         elif before:
             from datetime import datetime as dt
 
@@ -1873,21 +1879,50 @@ def forget_cmd(path, query, entity, before, skip_confirm):
                 console.print(f"[red]Invalid ISO timestamp:[/red] '{before}'")
                 raise SystemExit(1)
             description = f"memories before {before}"
-            if not skip_confirm and not click.confirm(f"Delete all {description}?"):
-                console.print("[dim]Cancelled.[/dim]")
-                return
-            result = await soul.forget_before(timestamp)
         elif query:
             description = f"query '{query}'"
-            if not skip_confirm and not click.confirm(f"Delete memories matching {description}?"):
-                console.print("[dim]Cancelled.[/dim]")
-                return
-            result = await soul.forget(query)
         else:
             console.print("[red]Provide a QUERY, --entity, or --before[/red]")
             raise SystemExit(1)
 
+        async def _execute_forget() -> dict:
+            if entity:
+                return await soul.forget_entity(entity)
+            if timestamp is not None:
+                return await soul.forget_before(timestamp)
+            return await soul.forget(query)
+
+        if not apply_changes:
+            # Preview mode — run forget against an in-memory soul and report
+            # what would have been deleted without saving.
+            result = await _execute_forget()
+            total = result.get("total_deleted", 0)
+            console.print(
+                f"[dim]Preview:[/dim] would forget "
+                f"{total} memor{'y' if total == 1 else 'ies'} "
+                f"from [bold]{soul.name}[/bold] ({description})"
+            )
+            if result.get("tiers"):
+                for tier, count in result["tiers"].items():
+                    if count > 0:
+                        console.print(f"  {tier}: {count}")
+            console.print(
+                "\n[dim]Pass --apply to execute "
+                "(a .soul.bak backup is written before any changes).[/]"
+            )
+            return
+
+        if not skip_confirm and not click.confirm(f"Delete memories matching {description}?"):
+            console.print("[dim]Cancelled.[/dim]")
+            return
+
+        result = await _execute_forget()
         total = result.get("total_deleted", 0)
+
+        # Back up before the destructive save.
+        from soul_protocol.runtime.backup import backup_soul_file
+
+        bak = backup_soul_file(path) if not Path(path).is_dir() else None
 
         # Save
         if Path(path).is_dir():
@@ -1895,10 +1930,13 @@ def forget_cmd(path, query, entity, before, skip_confirm):
         else:
             await soul.export(path)
 
-        console.print(
+        msg = (
             f"[yellow]Forgot[/yellow] {total} memor{'y' if total == 1 else 'ies'} "
             f"from [bold]{soul.name}[/bold] ({description})"
         )
+        if bak is not None:
+            msg += f" [dim](backup: {bak.name})[/dim]"
+        console.print(msg)
         if result.get("tiers"):
             for tier, count in result["tiers"].items():
                 if count > 0:
@@ -2523,9 +2561,19 @@ def health_cmd(path):
 
 @cli.command("cleanup")
 @click.argument("path", type=click.Path(exists=True))
-@click.option("--auto", "auto_mode", is_flag=True, help="Apply all cleanups without prompting.")
 @click.option(
-    "--dry-run", is_flag=True, help="Show what would be cleaned without changing anything."
+    "--apply",
+    "apply_changes",
+    is_flag=True,
+    help="Actually execute the cleanup. Without this flag, cleanup is a preview only.",
+)
+@click.option(
+    "--auto", "auto_mode", is_flag=True, help="Skip the confirmation prompt (requires --apply)."
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Preview only (the default). Kept for backward compatibility and explicit intent.",
 )
 @click.option("--dedup/--no-dedup", default=True, help="Remove near-duplicate memories.")
 @click.option(
@@ -2535,8 +2583,16 @@ def health_cmd(path):
 @click.option(
     "--low-importance", type=int, default=0, help="Remove memories with importance ≤ N (0=skip)."
 )
-def cleanup_cmd(path, auto_mode, dry_run, dedup, stale_evals, orphan_nodes, low_importance):
-    """Clean up a soul — remove duplicates, stale evals, orphan nodes."""
+def cleanup_cmd(
+    path, apply_changes, auto_mode, dry_run, dedup, stale_evals, orphan_nodes, low_importance
+):
+    """Clean up a soul — remove duplicates, stale evals, orphan nodes.
+
+    Dry-run by default — shows the plan without touching the soul. Pass
+    --apply to actually execute. Before any destructive write, a
+    side-by-side .soul.bak backup is created so an accidental cleanup
+    is recoverable.
+    """
 
     async def _cleanup():
         from soul_protocol.runtime.memory.compression import MemoryCompressor
@@ -2619,8 +2675,11 @@ def cleanup_cmd(path, auto_mode, dry_run, dedup, stale_evals, orphan_nodes, low_
 
         console.print(f"\n  [bold]Total: {total_removals} items to remove[/]")
 
-        if dry_run:
-            console.print("\n[dim]Dry run — no changes made.[/]")
+        if dry_run or not apply_changes:
+            console.print(
+                "\n[dim]Dry run — preview only. Pass --apply to execute "
+                "(a .soul.bak backup is written before any changes).[/]"
+            )
             return
 
         # Confirm
@@ -2646,9 +2705,16 @@ def cleanup_cmd(path, auto_mode, dry_run, dedup, stale_evals, orphan_nodes, low_
                         await mm._procedural.remove(mid)
                     removed += 1
 
-        # Save
+        # Back up before the destructive save so an accidental cleanup
+        # is recoverable via `cp <path>.bak <path>`.
+        from soul_protocol.runtime.backup import backup_soul_file
+
+        bak = backup_soul_file(path)
         await soul.export(path)
-        console.print(f"\n[green]✓ Cleaned {removed} items. Soul saved.[/]")
+        msg = f"\n[green]✓ Cleaned {removed} items. Soul saved.[/]"
+        if bak is not None:
+            msg += f" [dim](backup: {bak.name})[/dim]"
+        console.print(msg)
 
     asyncio.run(_cleanup())
 

--- a/src/soul_protocol/runtime/backup.py
+++ b/src/soul_protocol/runtime/backup.py
@@ -1,0 +1,30 @@
+# backup.py — Side-by-side backup helper for destructive soul mutations.
+# Created: feat/0.3.2-backup-safety-net — Writes <path>.bak before destructive
+#   writes in cleanup/forget/etc., so a single "soul cleanup --auto" can't
+#   silently wipe memory with no undo. Fixes #148.
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+def backup_soul_file(path: str | Path) -> Path | None:
+    """Copy a .soul file to `<path>.bak` before a destructive overwrite.
+
+    Returns the backup path on success, or None if no backup was made
+    (source missing, or source is a directory — unpacked form relies on
+    filesystem-level history like git until the in-zip snapshot feature
+    from #148 lands).
+
+    Any existing `.soul.bak` is overwritten — we keep exactly one
+    generation, which is enough to recover from "I ran cleanup by
+    accident." Multi-generation history is tracked in #148 as future
+    work.
+    """
+    src = Path(path)
+    if not src.exists() or src.is_dir():
+        return None
+    bak = src.with_suffix(src.suffix + ".bak")
+    shutil.copy2(src, bak)
+    return bak

--- a/tests/test_cli/test_cleanup_forget_safety.py
+++ b/tests/test_cli/test_cleanup_forget_safety.py
@@ -1,0 +1,204 @@
+# test_cleanup_forget_safety.py — Safety-net tests for cleanup and forget CLI commands.
+# Created: feat/0.3.2-backup-safety-net (#148) — Locks the new dry-run-by-default
+#   behavior, the --apply flag requirement, and the .soul.bak side-by-side backup
+#   that protects against accidental memory deletion.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from soul_protocol.cli.main import cli
+from soul_protocol.runtime.backup import backup_soul_file
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _birth_soul_at(path: str, name: str = "Safety") -> None:
+    runner = CliRunner()
+    runner.invoke(cli, ["birth", name, "-o", path])
+
+
+def _remember_twice(soul_path: str, text: str) -> None:
+    """Add the same memory twice so dedup has something to remove."""
+    runner = CliRunner()
+    runner.invoke(cli, ["remember", soul_path, text, "-i", "6"])
+    runner.invoke(cli, ["remember", soul_path, text, "-i", "6"])
+
+
+# ---------------------------------------------------------------------------
+# backup helper
+# ---------------------------------------------------------------------------
+
+
+class TestBackupHelper:
+    """Tests for runtime.backup.backup_soul_file()."""
+
+    def test_backup_creates_bak_file_next_to_source(self, tmp_path):
+        src = tmp_path / "echo.soul"
+        src.write_bytes(b"zipfile-contents")
+
+        bak = backup_soul_file(src)
+
+        assert bak is not None
+        assert bak == tmp_path / "echo.soul.bak"
+        assert bak.exists()
+        assert bak.read_bytes() == b"zipfile-contents"
+
+    def test_backup_overwrites_existing_bak(self, tmp_path):
+        src = tmp_path / "echo.soul"
+        bak = tmp_path / "echo.soul.bak"
+        src.write_bytes(b"new-contents")
+        bak.write_bytes(b"old-contents")
+
+        result = backup_soul_file(src)
+
+        assert result == bak
+        assert bak.read_bytes() == b"new-contents"
+
+    def test_backup_returns_none_when_source_missing(self, tmp_path):
+        result = backup_soul_file(tmp_path / "does-not-exist.soul")
+        assert result is None
+
+    def test_backup_returns_none_for_directories(self, tmp_path):
+        unpacked = tmp_path / "unpacked-soul"
+        unpacked.mkdir()
+
+        result = backup_soul_file(unpacked)
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# soul cleanup — dry-run default and --apply requirement
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupDryRunDefault:
+    """Without --apply, cleanup is a preview and leaves the soul untouched."""
+
+    def test_cleanup_without_apply_does_not_modify_file(self, tmp_path):
+        soul_path = str(tmp_path / "preview.soul")
+        _birth_soul_at(soul_path, "Preview")
+        _remember_twice(soul_path, "recurring fact about testing")
+
+        mtime_before = Path(soul_path).stat().st_mtime
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cleanup", soul_path])
+        mtime_after = Path(soul_path).stat().st_mtime
+
+        assert result.exit_code == 0, result.output
+        assert mtime_before == mtime_after, "cleanup without --apply must not write"
+
+    def test_cleanup_without_apply_tells_user_to_pass_apply(self, tmp_path):
+        soul_path = str(tmp_path / "hint.soul")
+        _birth_soul_at(soul_path, "Hint")
+        _remember_twice(soul_path, "another recurring fact")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cleanup", soul_path])
+
+        assert result.exit_code == 0, result.output
+        assert "--apply" in result.output or "Preview" in result.output
+
+    def test_cleanup_auto_without_apply_still_does_nothing(self, tmp_path):
+        """--auto alone must NOT trigger destructive execution — this is the
+        exact footgun that motivated #148."""
+        soul_path = str(tmp_path / "auto-only.soul")
+        _birth_soul_at(soul_path, "AutoOnly")
+        _remember_twice(soul_path, "don't lose me")
+
+        mtime_before = Path(soul_path).stat().st_mtime
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cleanup", "--auto", soul_path])
+        mtime_after = Path(soul_path).stat().st_mtime
+
+        assert result.exit_code == 0, result.output
+        assert mtime_before == mtime_after
+
+
+# ---------------------------------------------------------------------------
+# soul cleanup --apply — writes .soul.bak before saving
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupBackup:
+    def test_apply_creates_bak_file_when_changes_occur(self, tmp_path):
+        soul_path = tmp_path / "backup-me.soul"
+        _birth_soul_at(str(soul_path), "Backup")
+        _remember_twice(str(soul_path), "duplicate memory worth backing up")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cleanup", "--apply", "--auto", str(soul_path)])
+
+        assert result.exit_code == 0, result.output
+        bak = soul_path.with_suffix(".soul.bak")
+        assert bak.exists(), f"expected {bak} to exist after --apply"
+
+    def test_bak_contains_pre_cleanup_contents(self, tmp_path):
+        soul_path = tmp_path / "pre-state.soul"
+        _birth_soul_at(str(soul_path), "PreState")
+        _remember_twice(str(soul_path), "about to be deduped")
+
+        pre_bytes = soul_path.read_bytes()
+
+        runner = CliRunner()
+        runner.invoke(cli, ["cleanup", "--apply", "--auto", str(soul_path)])
+
+        bak = soul_path.with_suffix(".soul.bak")
+        assert bak.exists()
+        assert bak.read_bytes() == pre_bytes, "backup must hold the pre-cleanup zip"
+
+
+# ---------------------------------------------------------------------------
+# soul forget — dry-run default
+# ---------------------------------------------------------------------------
+
+
+class TestForgetDryRunDefault:
+    def test_forget_without_apply_does_not_modify_file(self, tmp_path):
+        soul_path = tmp_path / "forget-preview.soul"
+        _birth_soul_at(str(soul_path), "Forgetter")
+        runner = CliRunner()
+        runner.invoke(cli, ["remember", str(soul_path), "sensitive credit card info", "-i", "7"])
+
+        mtime_before = soul_path.stat().st_mtime
+        result = runner.invoke(cli, ["forget", str(soul_path), "credit card"])
+        mtime_after = soul_path.stat().st_mtime
+
+        assert result.exit_code == 0, result.output
+        assert mtime_before == mtime_after
+
+    def test_forget_without_apply_mentions_preview(self, tmp_path):
+        soul_path = tmp_path / "forget-hint.soul"
+        _birth_soul_at(str(soul_path), "ForgetHint")
+        runner = CliRunner()
+        runner.invoke(cli, ["remember", str(soul_path), "something to forget", "-i", "7"])
+
+        result = runner.invoke(cli, ["forget", str(soul_path), "forget"])
+
+        assert result.exit_code == 0, result.output
+        assert "Preview" in result.output or "--apply" in result.output
+
+
+class TestForgetBackup:
+    def test_forget_apply_writes_bak(self, tmp_path):
+        soul_path = tmp_path / "forget-backup.soul"
+        _birth_soul_at(str(soul_path), "ForgetBackup")
+        runner = CliRunner()
+        runner.invoke(cli, ["remember", str(soul_path), "will be forgotten", "-i", "7"])
+
+        pre_bytes = soul_path.read_bytes()
+
+        result = runner.invoke(
+            cli,
+            ["forget", str(soul_path), "forgotten", "--apply", "--confirm"],
+        )
+
+        assert result.exit_code == 0, result.output
+        bak = soul_path.with_suffix(".soul.bak")
+        assert bak.exists()
+        assert bak.read_bytes() == pre_bytes

--- a/tests/test_cli/test_health_cleanup_repair.py
+++ b/tests/test_cli/test_health_cleanup_repair.py
@@ -1,6 +1,8 @@
 # test_health_cleanup_repair.py — Tests for soul health, cleanup, and repair CLI commands.
 # Created: 2026-03-26 — Covers health_cmd (tier counts), cleanup_cmd (dry-run + auto),
 #   and repair_cmd (--reset-energy) added in the v0.2.7 maintenance commands batch.
+# Updated: feat/0.3.2-backup-safety-net (#148) — cleanup now requires --apply to
+#   execute; dry-run is the default. Existing --auto tests are paired with --apply.
 
 from __future__ import annotations
 
@@ -220,7 +222,7 @@ class TestCleanupAuto:
         _birth_soul_at(soul_path, "AutoClean")
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["cleanup", "--auto", soul_path])
+        result = runner.invoke(cli, ["cleanup", "--apply", "--auto", soul_path])
 
         assert result.exit_code == 0, result.output
 
@@ -239,7 +241,7 @@ class TestCleanupAuto:
         )
 
         # Run auto cleanup
-        result = runner.invoke(cli, ["cleanup", "--auto", soul_path])
+        result = runner.invoke(cli, ["cleanup", "--apply", "--auto", soul_path])
 
         assert result.exit_code == 0, result.output
         # Should confirm cleanup occurred — "Cleaned" in output, or "nothing to clean"
@@ -259,7 +261,7 @@ class TestCleanupAuto:
         runner.invoke(cli, ["remember", soul_path, "remember Python loves cats deeply", "-i", "5"])
         runner.invoke(cli, ["remember", soul_path, "remember Python loves cats deeply", "-i", "5"])
 
-        result = runner.invoke(cli, ["cleanup", "--auto", soul_path])
+        result = runner.invoke(cli, ["cleanup", "--apply", "--auto", soul_path])
 
         assert result.exit_code == 0, result.output
         # File should be updated if there was something to remove, otherwise unchanged
@@ -274,7 +276,9 @@ class TestCleanupAuto:
         # Add a low-importance memory
         runner.invoke(cli, ["remember", soul_path, "Minor note about nothing special", "-i", "1"])
 
-        result = runner.invoke(cli, ["cleanup", "--auto", "--low-importance", "2", soul_path])
+        result = runner.invoke(
+            cli, ["cleanup", "--apply", "--auto", "--low-importance", "2", soul_path]
+        )
 
         assert result.exit_code == 0, result.output
         # Should clean or report nothing found


### PR DESCRIPTION
Fixes #148. Part of #180 (0.3.2 release tracker).

## The problem

Running `soul cleanup --auto` silently deleted ~510 memories with no way to recover. The `--auto` flag meant "skip the confirmation prompt," but it also meant "actually execute the destructive change." One keystroke, no undo, the `.soul` file is gitignored by default, Time Machine wasn't covering it.

## What this changes

### 1. `.soul.bak` before every destructive save

A new helper at `src/soul_protocol/runtime/backup.py` writes a side-by-side `<path>.soul.bak` copy before `cleanup` or `forget` calls `export()`. Recovery is literally `cp my.soul.bak my.soul`. One generation is kept — enough to unwind "I ran cleanup by accident," not enough to bloat disk space.

Directory-form souls (unpacked `.soul/`) return None from the helper. Filesystem-level history (git, Time Machine) is the right tool there until the longer-term in-zip snapshot option from the issue lands.

### 2. `--apply` required on `cleanup` and `forget`

Both commands are now preview-by-default. Running `soul cleanup my.soul` shows exactly what would be removed and tells the user to pass `--apply` to execute. The old `--dry-run` flag still works as an explicit alias.

### 3. `--auto` is split from execution

Before: `--auto` meant "skip confirmation AND actually do it." After: `--auto` only means "skip confirmation, assuming `--apply` is also passed." Running `soul cleanup --auto` without `--apply` is a no-op preview — the exact footgun that motivated #148 is covered by an explicit test.

## Breaking changes

Scripts that rely on `soul cleanup --auto` doing a real cleanup will now be previews. Fix: pair them with `--apply`. Same for `soul forget --confirm`.

## Test evidence

```
$ uv run pytest tests/ -q --tb=no
2309 passed, 4 warnings in 104.81s

$ uv run ruff check .
All checks passed!
```

New test file: `tests/test_cli/test_cleanup_forget_safety.py` — 10 tests covering the backup helper, dry-run default, `--apply` requirement, and the backup-contents-match-pre-state invariant.

Updated tests: `tests/test_cli/test_health_cleanup_repair.py` — existing `--auto` cases now pass `--apply --auto`.

## CI note

This branch includes a lint-mirror commit (`3df8ba9`) that applies the same ruff auto-fixes already on PR #179. When either PR merges first, the rebase will drop that commit as a no-op. Keeps both PRs independently green regardless of merge order.

## Not included — queued for a later release

- Option A: embedded changelog of memory mutations inside the zip
- Option B: snapshot ring buffer inside the zip
- Option C: external `.soul.history` sibling file

The issue proposed these as longer-term options. `.soul.bak` is the "quick win" it explicitly asked for — one-generation recovery, zero zip-format changes, immediate safety.