### PR TITLE
fix(packaging): 0.3.4 hotfix — wheel duplicate-filename rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.3.4] -- 2026-04-24
+
+Hotfix release. The 0.3.3 wheel failed to upload to PyPI because `pyproject.toml` had a redundant `[tool.hatch.build.targets.wheel.force-include]` block that double-included the bundled template YAMLs (`analyst.yaml`, `arrow.yaml`, `cyborg.yaml`, `flash.yaml`). PyPI rejected the wheel with HTTP 400 ("Duplicate filename in local headers"). The 0.3.3 source distribution did upload, so `pip install soul-protocol==0.3.3` still works via the sdist — but a clean wheel install requires 0.3.4.
+
+### Fixed
+
+- Removed the redundant `force-include` for `src/soul_protocol/templates`. Templates already ship through the package-level auto-discovery; the explicit force-include duplicated them in the ZIP and broke PyPI upload. (Fixes the 0.3.3 wheel build.)
+
+### Notes
+
+- All 0.3.3 features remain unchanged. This is a packaging fix only.
+- PyPI does not allow re-uploads of the same version, even after deletion — that's why this is 0.3.4 rather than a re-cut of 0.3.3.
+
+---
+
 ## [0.3.3] -- 2026-04-24
 
 The "headless standard" release. soul-protocol is now positioned as a language-agnostic standard with a Python reference implementation. The 0.3.2 number was skipped — its scope rolled into 0.3.3 alongside the rest of the #97 visibility work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "soul-protocol"
-version = "0.3.3"
+version = "0.3.4"
 description = "The open standard for portable AI identity and memory"
 readme = "README.md"
 license = "MIT"
@@ -91,8 +91,12 @@ packages = ["src/soul_protocol"]
 # consumers cannot accidentally depend on it.
 exclude = ["src/soul_protocol/spike/**"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"src/soul_protocol/templates" = "soul_protocol/templates"
+# NOTE: do not add a [tool.hatch.build.targets.wheel.force-include] block for
+# `src/soul_protocol/templates` — those YAMLs already ship via the package
+# auto-discovery above. The redundant force-include caused a duplicate-name
+# wheel that PyPI rejected on 0.3.3 (HTTP 400 — "Duplicate filename in local
+# headers"). Keep the templates inside the package directory and let
+# hatchling pick them up once.
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/soul_protocol/__init__.py
+++ b/src/soul_protocol/__init__.py
@@ -184,4 +184,4 @@ __all__ = [
     "cluster_correction_patterns",
 ]
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/uv.lock
+++ b/uv.lock
@@ -2277,7 +2277,7 @@ wheels = [
 
 [[package]]
 name = "soul-protocol"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Hotfix for a packaging bug that blocked the 0.3.3 PyPI wheel upload.

## The failure

The 0.3.3 Publish to PyPI workflow ([run 24876338799](https://github.com/qbtrix/soul-protocol/actions/runs/24876338799)) failed with:

> \`400 Invalid distribution file. ZIP archive not accepted: Duplicate filename in local headers.\`

Root cause: \`pyproject.toml\` had a \`[tool.hatch.build.targets.wheel.force-include]\` block that re-included \`src/soul_protocol/templates\` on top of the default package-level auto-discovery. Each template YAML landed in the wheel ZIP twice. PyPI's validation (stricter on recent uploads) rejected the archive.

Local reproduction:

\`\`\`
$ uv build
UserWarning: Duplicate name: 'soul_protocol/templates/analyst.yaml'
UserWarning: Duplicate name: 'soul_protocol/templates/arrow.yaml'
UserWarning: Duplicate name: 'soul_protocol/templates/cyborg.yaml'
UserWarning: Duplicate name: 'soul_protocol/templates/flash.yaml'
\`\`\`

## The fix

Removed the redundant \`force-include\` block. Left a comment block explaining why it should not come back. Templates still ship — they're inside \`src/soul_protocol/\` so hatchling picks them up once during the normal package walk.

Verified locally:

\`\`\`
$ uv build
Successfully built dist/soul_protocol-0.3.4.tar.gz
Successfully built dist/soul_protocol-0.3.4-py3-none-any.whl
# no UserWarnings

$ unzip -l dist/soul_protocol-0.3.4-py3-none-any.whl | grep templates
  860 ... soul_protocol/templates/__init__.py
 1000 ... soul_protocol/templates/analyst.yaml
 1192 ... soul_protocol/templates/arrow.yaml
 1004 ... soul_protocol/templates/cyborg.yaml
 1040 ... soul_protocol/templates/flash.yaml
# each file appears once
\`\`\`

## Why 0.3.4 and not re-cut 0.3.3

PyPI does not allow re-uploads of the same version, even after deletion. The 0.3.3 sdist already uploaded successfully, so \`pip install soul-protocol==0.3.3\` works via the source distribution — it just can't install from a wheel. A version bump is the only forward path.

## What's in 0.3.4

- Only the packaging fix above. No feature changes from 0.3.3.
- Version bumps in \`pyproject.toml\` and \`src/soul_protocol/__init__.py\`.
- CHANGELOG gains a \`[0.3.4]\` section explaining the hotfix.

## Test evidence

\`\`\`
$ uv run pytest tests/ -q --tb=no
2371 passed, 4 warnings in 87.11s

$ uv run ruff check . && uv run ruff format --check .
All checks passed!
331 files already formatted
\`\`\`

## After merge

1. Tag \`v0.3.4\` on the merge commit and push.
2. \`gh release create v0.3.4\` — triggers the publish workflow.
3. Verify the wheel actually uploads this time (the whole point).