### PR TITLE
feat(state): density-driven focus with manual override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Density-driven focus** — `SoulState.focus` is now computed from a sliding window of recent interactions instead of being a static default. `Biorhythms` gains `focus_window_seconds` (default 1 hour), `focus_high_threshold` (default 3), and `focus_max_threshold` (default 10). With defaults: 0 interactions in window → `low`, 1-2 → `medium`, 3-9 → `high`, 10+ → `max`. A new `recent_interactions: list[datetime]` field on `SoulState` carries the rolling window.
+- **Manual focus lock** — `SoulState.focus_override` (`str | None`) pins focus to a fixed level, bypassing the density calc. Set via `soul.feel(focus="max")` (or `manager.update(focus="max")`). Clear with `soul.feel(focus="auto")` to re-enable density-driven focus.
+- **`soul feel --focus`** CLI flag — set focus to `low`/`medium`/`high`/`max`/`auto`.
+- **MCP `soul_feel` `focus` parameter** — same surface for MCP clients.
+- **`Soul.recompute_focus(now=None)`** — public method to refresh focus before reading state, used by CLI status display and MCP `soul_state` so stale values never leak into a status check.
+
+### Changed
+
+- `StateManager.on_interaction` now appends timestamps to `recent_interactions` and recomputes focus on every call.
+- `StateManager.reset()` clears `focus_override` and `recent_interactions` along with the existing fields.
+
 ---
 
 ## [0.3.1] -- 2026-04-14

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -362,12 +362,21 @@ def feel(self, **kwargs) -> None
 
 Update the soul's emotional state. Not async.
 
-For `energy` and `social_battery`, values are **deltas** (added to current value, clamped 0-100). All other fields (`mood`, `focus`, `last_interaction`) are **set directly**.
+For `energy` and `social_battery`, values are **deltas** (added to current value, clamped 0-100). `mood` and `last_interaction` are set directly. `focus` accepts a level (`"low"`, `"medium"`, `"high"`, `"max"`) which sets `focus_override` and locks focus to that value, or `"auto"` / `None` to clear the lock and re-enable density-driven focus.
 
 ```python
 soul.feel(energy=-10, mood=Mood.TIRED)
-soul.feel(social_battery=15, focus="high")
+soul.feel(social_battery=15, focus="high")  # locked
+soul.feel(focus="auto")                     # density-driven again
 ```
+
+#### `soul.recompute_focus()`
+
+```python
+def recompute_focus(self, now: datetime | None = None) -> str
+```
+
+Recompute density-driven focus at the given time and return the resulting level. Call before reading `soul.state.focus` if you need a value that reflects current interaction density rather than the last interaction tick. No-op when `focus_override` is set or `Biorhythms.focus_window_seconds` is 0.
 
 #### `soul.to_system_prompt()`
 
@@ -543,6 +552,9 @@ Simulated vitality and energy patterns.
 | `chronotype` | `str` | `"neutral"` | |
 | `social_battery` | `float` | `100.0` | `ge=0.0, le=100.0` |
 | `energy_regen_rate` | `float` | `5.0` | |
+| `focus_window_seconds` | `float` | `3600.0` | `ge=0.0` (set to 0 to disable density-driven focus) |
+| `focus_high_threshold` | `int` | `3` | `ge=1` (interactions in window at or above which focus rises to `high`) |
+| `focus_max_threshold` | `int` | `10` | `ge=1` (interactions in window at or above which focus rises to `max`) |
 
 #### `DNA`
 
@@ -690,9 +702,11 @@ The soul's current emotional and energy state.
 |-------|------|---------|-------------|
 | `mood` | `Mood` | `Mood.NEUTRAL` | |
 | `energy` | `float` | `100.0` | `ge=0.0, le=100.0` |
-| `focus` | `str` | `"medium"` | |
+| `focus` | `str` | `"medium"` | Effective level (one of `low`, `medium`, `high`, `max`). Computed from interaction density unless `focus_override` is set. |
+| `focus_override` | `str \| None` | `None` | When set, freezes `focus` to that level. Cleared via `feel(focus="auto")`. |
 | `social_battery` | `float` | `100.0` | `ge=0.0, le=100.0` |
 | `last_interaction` | `datetime \| None` | `None` | |
+| `recent_interactions` | `list[datetime]` | `[]` | Sliding-window timestamps for density-driven focus calc. |
 
 ### Evolution Types
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -688,6 +688,8 @@ Update a soul's emotional state directly.
 soul feel .soul/ --mood excited
 soul feel aria.soul --energy -10
 soul feel .soul/ --mood focused --energy 5
+soul feel .soul/ --focus max
+soul feel .soul/ --focus auto
 ```
 
 **Arguments:**
@@ -702,8 +704,13 @@ soul feel .soul/ --mood focused --energy 5
 |--------|-------------|
 | `--mood TEXT` | Set mood. One of: `neutral`, `curious`, `focused`, `tired`, `excited`, `contemplative`, `satisfied`, `concerned`. |
 | `--energy FLOAT` | Adjust energy (can be negative, e.g. `-10`). Applied as a delta. |
+| `--focus TEXT` | Lock focus to one of `low`, `medium`, `high`, `max`. Pass `auto` to clear the lock and re-enable density-driven focus (default behavior). |
 
-At least one of `--mood` or `--energy` is required.
+At least one of `--mood`, `--energy`, or `--focus` is required.
+
+**Focus modes:**
+
+By default, focus is computed from a sliding window of recent interactions (1 hour, configurable via `Biorhythms.focus_window_seconds`). Bands are: `low` (no interactions in window), `medium` (1-2), `high` (3-9), `max` (10+). Setting `--focus <level>` pins the value until you pass `--focus auto`.
 
 **Output:** Prints the updated mood and energy. Saves the soul automatically.
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -185,6 +185,8 @@ Get the soul's current mood, energy, focus, social battery, and lifecycle stage.
 
 **Returns:** JSON with `mood`, `energy`, `focus`, `social_battery`, and `lifecycle`.
 
+`focus` is recomputed from interaction density at call time (unless a manual override is in place — see `soul_feel` below). Bands with default thresholds: `low` (no interactions in the last hour), `medium` (1-2), `high` (3-9), `max` (10+).
+
 ---
 
 ### `soul_feel`
@@ -195,10 +197,11 @@ Update the soul's emotional state directly.
 |-----------|------|---------|-------------|
 | `mood` | `str` | `None` | One of: `neutral`, `curious`, `focused`, `tired`, `excited`, `contemplative`, `satisfied`, `concerned` |
 | `energy` | `float` | `None` | Energy **delta** (-100 to 100). Positive increases, negative decreases. Clamped to 0-100 after application. |
+| `focus` | `str` | `None` | Lock focus to `low`, `medium`, `high`, or `max`. Pass `auto` to clear the lock and re-enable density-driven focus. |
 
-**Returns:** JSON with updated `mood` and `energy`.
+**Returns:** JSON with updated `mood`, `energy`, `focus`, and `focus_override`.
 
-Note: `energy` is a delta, not an absolute value. Passing `energy: -10` drains 10 points from the current level.
+Note: `energy` is a delta, not an absolute value. Passing `energy: -10` drains 10 points from the current level. `focus` is an absolute level, not a delta.
 
 ---
 

--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -412,6 +412,7 @@ def inspect(path):
         )
 
         # ── State panel ──
+        soul.recompute_focus()
         mood = soul.state.mood.value
         energy = soul.state.energy
         social = soul.state.social_battery
@@ -507,6 +508,7 @@ def status(path):
         from soul_protocol.runtime.soul import Soul
 
         soul = await Soul.awaken(path)
+        soul.recompute_focus()
         mood = soul.state.mood.value
         energy = soul.state.energy
         social = soul.state.social_battery
@@ -1757,7 +1759,13 @@ def dream_cmd(path, since, no_archive, no_synthesize, dry_run, as_json):
 @click.option(
     "--energy", type=float, default=None, help="Adjust energy (can be negative, e.g. -10)"
 )
-def feel_cmd(path, mood, energy):
+@click.option(
+    "--focus",
+    type=str,
+    default=None,
+    help="Lock focus to a level (low, medium, high, max) or 'auto' to clear and re-enable density-driven focus",
+)
+def feel_cmd(path, mood, energy, focus):
     """Update a soul's emotional state.
 
     \b
@@ -1765,11 +1773,13 @@ def feel_cmd(path, mood, energy):
       soul feel .soul/ --mood excited
       soul feel aria.soul --energy -10
       soul feel .soul/ --mood focused --energy 5
+      soul feel .soul/ --focus max
+      soul feel .soul/ --focus auto
     """
 
     async def _feel():
         from soul_protocol.runtime.soul import Soul
-        from soul_protocol.runtime.types import Mood
+        from soul_protocol.runtime.types import FOCUS_LEVELS, Mood
 
         soul = await Soul.awaken(path)
 
@@ -1783,12 +1793,19 @@ def feel_cmd(path, mood, energy):
                 raise SystemExit(1)
         if energy is not None:
             kwargs["energy"] = energy
+        if focus is not None:
+            if focus != "auto" and focus not in FOCUS_LEVELS:
+                valid = ", ".join(FOCUS_LEVELS) + ", auto"
+                console.print(f"[red]Invalid focus:[/red] '{focus}'. Valid: {valid}")
+                raise SystemExit(1)
+            kwargs["focus"] = focus
 
         if not kwargs:
-            console.print("[red]Provide at least --mood or --energy[/red]")
+            console.print("[red]Provide at least --mood, --energy, or --focus[/red]")
             raise SystemExit(1)
 
         soul.feel(**kwargs)
+        soul.recompute_focus()
 
         # Save
         if Path(path).is_dir():
@@ -1797,10 +1814,14 @@ def feel_cmd(path, mood, energy):
             await soul.export(path)
 
         state = soul.state
+        focus_label = state.focus
+        if state.focus_override is None:
+            focus_label = f"{state.focus} (auto)"
         console.print(
             f"[green]Updated[/green] [bold]{soul.name}[/bold]\n"
             f"  Mood:   [cyan]{state.mood.value}[/cyan]\n"
-            f"  Energy: {state.energy:.0f}%"
+            f"  Energy: {state.energy:.0f}%\n"
+            f"  Focus:  {focus_label}"
         )
 
     asyncio.run(_feel())

--- a/src/soul_protocol/mcp/server.py
+++ b/src/soul_protocol/mcp/server.py
@@ -730,6 +730,7 @@ async def soul_state(soul: str | None = None) -> str:
         soul: Target soul name (uses active soul if omitted)
     """
     s = await _resolve_soul(soul)
+    s.recompute_focus()
     st = s.state
     return json.dumps(
         {
@@ -747,6 +748,7 @@ async def soul_state(soul: str | None = None) -> str:
 async def soul_feel(
     mood: str | None = None,
     energy: float | None = None,
+    focus: str | None = None,
     soul: str | None = None,
 ) -> str:
     """Update the soul's emotional state.
@@ -756,8 +758,12 @@ async def soul_feel(
               contemplative, satisfied, concerned
         energy: Energy delta (-100 to 100). Positive increases,
                 negative decreases. Clamped to 0-100.
+        focus: Lock focus to one of low/medium/high/max, or 'auto'
+                to clear the lock and re-enable density-driven focus.
         soul: Target soul name (uses active soul if omitted)
     """
+    from soul_protocol.runtime.types import FOCUS_LEVELS
+
     s = await _resolve_soul(soul)
     kwargs: dict[str, Any] = {}
     if mood is not None:
@@ -765,7 +771,13 @@ async def soul_feel(
     if energy is not None:
         energy = max(-100.0, min(100.0, energy))
         kwargs["energy"] = energy
+    if focus is not None:
+        if focus != "auto" and focus not in FOCUS_LEVELS:
+            valid = ", ".join(FOCUS_LEVELS) + ", auto"
+            raise ValueError(f"Invalid focus '{focus}'. Valid: {valid}")
+        kwargs["focus"] = focus
     s.feel(**kwargs)
+    s.recompute_focus()
     _registry.mark_modified(soul)
     st = s.state
     return json.dumps(
@@ -773,6 +785,8 @@ async def soul_feel(
             "soul": s.name,
             "mood": st.mood.value,
             "energy": round(st.energy, 1),
+            "focus": st.focus,
+            "focus_override": st.focus_override,
         }
     )
 
@@ -1611,6 +1625,7 @@ async def soul_core_memory_resource() -> str:
 async def soul_state_resource() -> str:
     """Current soul state: mood, energy, focus, social battery."""
     s = await _resolve_soul()
+    s.recompute_focus()
     st = s.state
     return json.dumps(
         {

--- a/src/soul_protocol/runtime/soul.py
+++ b/src/soul_protocol/runtime/soul.py
@@ -1438,6 +1438,16 @@ class Soul:
         """
         self._state.update(**kwargs)
 
+    def recompute_focus(self, now: datetime | None = None) -> str:
+        """Refresh density-driven focus before reading state.
+
+        Call before displaying focus in CLI/MCP/API surfaces so the value
+        reflects current interaction density, not the last tick. No-op when
+        focus_override is set or focus_window_seconds is 0. Returns the
+        resulting focus level.
+        """
+        return self._state.recompute_focus(now)
+
     # ============ Evolution ============
 
     async def propose_evolution(self, trait: str, new_value: str, reason: str) -> Mutation:

--- a/src/soul_protocol/runtime/state/manager.py
+++ b/src/soul_protocol/runtime/state/manager.py
@@ -1,4 +1,8 @@
 # state/manager.py — StateManager for tracking and mutating a soul's runtime state.
+# Updated: 2026-04-29 — Density-driven focus. on_interaction now records timestamps
+#   into a sliding window (Biorhythms.focus_window_seconds) and recomputes focus from
+#   the count. update(focus="<level>") sets focus_override (manual lock); focus="auto"
+#   clears the override. Public recompute_focus(now) lets callers refresh at read time.
 # Updated: Configurable biorhythms — all drain/regen/mood params read from Biorhythms
 #   instead of hardcoded constants. Added time-based auto-regen on elapsed time.
 
@@ -8,6 +12,7 @@ import logging
 from datetime import UTC, datetime
 
 from soul_protocol.runtime.types import (
+    FOCUS_LEVELS,
     Biorhythms,
     Interaction,
     Mood,
@@ -104,11 +109,17 @@ class StateManager:
         *deltas* (added to the current value) and the result is clamped to
         the 0-100 range.  All other fields are set directly.
 
+        ``focus`` accepts a level name (``"low"``, ``"medium"``, ``"high"``,
+        ``"max"``) which sets ``focus_override`` and locks focus to that
+        value, or ``"auto"`` / ``None`` which clears the override and
+        re-enables density-driven focus.
+
         Examples::
 
             manager.update(mood=Mood.TIRED)
             manager.update(energy=-10)        # decrease by 10
-            manager.update(focus="high")
+            manager.update(focus="high")      # lock focus
+            manager.update(focus="auto")      # back to density-driven
             manager.update(energy=5, social_battery=-3)
         """
         for key, value in kwargs.items():
@@ -118,8 +129,65 @@ class StateManager:
             elif key == "social_battery" and isinstance(value, (int, float)):
                 new_val = self._state.social_battery + float(value)
                 self._state.social_battery = max(0.0, min(100.0, new_val))
+            elif key == "focus":
+                if value is None or value == "auto":
+                    self._state.focus_override = None
+                    self._recompute_focus()
+                elif isinstance(value, str) and value in FOCUS_LEVELS:
+                    self._state.focus_override = value
+                    self._state.focus = value
+                else:
+                    raise ValueError(
+                        f"focus must be one of {FOCUS_LEVELS} or 'auto'/None, got {value!r}"
+                    )
             elif hasattr(self._state, key):
                 setattr(self._state, key, value)
+
+    def _trim_recent_interactions(self, now: datetime) -> None:
+        """Drop interaction timestamps older than the focus window."""
+        window = self._bio.focus_window_seconds
+        if window <= 0:
+            return
+        cutoff = now.timestamp() - window
+        self._state.recent_interactions = [
+            ts for ts in self._state.recent_interactions
+            if (ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts).timestamp() >= cutoff
+        ]
+
+    def _recompute_focus(self, now: datetime | None = None) -> None:
+        """Recompute focus from interaction density.
+
+        No-op when ``focus_override`` is set or ``focus_window_seconds`` is 0.
+        Bands: 0 in window → "low"; below high_threshold → "medium";
+        below max_threshold → "high"; at or above max_threshold → "max".
+        """
+        if self._state.focus_override is not None:
+            self._state.focus = self._state.focus_override
+            return
+        if self._bio.focus_window_seconds <= 0:
+            return
+        if now is None:
+            now = datetime.now(UTC)
+        self._trim_recent_interactions(now)
+        count = len(self._state.recent_interactions)
+        if count == 0:
+            self._state.focus = "low"
+        elif count < self._bio.focus_high_threshold:
+            self._state.focus = "medium"
+        elif count < self._bio.focus_max_threshold:
+            self._state.focus = "high"
+        else:
+            self._state.focus = "max"
+
+    def recompute_focus(self, now: datetime | None = None) -> str:
+        """Public hook to refresh focus before reading it.
+
+        Call this from CLI/MCP code paths that display focus, so the value
+        reflects current time rather than the moment of the last interaction.
+        Returns the resulting focus level.
+        """
+        self._recompute_focus(now)
+        return self._state.focus
 
     def _apply_auto_regen(self, now: datetime) -> None:
         """Recover energy based on elapsed time since last interaction.
@@ -204,6 +272,13 @@ class StateManager:
                 )
             self._state.mood = Mood.TIRED
 
+        # Record timestamp for density-driven focus and recompute
+        ts = interaction.timestamp
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        self._state.recent_interactions.append(ts)
+        self._recompute_focus(ts)
+
     def rest(self, hours: float = 1.0) -> None:
         """Recover energy and social battery over a rest period.
 
@@ -221,6 +296,8 @@ class StateManager:
         self._state.mood = Mood.NEUTRAL
         self._state.energy = 100.0
         self._state.focus = "medium"
+        self._state.focus_override = None
         self._state.social_battery = 100.0
         self._state.last_interaction = None
+        self._state.recent_interactions = []
         self._valence_ema = 0.0

--- a/src/soul_protocol/runtime/types.py
+++ b/src/soul_protocol/runtime/types.py
@@ -1,4 +1,8 @@
 # types.py — All Pydantic data models for the Digital Soul Protocol
+# Updated: 2026-04-29 — Density-driven focus: SoulState gains focus_override and
+#   recent_interactions; Biorhythms gains focus_window_seconds, focus_high_threshold,
+#   focus_max_threshold. focus is now computed from interaction density unless
+#   focus_override is set.
 # Updated: 2026-04-04 — Added skip_deep_processing_on_low_significance to
 #   MemorySettings. When True (default), observe() skips entity extraction
 #   (step 5) and self-model update (step 6) for non-significant interactions,
@@ -160,6 +164,23 @@ class Biorhythms(BaseModel):
     auto_regen: bool = Field(
         default=False,
         description="Recover energy automatically based on elapsed time (enable for companion souls)",
+    )
+
+    # Focus dynamics — density-driven
+    focus_window_seconds: float = Field(
+        default=3600.0,
+        ge=0.0,
+        description="Sliding window for interaction-density focus calc (0 disables auto-focus)",
+    )
+    focus_high_threshold: int = Field(
+        default=3,
+        ge=1,
+        description="Interactions in window at or above which focus rises to 'high'",
+    )
+    focus_max_threshold: int = Field(
+        default=10,
+        ge=1,
+        description="Interactions in window at or above which focus rises to 'max'",
     )
 
 
@@ -372,14 +393,27 @@ class Mood(StrEnum):
     CONCERNED = "concerned"
 
 
+FOCUS_LEVELS: tuple[str, ...] = ("low", "medium", "high", "max")
+
+
 class SoulState(BaseModel):
-    """The soul's current emotional and energy state."""
+    """The soul's current emotional and energy state.
+
+    ``focus`` is the effective level (one of FOCUS_LEVELS). When
+    ``focus_override`` is None, StateManager recomputes focus from
+    ``recent_interactions`` density on each interaction or status read.
+    Setting ``focus_override`` to a level locks focus to that value
+    until cleared (set focus_override back to None or call
+    ``manager.update(focus="auto")``).
+    """
 
     mood: Mood = Mood.NEUTRAL
     energy: float = Field(default=100.0, ge=0.0, le=100.0)
     focus: str = "medium"
+    focus_override: str | None = None
     social_battery: float = Field(default=100.0, ge=0.0, le=100.0)
     last_interaction: datetime | None = None
+    recent_interactions: list[datetime] = Field(default_factory=list)
 
 
 # ============ Evolution ============

--- a/tests/test_state/test_manager.py
+++ b/tests/test_state/test_manager.py
@@ -7,6 +7,9 @@
 # Updated: 2026-03-13 — Added TestBiorhythmsConfig and TestAutoRegen test classes covering
 #   configurable Biorhythms parameter: drain rates, tired threshold, mood inertia, mood
 #   sensitivity, auto-regen on/off, and the "always-on" agent preset.
+# Updated: 2026-04-29 — Added TestFocusDensity covering density-driven focus calc,
+#   manual override via update(focus="<level>"), "auto" reset, window pruning, and
+#   the public recompute_focus() refresh hook.
 
 from __future__ import annotations
 
@@ -604,3 +607,224 @@ class TestAutoRegen:
         assert manager.current.energy == pytest.approx(70.0)
         # social recovers at half rate: 100 + 10*1 = 100 (capped)
         assert manager.current.social_battery == pytest.approx(100.0)
+
+
+# ---------------------------------------------------------------------------
+# Density-driven focus
+# ---------------------------------------------------------------------------
+
+
+class TestFocusDensity:
+    """focus is recomputed from a sliding window of interaction timestamps,
+    unless focus_override is set (manual lock)."""
+
+    # ------------------------------------------------------------------
+    # Default thresholds (low=0, medium=1-2, high=3-9, max=10+)
+    # ------------------------------------------------------------------
+
+    def test_default_focus_is_medium(self):
+        """A fresh state has focus='medium' (the field default)."""
+        manager = StateManager(_make_state())
+        assert manager.current.focus == "medium"
+        assert manager.current.focus_override is None
+
+    def test_zero_interactions_in_window_recomputes_to_low(self):
+        """recompute with empty history → 'low'."""
+        manager = StateManager(_make_state())
+        # Past time so any default state is irrelevant
+        manager.recompute_focus(datetime(2026, 1, 1, 12, 0, tzinfo=UTC))
+        assert manager.current.focus == "low"
+
+    def test_one_interaction_yields_medium(self):
+        """Single interaction → density=1 → 'medium' (below high_threshold=3)."""
+        manager = StateManager(_make_state())
+        t = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        manager.on_interaction(_make_interaction_at(t))
+        assert manager.current.focus == "medium"
+
+    def test_two_interactions_still_medium(self):
+        """2 interactions in window → still 'medium'."""
+        manager = StateManager(_make_state())
+        t = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        for i in range(2):
+            manager.on_interaction(_make_interaction_at(t + timedelta(seconds=i * 10)))
+        assert manager.current.focus == "medium"
+
+    def test_three_interactions_promotes_to_high(self):
+        """3 interactions in window → 'high' (== high_threshold)."""
+        manager = StateManager(_make_state())
+        t = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        for i in range(3):
+            manager.on_interaction(_make_interaction_at(t + timedelta(seconds=i * 10)))
+        assert manager.current.focus == "high"
+
+    def test_ten_interactions_promotes_to_max(self):
+        """10 interactions in window → 'max' (== max_threshold)."""
+        manager = StateManager(_make_state())
+        t = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        for i in range(10):
+            manager.on_interaction(_make_interaction_at(t + timedelta(seconds=i * 10)))
+        assert manager.current.focus == "max"
+
+    # ------------------------------------------------------------------
+    # Window pruning
+    # ------------------------------------------------------------------
+
+    def test_old_interactions_outside_window_are_pruned(self):
+        """Interactions older than focus_window_seconds drop from the count."""
+        bio = Biorhythms(focus_window_seconds=600.0)  # 10-min window
+        manager = StateManager(_make_state(), biorhythms=bio)
+        t0 = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        # 5 interactions packed into 60 seconds at t0
+        for i in range(5):
+            manager.on_interaction(_make_interaction_at(t0 + timedelta(seconds=i)))
+        assert manager.current.focus == "high"
+
+        # One interaction 30 minutes later → original 5 are outside window
+        t1 = t0 + timedelta(minutes=30)
+        manager.on_interaction(_make_interaction_at(t1))
+        # Only the t1 interaction remains in window → density=1 → medium
+        assert manager.current.focus == "medium"
+        assert len(manager.current.recent_interactions) == 1
+
+    def test_recompute_focus_at_later_time_drops_stale_density(self):
+        """recompute_focus(now) re-prunes and recomputes — high → low after long idle."""
+        manager = StateManager(_make_state())
+        t0 = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        for i in range(5):
+            manager.on_interaction(_make_interaction_at(t0 + timedelta(seconds=i)))
+        assert manager.current.focus == "high"
+
+        # 2 hours later, no interaction — focus should drop to low
+        t1 = t0 + timedelta(hours=2)
+        result = manager.recompute_focus(t1)
+        assert result == "low"
+        assert manager.current.focus == "low"
+        assert manager.current.recent_interactions == []
+
+    def test_window_zero_disables_auto_focus(self):
+        """focus_window_seconds=0 → recompute is a no-op, focus stays at default."""
+        bio = Biorhythms(focus_window_seconds=0.0)
+        manager = StateManager(_make_state(), biorhythms=bio)
+        t = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        for i in range(20):
+            manager.on_interaction(_make_interaction_at(t + timedelta(seconds=i)))
+        # Density would be 'max' but auto-focus is disabled → stays at default 'medium'
+        assert manager.current.focus == "medium"
+
+    # ------------------------------------------------------------------
+    # Configurable thresholds
+    # ------------------------------------------------------------------
+
+    def test_custom_thresholds_respected(self):
+        """Custom high/max thresholds shift the bands."""
+        bio = Biorhythms(focus_high_threshold=5, focus_max_threshold=20)
+        manager = StateManager(_make_state(), biorhythms=bio)
+        t = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        # 4 interactions → below high_threshold=5 → medium
+        for i in range(4):
+            manager.on_interaction(_make_interaction_at(t + timedelta(seconds=i)))
+        assert manager.current.focus == "medium"
+        # 5th → reaches high
+        manager.on_interaction(_make_interaction_at(t + timedelta(seconds=5)))
+        assert manager.current.focus == "high"
+
+    # ------------------------------------------------------------------
+    # Manual override
+    # ------------------------------------------------------------------
+
+    def test_manual_override_locks_focus(self):
+        """update(focus='max') sets override and pins focus."""
+        manager = StateManager(_make_state())
+        manager.update(focus="max")
+        assert manager.current.focus == "max"
+        assert manager.current.focus_override == "max"
+
+        # Even with zero interactions, recompute respects the override
+        manager.recompute_focus(datetime(2026, 1, 1, 12, 0, tzinfo=UTC))
+        assert manager.current.focus == "max"
+
+    def test_override_survives_density_changes(self):
+        """While override is set, on_interaction should not change focus."""
+        manager = StateManager(_make_state())
+        manager.update(focus="low")
+        t = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        for i in range(15):
+            manager.on_interaction(_make_interaction_at(t + timedelta(seconds=i)))
+        # Density would be 'max', but override pins it to 'low'
+        assert manager.current.focus == "low"
+
+    def test_focus_auto_clears_override_and_recomputes(self):
+        """update(focus='auto') clears override and triggers recalc."""
+        manager = StateManager(_make_state())
+        manager.update(focus="high")
+        assert manager.current.focus_override == "high"
+
+        # Clear and recompute — empty history → low
+        manager.update(focus="auto")
+        assert manager.current.focus_override is None
+        assert manager.current.focus == "low"
+
+    def test_focus_none_also_clears_override(self):
+        """update(focus=None) is equivalent to focus='auto'."""
+        manager = StateManager(_make_state())
+        manager.update(focus="medium")
+        assert manager.current.focus_override == "medium"
+
+        manager.update(focus=None)
+        assert manager.current.focus_override is None
+
+    def test_invalid_focus_value_raises(self):
+        """update(focus='banana') raises ValueError."""
+        manager = StateManager(_make_state())
+        with pytest.raises(ValueError, match="focus must be one of"):
+            manager.update(focus="banana")
+
+    def test_all_focus_levels_are_settable(self):
+        """Every level in FOCUS_LEVELS is a valid override target."""
+        manager = StateManager(_make_state())
+        for level in ("low", "medium", "high", "max"):
+            manager.update(focus=level)
+            assert manager.current.focus == level
+            assert manager.current.focus_override == level
+
+    # ------------------------------------------------------------------
+    # reset()
+    # ------------------------------------------------------------------
+
+    def test_reset_clears_focus_override_and_history(self):
+        """reset() returns focus to default and clears recent_interactions + override."""
+        manager = StateManager(_make_state())
+        manager.update(focus="max")
+        t = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        for i in range(5):
+            manager.on_interaction(_make_interaction_at(t + timedelta(seconds=i)))
+
+        manager.reset()
+        assert manager.current.focus == "medium"
+        assert manager.current.focus_override is None
+        assert manager.current.recent_interactions == []
+
+    # ------------------------------------------------------------------
+    # Public recompute_focus() return value
+    # ------------------------------------------------------------------
+
+    def test_recompute_focus_returns_resulting_level(self):
+        """recompute_focus(now) returns the new focus level."""
+        manager = StateManager(_make_state())
+        t = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        for i in range(3):
+            manager.on_interaction(_make_interaction_at(t + timedelta(seconds=i)))
+        assert manager.recompute_focus(t + timedelta(seconds=10)) == "high"
+
+    def test_recompute_focus_with_naive_timestamps_in_history(self):
+        """Timestamps stored without tz must not crash window comparison."""
+        state = _make_state()
+        # Inject a naive datetime as if from an older soul file
+        naive_ts = datetime(2026, 1, 1, 12, 0)  # no tzinfo
+        state.recent_interactions = [naive_ts]
+        manager = StateManager(state)
+        # Should compute without raising
+        result = manager.recompute_focus(datetime(2026, 1, 1, 12, 0, 30, tzinfo=UTC))
+        # Within window → medium
+        assert result == "medium"


### PR DESCRIPTION
## What changed

`SoulState.focus` was a static string defaulting to `"medium"` with no calculation behind it — only an explicit `manager.update(focus=...)` ever moved the value. Now it's computed from a sliding-window count of recent interactions, with the explicit-set behavior preserved as a manual lock.

### Defaults

- Window: 1 hour (`Biorhythms.focus_window_seconds`)
- Bands: 0 interactions in window → `low`, 1-2 → `medium`, 3-9 → `high`, 10+ → `max`
- Thresholds configurable: `focus_high_threshold` and `focus_max_threshold`
- Set `focus_window_seconds=0` to disable density-driven focus entirely (the field stays at whatever was last written)

### Manual lock

`soul.feel(focus="<level>")` (or `manager.update(...)`) sets `focus_override` and pins the level. `soul.feel(focus="auto")` clears the lock and runs the density calc again. The override survives subsequent interactions, so it's a real lock, not a one-shot.

### Read-time freshness

`Soul.recompute_focus(now=None)` lets callers refresh focus before reading state. The CLI status display and MCP `soul_state` tool both call it now, so a long idle period drops the displayed focus to `low` without needing a fresh interaction to trigger the recompute.

### Surfaces

- `soul feel --focus low|medium|high|max|auto` — new CLI flag
- MCP `soul_feel(focus=...)` — new parameter, returns `focus` and `focus_override` in the response

## Test plan

- [x] 19 new tests in `TestFocusDensity` cover: default thresholds, custom thresholds, window pruning, manual override, `auto` reset, `None` reset, invalid value rejection, all 4 levels settable, reset clears history, naive timestamp tolerance.
- [x] Existing 47 state-manager tests still pass.
- [x] Full suite: 2316 passing.
- [ ] Manual smoke: `soul status` on an existing soul shows the correct focus band based on recent interactions.

## Backwards compatibility

`focus_override` defaults to `None` and `recent_interactions` defaults to `[]`, so existing soul files load cleanly. The naive-timestamp test confirms older payloads without timezone info don't break the window comparison.

## Files

- `src/soul_protocol/runtime/types.py` — new fields on `SoulState` and `Biorhythms`, exported `FOCUS_LEVELS`
- `src/soul_protocol/runtime/state/manager.py` — density calc, override semantics, public `recompute_focus`
- `src/soul_protocol/runtime/soul.py` — `recompute_focus` method on Soul
- `src/soul_protocol/cli/main.py` — `soul feel --focus`, refresh in `soul status` and `soul info`
- `src/soul_protocol/mcp/server.py` — `focus` param on `soul_feel`, refresh in `soul_state` tool and `soul://state` resource
- `tests/test_state/test_manager.py` — `TestFocusDensity` class
- `docs/api-reference.md`, `docs/cli-reference.md`, `docs/mcp-server.md`, `CHANGELOG.md`