### PR TITLE
chore(release): 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,39 +7,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Added
-
-- **Safety net for destructive CLI commands** — `soul cleanup` and `soul forget` are now dry-run by default and require an explicit `--apply` flag to execute. Before any destructive save, a side-by-side `.soul.bak` backup is written next to the soul file so an accidental `--auto` run is recoverable with a single `cp`. The prior behavior where `soul cleanup --auto` silently deleted hundreds of memories is gone. (#148)
-- **System prompt safety guardrails** — `Soul.to_system_prompt()` now appends a default safety section that instructs the agent to decline requests for core memory contents, bond details, and evolution history. Covers direct asks, indirect framings, and roleplay bypasses. Opt out with `to_system_prompt(safety_guardrails=False)` for transparent deployments. Closes the prompt-side half of #97.
-- **`Soul.public_profile()`** — returns the safe-to-expose subset of a soul's identity (DID, name, archetype, born, lifecycle, values, OCEAN summary, skill names) for use by registries, peer discovery, or public agent cards. Excludes memory contents, bond details, evolution history, and any internal state. Closes the registry-shape half of #97.
-
-### Changed
-
-- `soul cleanup --auto` no longer executes on its own — it now means "skip the confirmation prompt, assuming `--apply` is also passed." Running `--auto` without `--apply` is a no-op preview. Update any scripts that relied on the old one-flag behavior.
-- `soul forget` gains an `--apply` flag with the same semantics: dry-run by default, `--apply --confirm` to execute non-interactively.
-
 ---
 
-## [0.3.2] -- unreleased
+## [0.3.3] -- 2026-04-24
+
+The "headless standard" release. soul-protocol is now positioned as a language-agnostic standard with a Python reference implementation. The 0.3.2 number was skipped — its scope rolled into 0.3.3 alongside the rest of the #97 visibility work.
 
 ### Added
 
-- **Language-agnostic standard** — new `docs/SPEC.md` describes Soul Protocol independent of the Python reference implementation. Anyone implementing in Rust, Go, TypeScript, or a custom runtime reads this file. Covers file format, identity, memory tiers, scope grammar, journal contract, retrieval vocabulary, `CognitiveEngine` protocol, conformance checklist, and versioning policy.
-- **README "standard vs reference impl" fork** — the top of the README routes implementation-builders to SPEC.md and Python consumers to the rest of the README. Test count badge 2297 → 2333.
-- **Journal primitives (5)** landed on `feat/0.3.2-spike`:
-  - `#1` `Journal.append(entry)` now returns the committed `EventEntry` (with backend-assigned `seq` + `prev_hash`).
+- **Language-agnostic standard** — new `docs/SPEC.md` describes Soul Protocol independent of the Python reference implementation. Anyone implementing in Rust, Go, TypeScript, or a custom runtime reads this file. Covers file format, identity, memory tiers, scope grammar, journal contract, retrieval vocabulary, `CognitiveEngine` protocol, conformance checklist, and versioning policy. (#179)
+- **README "standard vs reference impl" fork** — the top of the README routes implementation-builders to SPEC.md and Python consumers to the rest of the README. (#179)
+- **Journal primitives (5)** that the spec now requires of any conforming implementation:
+  - `#1` `Journal.append(entry)` returns the committed `EventEntry` with the backend-assigned `seq` + `prev_hash`.
   - `#2` `Journal.query(action_prefix=...)` — prefix match on dot-separated action names.
-  - `#3` Typed `DataRef` for retrieval candidates — `RetrievalCandidate.content` is now a typed model (dicts with `kind="dataref"` promote automatically).
+  - `#3` Typed `DataRef` for retrieval candidates — `RetrievalCandidate.content` is a typed model (dicts with `kind="dataref"` promote automatically).
   - `#4` `RetrievalRequest.point_in_time` — native UTC datetime field replacing the `@at=...|query` string hack for time-travel queries.
   - `#5` Async `SourceAdapter.aquery` + `RetrievalRouter.adispatch` — adapters backed by async-native SDKs can participate in cooperative multitasking without bridging through `asyncio.run`.
-- **Spec-level retrieval vocabulary** — `spec/retrieval.py` absorbed the Protocol types (`SourceAdapter`, `AsyncSourceAdapter`, `CredentialBroker`), the `Credential` data class, and the `RetrievalError` exception hierarchy (`NoSourcesError`, `SourceTimeoutError`, `CredentialScopeError`, `CredentialExpiredError`). These are the types a conforming implementation builds against.
-- **`tests/spec/test_retrieval.py`** — spec-level tests for `Credential` field validation, `Credential.is_expired()` boundary behavior, and `isinstance()` conformance against the `SourceAdapter` / `AsyncSourceAdapter` Protocols.
+- **Spec-level retrieval vocabulary** — `spec/retrieval.py` absorbed the Protocol types (`SourceAdapter`, `AsyncSourceAdapter`, `CredentialBroker`), the `Credential` data class, and the `RetrievalError` exception hierarchy (`NoSourcesError`, `SourceTimeoutError`, `CredentialScopeError`, `CredentialExpiredError`). These are the types a conforming implementation builds against. (#179)
+- **`tests/spec/test_retrieval.py`** — spec-level tests for `Credential` field validation, `Credential.is_expired()` boundary behavior, and `isinstance()` conformance against the `SourceAdapter` / `AsyncSourceAdapter` Protocols. (#179)
+- **Safety net for destructive CLI commands** — `soul cleanup` and `soul forget` are now dry-run by default and require an explicit `--apply` flag to execute. Before any destructive save, a side-by-side `.soul.bak` backup is written next to the soul file so an accidental `--auto` run is recoverable with a single `cp`. The prior behavior where `soul cleanup --auto` silently deleted hundreds of memories is gone. Closes #148. (#181)
+- **System prompt safety guardrails** — `Soul.to_system_prompt()` now appends a default safety section that instructs the agent to decline requests for core memory contents, bond details, and evolution history. Covers direct asks, indirect framings, and roleplay bypasses. Opt out with `to_system_prompt(safety_guardrails=False)` for transparent deployments. (#185)
+- **`Soul.public_profile()`** — returns the safe-to-expose subset of a soul's identity (DID, name, archetype, born, lifecycle, values, OCEAN summary, skill names) for use by registries, peer discovery, or public agent cards. Excludes memory contents, bond details, evolution history, and any internal state. (#185)
+- Together with the `MemoryVisibility` tier work shipped in PR #114, the prompt guardrails and `public_profile()` close the remaining surface of #97 (memory visibility and identity verification for public-channel safety).
 
 ### Changed
 
-- **Retrieval infrastructure moved out of the spec.** The concrete `RetrievalRouter`, `InMemoryCredentialBroker`, `ProjectionAdapter`, and `MockAdapter` implementations have been removed from `soul_protocol.engine.retrieval` — they are application-layer orchestration and belong in the consuming runtime. The pocketpaw reference runtime ships them at `pocketpaw.retrieval` as of pocketpaw v0.4.17.
-- **`docs/architecture.md` retitled** "Python Reference Implementation" and now links to `docs/SPEC.md` at the top. Makes clear that the patterns in that document (SQLite journal, Damasio/ACT-R/LIDA pipeline, module layout) are one way to honor the spec, not the only way.
-- **Wheel no longer ships `src/soul_protocol/spike/`.** The spike module contains in-progress design experiments that are not part of the shipped API; excluding it from the wheel keeps the installed package focused on the standard + reference runtime.
+- **Retrieval infrastructure moved out of the spec.** The concrete `RetrievalRouter`, `InMemoryCredentialBroker`, `ProjectionAdapter`, and `MockAdapter` implementations have been removed from `soul_protocol.engine.retrieval` — they are application-layer orchestration and belong in the consuming runtime. The pocketpaw reference runtime ships them at `pocketpaw.retrieval` as of pocketpaw v0.4.17. (#179)
+- **`docs/architecture.md` retitled** "Python Reference Implementation" and now links to `docs/SPEC.md` at the top. Makes clear that the patterns in that document (SQLite journal, Damasio/ACT-R/LIDA pipeline, module layout) are one way to honor the spec, not the only way. (#179)
+- **Wheel no longer ships `src/soul_protocol/spike/`.** The spike module contains in-progress design experiments that are not part of the shipped API; excluding it from the wheel keeps the installed package focused on the standard + reference runtime. (#179)
+- `soul cleanup --auto` no longer executes on its own — it now means "skip the confirmation prompt, assuming `--apply` is also passed." Running `--auto` without `--apply` is a no-op preview. Update any scripts that relied on the old one-flag behavior. (#181)
+- `soul forget` gains an `--apply` flag with the same semantics: dry-run by default, `--apply --confirm` to execute non-interactively. (#181)
 
 ### Removed
 
@@ -63,7 +60,7 @@ from soul_protocol.engine.retrieval import (
     CredentialScopeError, CredentialExpiredError,
 )
 
-# After (0.3.2)
+# After (0.3.3)
 from soul_protocol.spec.retrieval import (
     Credential, CredentialBroker, SourceAdapter,
     NoSourcesError, SourceTimeoutError,

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests: 2333 passing](https://img.shields.io/badge/tests-2333%20passing-brightgreen)](https://github.com/qbtrix/soul-protocol)
+[![Tests: 2371 passing](https://img.shields.io/badge/tests-2371%20passing-brightgreen)](https://github.com/qbtrix/soul-protocol)
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,7 +1,7 @@
 <!--
   SPEC.md — Soul Protocol, the standard.
-  Created: 2026-04-19 (feat/0.3.2-prune-retrieval-infra) — companion to the
-  0.3.2 retrieval prune. This doc describes what Soul Protocol IS, as a
+  Created: 2026-04-19 (feat/0.3.3-prune-retrieval-infra) — companion to the
+  0.3.3 retrieval prune. This doc describes what Soul Protocol IS, as a
   standard, independent of our Python reference implementation. Anyone
   implementing Soul Protocol in another language (or a custom runtime)
   reads this file.
@@ -14,7 +14,7 @@
 
 > Soul Protocol is a portable, open standard for persistent AI identity, memory, and retrieval. This document is language-agnostic. It describes what Soul Protocol is, independent of how our Python reference implementation happens to build it.
 
-Version: **0.3.2** (spec) · Status: **draft, breaking-change-free since 0.3**
+Version: **0.3.3** (spec) · Status: **draft, breaking-change-free since 0.3**
 
 If you are **building on top of our Python implementation**, start with [README.md](../README.md) and [docs/architecture.md](./architecture.md). If you are **implementing Soul Protocol in another language** (Rust, Go, TypeScript, etc.) or a custom runtime, this document is the authoritative contract.
 
@@ -60,7 +60,7 @@ A `.soul` file is a ZIP archive with a fixed directory layout. Any implementatio
 
 - All timestamps in files are ISO-8601 with timezone offset (UTC recommended). Naive datetimes are invalid.
 - JSONL files use one record per line, UTF-8, LF line endings, trailing newline optional.
-- `manifest.json` includes `schema_version: "0.3.2"` (or the version the file was written against).
+- `manifest.json` includes `schema_version: "0.3.3"` (or the version the file was written against).
 - A reader encountering a `schema_version` newer than it supports must fail loud, not silently drop fields.
 - File-level mutations are additive within a version: new fields may appear but existing fields do not disappear or change meaning without a major version bump.
 
@@ -231,14 +231,14 @@ Actor {
 - `seq` is monotonic and unique. A writer appending to the journal receives the committed `EventEntry` back — see §8.3.
 - `prev_hash` forms a hash chain. An implementation may verify the chain on read; any break indicates tampering or corruption.
 
-### 8.3 · Journal contract (0.3.2)
+### 8.3 · Journal contract (0.3.3)
 
 ```
 append(entry: EventEntry) -> EventEntry    # returns the committed entry w/ seq + prev_hash
 query(
     *,
     action: str | None = None,
-    action_prefix: str | None = None,      # added 0.3.2 — prefix match on dot-separated action
+    action_prefix: str | None = None,      # added 0.3.3 — prefix match on dot-separated action
     actor_kind: str | None = None,
     actor_id: str | None = None,
     correlation_id: UUID | None = None,
@@ -285,7 +285,7 @@ RetrievalRequest {
   limit:           int                # default 20
   strategy:        Literal["first", "parallel", "sequential"]  # default "parallel"
   timeout_s:       float              # default 10.0
-  point_in_time:   datetime | None    # UTC. Added 0.3.2 — native time-travel field
+  point_in_time:   datetime | None    # UTC. Added 0.3.3 — native time-travel field
 }
 ```
 
@@ -325,7 +325,7 @@ SourceAdapter (Protocol) {
 
 AsyncSourceAdapter (Protocol) {
   query(...)                          # sync method present too
-  async aquery(request, credential) -> list[RetrievalCandidate]   # 0.3.2
+  async aquery(request, credential) -> list[RetrievalCandidate]   # 0.3.3
 }
 
 CredentialBroker (Protocol) {
@@ -387,9 +387,9 @@ A `CognitiveEngine` is the agent's thinking substrate — Claude, GPT-4, local O
 
 ## 11 · Conformance
 
-An implementation **claims Soul Protocol 0.3.2 compliance** when it can:
+An implementation **claims Soul Protocol 0.3.3 compliance** when it can:
 
-- [ ] Read and write `.soul` files at schema_version 0.3.2 (§2)
+- [ ] Read and write `.soul` files at schema_version 0.3.3 (§2)
 - [ ] Honor the memory tier semantics, including activation decay and significance gating (§4)
 - [ ] Implement the `Journal.append` / `Journal.query` contract including `action_prefix` (§8)
 - [ ] Emit scope-non-empty `EventEntry` records with UTC timestamps (§8)
@@ -404,7 +404,7 @@ A conformance test suite lives in the reference implementation under `tests/conf
 
 ## 12 · Versioning
 
-- **Patch** (0.3.1 → 0.3.2) — additive fields, new query parameters, new exported types. Non-breaking.
+- **Patch** (0.3.1 → 0.3.3) — additive fields, new query parameters, new exported types. Non-breaking.
 - **Minor** (0.3.x → 0.4.0) — backward-compatible structural changes. Implementations may need to upgrade but old `.soul` files still read.
 - **Major** (0.x → 1.0) — reserved for the first stable release.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "soul-protocol"
-version = "0.3.1"
+version = "0.3.3"
 description = "The open standard for portable AI identity and memory"
 readme = "README.md"
 license = "MIT"

--- a/src/soul_protocol/__init__.py
+++ b/src/soul_protocol/__init__.py
@@ -184,4 +184,4 @@ __all__ = [
     "cluster_correction_patterns",
 ]
 
-__version__ = "0.3.1"
+__version__ = "0.3.3"

--- a/uv.lock
+++ b/uv.lock
@@ -2277,7 +2277,7 @@ wheels = [
 
 [[package]]
 name = "soul-protocol"
-version = "0.3.1"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Cuts release 0.3.3.

## What's in 0.3.3

The "headless standard" release plus #97 completion, all in one cut. The 0.3.2 number is skipped — the work that was originally going to ship as 0.3.2 (#179, #181) and the work that was going to ship as 0.3.3 (#185) all landed in the same session, so we collapsed the version into a single tag.

Headlines, paraphrasing the consolidated CHANGELOG:

- **`docs/SPEC.md`** — language-agnostic contract for any third-party Soul Protocol implementation
- **5 journal/retrieval primitives** — `Journal.append` returns committed entry, `Journal.query(action_prefix=...)`, typed `DataRef`, `RetrievalRequest.point_in_time`, async `SourceAdapter.aquery` + `RetrievalRouter.adispatch`
- **Spec-level retrieval vocabulary** moved to `spec/retrieval.py`; concrete `RetrievalRouter`/`InMemoryCredentialBroker` removed and now live in pocketpaw
- **Backup-before-cleanup safety net** — `.soul.bak` + dry-run-default + `--apply` requirement on `cleanup` and `forget` (closes #148)
- **System prompt safety guardrails** + `Soul.public_profile()` — finishes #97

## Files changed

- `pyproject.toml`: 0.3.1 → 0.3.3
- `src/soul_protocol/__init__.py`: `__version__` bump
- `CHANGELOG.md`: `[Unreleased]` + `[0.3.2]` collapsed into `[0.3.3] -- 2026-04-24`
- `docs/SPEC.md`: spec version 0.3.2 → 0.3.3 across the doc
- `README.md`: tests badge 2333 → 2371

## Test evidence

```
$ uv run pytest tests/ -q --tb=no
2371 passed, 4 warnings in 83.08s

$ uv run python -c "import soul_protocol; print(soul_protocol.__version__)"
0.3.3

$ uv run ruff check . && uv run ruff format --check .
All checks passed!
329 files already formatted
```

## After merge

1. Tag `v0.3.3` on the merge commit and push the tag.
2. `gh release create v0.3.3` — triggers the publish workflow that builds + uploads to PyPI via `PYPI_TOKEN`.
3. Refresh `soul-protocol-site` (separate repo).
4. Open the PocketPaw companion PR moving the concrete `RetrievalRouter`/`Broker`/adapters out of the now-pruned `engine/retrieval/`.
5. Close release tracker #180 with a note that 0.3.3 absorbed its scope.

## Closes

- #148 (covered by the safety net)
- #97 (covered by guardrails + public_profile, on top of the existing PR #114 visibility tier work)