### PR TITLE
feat(memory): multi-user soul support (#46)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -225,6 +225,7 @@ async def recall(
     limit: int = 10,
     types: list[MemoryType] | None = None,
     min_importance: int = 0,
+    user_id: str | None = None,
 ) -> list[MemoryEntry]
 ```
 
@@ -236,17 +237,27 @@ Search memories ranked by ACT-R activation (recency, frequency, relevance). Rele
 | `limit` | `int` | `10` | Max results |
 | `types` | `list[MemoryType] \| None` | `None` | Filter by memory type(s). `None` = all types. |
 | `min_importance` | `int` | `0` | Minimum importance threshold |
+| `user_id` | `str \| None` | `None` | Multi-user filter (#46). When set, results restrict to memories whose `user_id` matches OR is `None` (legacy/orphan entries are visible to every user). When unset, returns all memories regardless of attribution. |
 
 **Returns:** `list[MemoryEntry]`
 
 ```python
+# Legacy (single-user) recall
 memories = await soul.recall("dark mode preference", limit=5)
+
+# Multi-user soul: scope to alice
+alice_memories = await soul.recall("preferences", user_id="alice", limit=5)
 ```
 
 #### `soul.observe()`
 
 ```python
-async def observe(self, interaction: Interaction) -> None
+async def observe(
+    self,
+    interaction: Interaction,
+    *,
+    user_id: str | None = None,
+) -> None
 ```
 
 The primary learning hook. Call after every user-agent exchange. Runs the full psychology pipeline:
@@ -264,10 +275,37 @@ The primary learning hook. Call after every user-agent exchange. Runs the full p
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `interaction` | `Interaction` | required | The user-agent exchange |
+| `user_id` | `str \| None` | `None` | Multi-user attribution (#46). When set, every memory written during this call is stamped with the user_id, and the per-user bond is strengthened instead of the default bond. When unset, behaviour is unchanged: orphan entries with `user_id=None`. |
 
 ```python
+# Legacy (single-user) observe
 await soul.observe(Interaction(user_input="Hi!", agent_output="Hello there!"))
+
+# Multi-user soul: attribute to alice
+await soul.observe(
+    Interaction(user_input="My favorite color is blue", agent_output="Got it!"),
+    user_id="alice",
+)
 ```
+
+#### `soul.bond_for()`
+
+```python
+def bond_for(self, user_id: str) -> Bond
+```
+
+Return the per-user `Bond` for a given `user_id` (multi-user souls, #46). Lazily creates the bond on first access (strength=50, count=0). Bonds survive export/awaken. Use this to inspect or mutate a single user's relationship without touching the default bond.
+
+```python
+alice_bond = soul.bond_for("alice")
+alice_bond.strengthen(2.0)  # only alice's bond moves
+
+# bond.strengthen() also accepts a user_id keyword for routing
+soul.bond.strengthen(2.0, user_id="alice")  # same as above
+soul.bond.strengthen(2.0)  # default bond (legacy)
+```
+
+`soul.bonded_users` returns the list of `user_id`s with their own per-user bonds (excludes the default bond's `bonded_to`).
 
 #### `soul.forget()`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -570,6 +570,10 @@ soul recall aria.soul --recent 10
 soul recall aria.soul "python" --full            # Untruncated content
 soul recall aria.soul "python" --json            # Machine-readable JSON
 soul recall aria.soul --recent 5 --json          # Recent memories as JSON
+
+# Multi-user (#46) — scope recall to one user
+soul recall aria.soul "preferences" --user alice
+soul recall aria.soul --recent 10 --user alice
 ```
 
 **Arguments:**
@@ -588,8 +592,9 @@ soul recall aria.soul --recent 5 --json          # Recent memories as JSON
 | `--recent, -r INT` | | Show N most recent memories instead of searching. |
 | `--full` | off | Return untruncated content (for LLM consumption). |
 | `--json` | off | Return results as JSON (for scripting). |
+| `--user TEXT` | | Filter results to memories attributed to this `user_id` (#46). Legacy entries with no `user_id` are also returned. |
 
-**Output:** A table of ranked memories with type, content, importance, emotion, and timestamp. Use `--full` or `--json` when an agent or script needs machine-readable output.
+**Output:** A table of ranked memories with type, content, importance, emotion, and timestamp. Use `--full` or `--json` when an agent or script needs machine-readable output. The JSON payload includes a `user_id` field per entry.
 
 ---
 
@@ -600,6 +605,9 @@ Process an interaction through the full cognitive pipeline. Runs sentiment detec
 ```bash
 soul observe .soul/ --user-input "Hello" --agent-output "Hi there!"
 soul observe aria.soul --user-input "Tell me a joke" --agent-output "Why did..." --channel discord
+
+# Multi-user (#46) — attribute the memory to one user
+soul observe aria.soul --user-input "Hi" --agent-output "Hello!" --user alice
 ```
 
 **Arguments:**
@@ -615,6 +623,7 @@ soul observe aria.soul --user-input "Tell me a joke" --agent-output "Why did..."
 | `--user-input TEXT` | User's message. **Required.** |
 | `--agent-output TEXT` | Agent's response. **Required.** |
 | `--channel TEXT` | Channel name. Defaults to `cli`. |
+| `--user TEXT` | Attribute observed memories to this `user_id` (#46). The per-user bond is strengthened instead of the default bond. |
 
 **Output:** Prints the soul's mood and energy after processing the interaction. Saves the soul automatically.
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -117,8 +117,10 @@ Process an interaction through the full psychology pipeline. Extracts facts, det
 | `user_input` | `str` | required | What the user said |
 | `agent_output` | `str` | required | What the agent responded |
 | `channel` | `str` | `"mcp"` | Source channel identifier |
+| `soul` | `str \| None` | `None` | Target soul name (uses active soul if omitted) |
+| `user_id` | `str \| None` | `None` | Multi-user attribution (#46). When set, every memory written during this call is stamped with the user_id, and the per-user bond is strengthened instead of the default bond. |
 
-**Returns:** JSON with `status`, `mood`, and `energy`.
+**Returns:** JSON with `status`, `soul`, `mood`, `energy`, and `user_id` (echoed back).
 
 ---
 
@@ -145,8 +147,10 @@ Search the soul's memories by natural language query. Results are ranked by ACT-
 |-----------|------|---------|-------------|
 | `query` | `str` | required | Search query |
 | `limit` | `int` | `5` | Maximum number of results |
+| `soul` | `str \| None` | `None` | Target soul name (uses active soul if omitted) |
+| `user_id` | `str \| None` | `None` | Multi-user filter (#46). When set, restrict results to memories attributed to this `user_id`, plus any legacy entries with no `user_id`. When unset, returns all memories regardless of attribution. |
 
-**Returns:** JSON with `count` and `memories` array. Each memory includes `id`, `type`, `content`, `importance`, and `emotion`.
+**Returns:** JSON with `count`, `soul`, and `memories` array. Each memory includes `id`, `type`, `content`, `importance`, `emotion`, and `user_id`.
 
 ---
 

--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -1,4 +1,11 @@
 # cli/main.py — Click CLI for the Soul Protocol (org + user groups + runtime commands)
+# Updated: 2026-04-29 (#46) — Multi-user soul support. ``soul observe`` and
+#   ``soul recall`` accept ``--user <id>``; the user_id pipes through to
+#   Soul.observe() / Soul.recall() so memory writes get attributed and
+#   recall results filter by user. ``soul status`` renders per-user bond
+#   strengths when more than one user is bonded; falls back to the legacy
+#   single-bond view otherwise. The `--user` flag also includes legacy
+#   (user_id=None) entries — orphan memories stay visible to every user.
 # Updated: 2026-04-27 — Memory update primitives + forget display fix.
 #   - `soul forget --id <id>` for surgical single-memory deletion (audited).
 #   - `soul supersede <path> <new_content> --old-id <id> [--reason ...]` writes
@@ -513,7 +520,12 @@ def inspect(path):
 @cli.command()
 @click.argument("path", type=click.Path(exists=True))
 def status(path):
-    """Show a Soul's current status (quick view)."""
+    """Show a Soul's current status (quick view).
+
+    Shows per-user bond strengths when more than one user is bonded
+    (multi-user souls, #46). Falls back to the default single-bond view
+    for legacy souls.
+    """
 
     async def _status():
         from soul_protocol.runtime.soul import Soul
@@ -536,6 +548,26 @@ def status(path):
             f"  Focus           {soul.state.focus}",
             f"  Memories        {soul.memory_count}",
         ]
+
+        # Multi-user bond display when more than one user has a bond.
+        bonded_users = soul.bonded_users
+        if bonded_users:
+            lines.append("")
+            lines.append("  [dim]Per-user bonds:[/dim]")
+            # Show default bond first if it has a bonded_to identifier
+            default_label = soul.bond.default.bonded_to or "[dim]default[/dim]"
+            lines.append(
+                f"    {default_label:24}  "
+                f"strength={soul.bond.default.bond_strength:5.1f}, "
+                f"interactions={soul.bond.default.interaction_count}"
+            )
+            for uid in bonded_users:
+                b = soul.bond_for(uid)
+                lines.append(
+                    f"    {uid:24}  "
+                    f"strength={b.bond_strength:5.1f}, "
+                    f"interactions={b.interaction_count}"
+                )
 
         console.print(
             Panel(
@@ -1101,7 +1133,14 @@ def remember_cmd(path, text, importance, emotion, memory_type):
     default=False,
     help="Output results as a JSON array (machine-readable)",
 )
-def recall_cmd(path, query, recent, limit, min_importance, full, as_json):
+@click.option(
+    "--user",
+    "user_id",
+    default=None,
+    help="Filter memories to a specific user_id (multi-user souls, #46). "
+    "Legacy entries with no user_id are also returned.",
+)
+def recall_cmd(path, query, recent, limit, min_importance, full, as_json, user_id):
     """Query a Soul's memories.
 
     \b
@@ -1111,6 +1150,7 @@ def recall_cmd(path, query, recent, limit, min_importance, full, as_json):
       soul recall aria.soul "python" --min-importance 5
       soul recall aria.soul "python" --full
       soul recall aria.soul --recent 5 --json
+      soul recall aria.soul "preferences" --user alice
     """
 
     async def _recall():
@@ -1119,12 +1159,18 @@ def recall_cmd(path, query, recent, limit, min_importance, full, as_json):
         soul = await Soul.awaken(path)
 
         if recent is not None:
-            # Show N most recent memories across all stores
+            # Show N most recent memories across all stores. Apply --user
+            # filter post-hoc so the legacy --recent path keeps its
+            # cross-tier ordering.
             all_memories = (
                 soul._memory._episodic.entries()
                 + soul._memory._semantic.facts()
                 + soul._memory._procedural.entries()
             )
+            if user_id is not None:
+                all_memories = [
+                    m for m in all_memories if m.user_id == user_id or m.user_id is None
+                ]
             all_memories.sort(
                 key=lambda m: m.created_at or "",
                 reverse=True,
@@ -1136,6 +1182,7 @@ def recall_cmd(path, query, recent, limit, min_importance, full, as_json):
                 query,
                 limit=limit,
                 min_importance=min_importance,
+                user_id=user_id,
             )
             title = f'Recall — {soul.name} — "{query}"'
         else:
@@ -1158,6 +1205,7 @@ def recall_cmd(path, query, recent, limit, min_importance, full, as_json):
                     "importance": entry.importance,
                     "emotion": entry.emotion,
                     "created": entry.created_at.isoformat(),
+                    "user_id": entry.user_id,
                 }
                 for entry in entries
             ]
@@ -1498,7 +1546,14 @@ def _save_soul(soul, path):
 @click.option("--user-input", "user_input", required=True, help="User's message")
 @click.option("--agent-output", "agent_output", required=True, help="Agent's response")
 @click.option("--channel", default="cli", help="Channel name (default: cli)")
-def observe_cmd(path, user_input, agent_output, channel):
+@click.option(
+    "--user",
+    "user_id",
+    default=None,
+    help="Attribute the observed memory to this user_id (multi-user souls, #46). "
+    "Per-user bond is strengthened instead of the default bond.",
+)
+def observe_cmd(path, user_input, agent_output, channel, user_id):
     """Process an interaction through the full cognitive pipeline.
 
     Runs sentiment detection, significance gating, memory storage,
@@ -1508,6 +1563,7 @@ def observe_cmd(path, user_input, agent_output, channel):
     Examples:
       soul observe .soul/ --user-input "Hello" --agent-output "Hi there!"
       soul observe aria.soul --user-input "Tell me a joke" --agent-output "Why did..." --channel discord
+      soul observe aria.soul --user-input "Hi" --agent-output "Hello!" --user alice
     """
 
     async def _observe():
@@ -1520,7 +1576,7 @@ def observe_cmd(path, user_input, agent_output, channel):
             agent_output=agent_output,
             channel=channel,
         )
-        await soul.observe(interaction)
+        await soul.observe(interaction, user_id=user_id)
 
         # Save
         if Path(path).is_dir():

--- a/src/soul_protocol/mcp/server.py
+++ b/src/soul_protocol/mcp/server.py
@@ -1,5 +1,10 @@
 # soul_protocol.mcp.server — FastMCP server for soul-protocol
 # 28 tools (23 soul + 5 context), 3 resources, 2 prompts for AI agent integration
+# Updated: 2026-04-29 (#46) — Multi-user soul support. ``soul_observe`` and
+#   ``soul_recall`` accept an optional ``user_id`` parameter that pipes
+#   through to the runtime so memories get attributed and recall results
+#   filter by user. The recall payload now carries ``user_id`` per entry
+#   so consumers can render multi-user views.
 # Updated: 2026-04-06 — Added soul_dream tool for offline batch memory consolidation.
 #   Detects topic clusters, recurring procedures, behavioral trends, consolidates
 #   graph, and proposes personality evolution.
@@ -549,6 +554,7 @@ async def soul_observe(
     agent_output: str,
     channel: str = "mcp",
     soul: str | None = None,
+    user_id: str | None = None,
     ctx: Context | None = None,
 ) -> str:
     """Process an interaction through the psychology pipeline.
@@ -561,6 +567,9 @@ async def soul_observe(
         agent_output: What the agent responded
         channel: Source channel identifier
         soul: Target soul name (uses active soul if omitted)
+        user_id: When set, attribute the observed memory to this user_id
+            (multi-user souls, #46). Per-user bond is strengthened instead
+            of the default bond.
     """
     if ctx is not None:
         _get_or_create_engine(ctx)
@@ -570,7 +579,8 @@ async def soul_observe(
             user_input=user_input,
             agent_output=agent_output,
             channel=channel,
-        )
+        ),
+        user_id=user_id,
     )
     _registry.mark_modified(soul)
     state = s.state
@@ -580,6 +590,7 @@ async def soul_observe(
             "soul": s.name,
             "mood": state.mood.value,
             "energy": round(state.energy, 1),
+            "user_id": user_id,
         }
     )
 
@@ -626,6 +637,7 @@ async def soul_recall(
     query: str,
     limit: int = 5,
     soul: str | None = None,
+    user_id: str | None = None,
 ) -> str:
     """Search the soul's memories by natural language query.
 
@@ -633,9 +645,12 @@ async def soul_recall(
         query: Search query
         limit: Maximum results to return
         soul: Target soul name (uses active soul if omitted)
+        user_id: When set, restrict results to memories attributed to this
+            user_id, plus legacy entries with no user_id (multi-user souls,
+            #46). When unset, returns all memories regardless of attribution.
     """
     s = await _resolve_soul(soul)
-    results = await s.recall(query, limit=limit)
+    results = await s.recall(query, limit=limit, user_id=user_id)
     memories = [
         {
             "id": r.id,
@@ -643,6 +658,7 @@ async def soul_recall(
             "content": r.content,
             "importance": r.importance,
             "emotion": r.emotion,
+            "user_id": r.user_id,
         }
         for r in results
     ]

--- a/src/soul_protocol/runtime/bond.py
+++ b/src/soul_protocol/runtime/bond.py
@@ -1,4 +1,11 @@
 # bond.py — Human-Soul Bond model for tracking relationship strength
+# Updated: 2026-04-29 (#46) — Added BondRegistry for multi-user soul support.
+#   Wraps a default Bond plus a dict of per-user bonds keyed by user_id.
+#   Exposes Bond-like proxy attributes (bond_strength, interaction_count,
+#   bonded_to, bonded_at) that delegate to the default bond, so existing
+#   callers reading ``soul.bond.bond_strength`` keep working unchanged.
+#   strengthen()/weaken() accept a ``user_id`` keyword-only arg to route
+#   to a per-user bond when given, default bond otherwise.
 # Updated: feat/spec-multi-participant — No structural changes. Bond model is
 #   per-relationship; multi-bond tracking is managed at the Identity level
 #   via BondTarget list.
@@ -46,3 +53,126 @@ class Bond(BaseModel):
     def weaken(self, amount: float = 0.5) -> None:
         """Weaken bond (time decay or negative interactions)."""
         self.bond_strength = max(0.0, self.bond_strength - amount)
+
+
+class BondRegistry:
+    """Per-user bond registry for multi-user souls (#46).
+
+    Wraps a default :class:`Bond` (the soul's primary bond, kept on
+    ``Identity.bond`` for back-compat) plus a dict of per-user bonds keyed
+    by ``user_id``. Quacks like a :class:`Bond` for callers that only care
+    about the default — reading ``registry.bond_strength`` returns the
+    default bond's strength, ``registry.strengthen(amount)`` strengthens
+    the default. Pass ``user_id`` to route to a per-user bond instead.
+
+    The registry creates per-user :class:`Bond` instances lazily — calling
+    :meth:`for_user` or passing ``user_id`` to :meth:`strengthen` /
+    :meth:`weaken` instantiates a new bond seeded from default if absent.
+    """
+
+    def __init__(
+        self,
+        default: Bond | None = None,
+        per_user: dict[str, Bond] | None = None,
+    ) -> None:
+        self._default = default if default is not None else Bond()
+        self._per_user: dict[str, Bond] = dict(per_user) if per_user else {}
+
+    # ---- Bond proxy attributes (default bond) ----
+
+    @property
+    def default(self) -> Bond:
+        """The default bond — used when no user_id is supplied."""
+        return self._default
+
+    @property
+    def bonded_to(self) -> str:
+        return self._default.bonded_to
+
+    @bonded_to.setter
+    def bonded_to(self, value: str) -> None:
+        self._default.bonded_to = value
+
+    @property
+    def bonded_at(self) -> datetime:
+        return self._default.bonded_at
+
+    @property
+    def bond_strength(self) -> float:
+        return self._default.bond_strength
+
+    @bond_strength.setter
+    def bond_strength(self, value: float) -> None:
+        self._default.bond_strength = value
+
+    @property
+    def interaction_count(self) -> int:
+        return self._default.interaction_count
+
+    # ---- Multi-user accessors ----
+
+    def for_user(self, user_id: str) -> Bond:
+        """Return the bond for ``user_id``, creating one if missing.
+
+        New bonds default to ``Bond()`` (strength=50, count=0) with their
+        ``bonded_to`` field set to the user_id. The default bond is never
+        returned from this method — call :attr:`default` for that.
+        """
+        bond = self._per_user.get(user_id)
+        if bond is None:
+            bond = Bond(bonded_to=user_id)
+            self._per_user[user_id] = bond
+        return bond
+
+    def has_user(self, user_id: str) -> bool:
+        """True if a per-user bond exists for ``user_id``."""
+        return user_id in self._per_user
+
+    def users(self) -> list[str]:
+        """List of user_ids with their own per-user bonds.
+
+        Does not include the default bond's ``bonded_to`` (that's the
+        soul's primary user, tracked on Identity).
+        """
+        return list(self._per_user.keys())
+
+    def all_bonds(self) -> dict[str, Bond]:
+        """Snapshot of all per-user bonds (excludes the default)."""
+        return dict(self._per_user)
+
+    # ---- Operations ----
+
+    def strengthen(self, amount: float = 1.0, *, user_id: str | None = None) -> None:
+        """Strengthen the bond — default bond if user_id is None, else per-user.
+
+        Per-user bonds are created on first call with default strength=50.
+        """
+        if user_id is None:
+            self._default.strengthen(amount)
+        else:
+            self.for_user(user_id).strengthen(amount)
+
+    def weaken(self, amount: float = 0.5, *, user_id: str | None = None) -> None:
+        """Weaken the bond — default if user_id is None, else per-user."""
+        if user_id is None:
+            self._default.weaken(amount)
+        else:
+            self.for_user(user_id).weaken(amount)
+
+    # ---- Serialization ----
+
+    def to_dict(self) -> dict[str, dict]:
+        """Serialize per-user bonds (default bond is serialised separately)."""
+        return {uid: b.model_dump(mode="json") for uid, b in self._per_user.items()}
+
+    @classmethod
+    def from_dict(cls, default: Bond, per_user_data: dict[str, dict] | None) -> BondRegistry:
+        """Reconstruct a registry from a default bond plus serialised per-user data."""
+        per_user: dict[str, Bond] = {}
+        if per_user_data:
+            for uid, data in per_user_data.items():
+                if isinstance(data, Bond):
+                    per_user[uid] = data
+                else:
+                    per_user[uid] = Bond.model_validate(data)
+        return cls(default=default, per_user=per_user)

--- a/src/soul_protocol/runtime/memory/manager.py
+++ b/src/soul_protocol/runtime/memory/manager.py
@@ -1,4 +1,8 @@
 # memory/manager.py — MemoryManager facade orchestrating all memory subsystems.
+# Updated: 2026-04-29 (#46) — Multi-user soul support. observe() and recall()
+#   accept a ``user_id`` keyword that is stamped onto stored MemoryEntry
+#   instances and used to filter recall results. None preserves legacy
+#   behaviour: orphan entries are visible to any user_id query.
 # Updated: 2026-04-27 — User-driven memory update primitives.
 #   - `forget_by_id(id)` audits a single-id deletion and returns a dict in the
 #     same shape as `forget()` so the CLI can use one display path.
@@ -644,8 +648,18 @@ class MemoryManager:
         interaction: Interaction,
         core_values: list[str] | None = None,
         detect_contradictions: bool = True,
+        user_id: str | None = None,
     ) -> dict:
-        """Process an interaction through the psychology-informed pipeline."""
+        """Process an interaction through the psychology-informed pipeline.
+
+        Args:
+            interaction: The interaction to observe.
+            core_values: Override for significance scoring.
+            detect_contradictions: Whether to run contradiction detection.
+            user_id: When set, stamp the user_id on every memory written
+                during this observe call (episodic + semantic facts).
+                None leaves new entries unattributed (legacy behaviour).
+        """
         from soul_protocol.runtime.cognitive.engine import (
             compute_salience,
             generate_abstract,
@@ -693,6 +707,10 @@ class MemoryManager:
                 )
                 salience = compute_salience(sig_score)
                 self._episodic.update_entry(episodic_id, abstract=abstract, salience=salience)
+                # v0.4.0 (#46) — stamp user_id on the new episodic entry so
+                # multi-user recall can filter by attribution.
+                if user_id is not None:
+                    self._episodic.update_entry(episodic_id, user_id=user_id)
             logger.debug("Episodic memory stored: id=%s", episodic_id)
 
         # --- 4. Extract and store semantic facts ---
@@ -701,6 +719,12 @@ class MemoryManager:
             self._semantic.facts(),
             significance=sig_score,
         )
+        # v0.4.0 (#46) — stamp user_id on each newly extracted fact before
+        # dedup. Stamping pre-storage keeps the entry consistent across the
+        # MERGE/CREATE branches without re-walking after add().
+        if user_id is not None:
+            for fact in facts:
+                fact.user_id = user_id
         await self._resolve_fact_conflicts(facts)
         # Phase 2: dedup pipeline before storing
         stored_facts: list[MemoryEntry] = []
@@ -746,6 +770,9 @@ class MemoryManager:
                 )
                 salience = compute_salience(sig_score)
                 self._episodic.update_entry(episodic_id, abstract=abstract, salience=salience)
+                # v0.4.0 (#46) — stamp user_id for promoted episodic too.
+                if user_id is not None:
+                    self._episodic.update_entry(episodic_id, user_id=user_id)
             logger.debug(
                 "Promoted to episodic (facts found): id=%s, sig=%.3f",
                 episodic_id,
@@ -875,10 +902,21 @@ class MemoryManager:
         bond_strength: float = 100.0,
         bond_threshold: float = 30.0,
         progressive: bool = False,
+        user_id: str | None = None,
     ) -> list[MemoryEntry]:
+        """Recall memories from the appropriate stores.
+
+        ``user_id``: when set, filter results to entries whose ``user_id``
+        matches OR is ``None`` (legacy entries are visible to every user).
+        When ``user_id`` is ``None``, all entries are returned regardless
+        of attribution — preserves pre-#46 behaviour.
+        """
+        # Fetch a larger candidate pool when user_id filter is active so the
+        # filter doesn't shrink the result set below ``limit``.
+        fetch_limit = limit * 3 if user_id is not None else limit
         results = await self._recall_engine.recall(
             query=query,
-            limit=limit,
+            limit=fetch_limit,
             types=types,
             min_importance=min_importance,
             requester_id=requester_id,
@@ -886,6 +924,11 @@ class MemoryManager:
             bond_threshold=bond_threshold,
             progressive=progressive,
         )
+        if user_id is not None:
+            results = [
+                entry for entry in results if entry.user_id == user_id or entry.user_id is None
+            ]
+            results = results[:limit]
         logger.debug("Recall query_len=%d returned %d results", len(query), len(results))
         return results
 

--- a/src/soul_protocol/runtime/soul.py
+++ b/src/soul_protocol/runtime/soul.py
@@ -1,4 +1,12 @@
 # soul.py — The main Soul class: birth, awaken, observe, dream, save, export
+# Updated: 2026-04-29 (#46) — Multi-user soul support. observe() and recall()
+#   accept a keyword-only ``user_id`` argument. recall filters memories by
+#   user attribution. observe stamps the user_id onto written memories and
+#   strengthens the per-user bond. Soul.bond now returns a BondRegistry
+#   that quacks like the old Bond for back-compat (default bond proxy)
+#   while also routing strengthen/weaken to per-user bonds when given a
+#   user_id. New helpers: ``Soul.bond_for(user_id) -> Bond``,
+#   ``Soul.bonded_users``, ``Soul.migrate_to_multi_user()``.
 # Updated: 2026-04-27 — User-facing memory update primitives.
 #   - `Soul.forget_one(id)`: audited single-id deletion returning the same
 #     dict shape as `forget()`. Powers `soul forget --id`.
@@ -111,7 +119,7 @@ from typing import Any
 from soul_protocol.spec.learning import LearningEvent
 from soul_protocol.spec.trace import RetrievalTrace, TraceCandidate
 
-from .bond import Bond
+from .bond import Bond, BondRegistry
 from .cognitive.engine import CognitiveEngine
 from .dna.prompt import dna_to_system_prompt
 from .dream import Dreamer, DreamReport
@@ -128,6 +136,7 @@ from .state.manager import StateManager
 from .types import (
     DNA,
     Biorhythms,
+    BondTarget,
     CommunicationStyle,
     CoreMemory,
     GeneralEvent,
@@ -373,6 +382,25 @@ class Soul:
 
         # F5: Interaction counter for auto-consolidation (persisted in SoulConfig)
         self._interaction_count: int = getattr(config, "interaction_count", 0)
+
+        # v0.4.0 (#46) — Multi-user bond registry. Wraps the default bond on
+        # ``identity.bond`` plus any per-user bonds carried in
+        # ``config.bonds_per_user``. ``Soul.bond`` returns this registry; it
+        # quacks like a Bond for back-compat readers (``soul.bond.bond_strength``
+        # etc. proxy to the default bond) and also routes strengthen/weaken
+        # to per-user bonds when given a user_id.
+        self._bonds = BondRegistry.from_dict(
+            default=config.identity.bond,
+            per_user_data=getattr(config, "bonds_per_user", None) or {},
+        )
+
+        # Auto-migrate legacy souls: if Identity.bonded_to is set and the
+        # default bond doesn't yet record it, propagate. The actual
+        # bond/memory migration happens in :meth:`migrate_to_multi_user`,
+        # but we keep this lightweight sync here so existing code that
+        # reads ``soul.bond.bonded_to`` keeps working immediately.
+        if config.identity.bonded_to and not self._bonds.default.bonded_to:
+            self._bonds.default.bonded_to = config.identity.bonded_to
 
         # Retrieval trace for the most recent recall() call.
         # Consumers (paw-runtime JSONL sink, graduation policy) read this after
@@ -944,7 +972,7 @@ class Soul:
             memories = await self._memory.recall(
                 query=user_input,
                 limit=max_memories,
-                bond_strength=self._identity.bond.bond_strength,
+                bond_strength=self._bonds.default.bond_strength,
             )
             if memories:
                 lines = [f"- {m.content}" for m in memories]
@@ -1003,6 +1031,7 @@ class Soul:
         bond_threshold: float = 30.0,
         progressive: bool = False,
         scopes: list[str] | None = None,
+        user_id: str | None = None,
     ) -> list[MemoryEntry]:
         """Soul recalls relevant memories with visibility + scope filtering.
 
@@ -1014,6 +1043,13 @@ class Soul:
         returned. Filtering happens after scoring so the underlying recall
         order is unchanged.
 
+        ``user_id`` (#46): when set, results are restricted to memories
+        attributed to that user_id, plus any legacy entries where
+        ``user_id is None`` (orphan entries are visible to every user).
+        When unset, all memories are returned regardless of attribution —
+        preserves pre-#46 behaviour. Per-user bond strength is used for
+        the visibility filter when ``bond_strength`` isn't given explicitly.
+
         Populates ``self.last_retrieval`` with a :class:`RetrievalTrace`
         receipt every call, regardless of whether results were found. The
         receipt is in-memory only — never serialised into the ``.soul``
@@ -1021,9 +1057,14 @@ class Soul:
         """
         import time as _time
 
-        effective_bond = (
-            bond_strength if bond_strength is not None else self._identity.bond.bond_strength
-        )
+        # Resolve effective bond strength: caller-supplied wins, else per-user
+        # bond when user_id is set, else default bond.
+        if bond_strength is not None:
+            effective_bond = bond_strength
+        elif user_id is not None and self._bonds.has_user(user_id):
+            effective_bond = self._bonds.for_user(user_id).bond_strength
+        else:
+            effective_bond = self._bonds.default.bond_strength
         start = _time.monotonic()
         results = await self._memory.recall(
             query=query,
@@ -1034,6 +1075,7 @@ class Soul:
             bond_strength=effective_bond,
             bond_threshold=bond_threshold,
             progressive=progressive,
+            user_id=user_id,
         )
         if scopes:
             from soul_protocol.spec.scope import match_scope
@@ -1121,10 +1163,21 @@ class Soul:
         )
         return results
 
-    async def observe(self, interaction: Interaction) -> None:
+    async def observe(
+        self,
+        interaction: Interaction,
+        *,
+        user_id: str | None = None,
+    ) -> None:
         """Soul observes an interaction and learns from it.
 
         This is the main learning hook — call after every user-agent exchange.
+
+        ``user_id`` (#46): when set, every memory written during this observe
+        call is stamped with the user_id, and the per-user bond is
+        strengthened instead of the default bond. When unset (legacy
+        callers), behaviour is unchanged: memories carry ``user_id=None``
+        and the default bond is strengthened.
 
         v0.2.0 Pipeline (handled by MemoryManager.observe()):
           1. Detect sentiment → SomaticMarker
@@ -1145,7 +1198,7 @@ class Soul:
         self._skills.decay_all()
 
         # Delegate to psychology-informed memory pipeline
-        result = await self._memory.observe(interaction)
+        result = await self._memory.observe(interaction, user_id=user_id)
 
         # Update knowledge graph from extracted entities
         raw_entities = result["entities"]
@@ -1167,12 +1220,14 @@ class Soul:
         # Update state based on interaction + detected sentiment
         self._state.on_interaction(interaction, somatic=result.get("somatic"))
 
-        # Strengthen bond on each interaction
+        # Strengthen bond on each interaction. When user_id is supplied
+        # (#46), bump the per-user bond; otherwise mutate the default bond.
+        # The registry handles the routing.
         somatic = result.get("somatic")
         if somatic and somatic.valence >= 0:
-            self._identity.bond.strengthen(amount=1.0 + somatic.valence)
+            self._bonds.strengthen(amount=1.0 + somatic.valence, user_id=user_id)
         else:
-            self._identity.bond.strengthen(amount=0.5)
+            self._bonds.strengthen(amount=0.5, user_id=user_id)
 
         # Grant XP to skills matching extracted entities/topics
         # Significance-weighted XP: range 5-30 based on interaction significance
@@ -1465,9 +1520,92 @@ class Soul:
     # ============ Bond / Skills ============
 
     @property
-    def bond(self) -> Bond:
-        """Access the soul's bond with its bonded entity."""
-        return self._identity.bond
+    def bond(self) -> BondRegistry:
+        """Access the soul's bond registry (v0.4.0 / #46).
+
+        Backwards compatible: reading ``soul.bond.bond_strength``,
+        ``soul.bond.bonded_to``, ``soul.bond.interaction_count`` etc.
+        proxies to the default bond. Calling ``soul.bond.strengthen(amount)``
+        or ``soul.bond.weaken(amount)`` mutates the default bond.
+
+        Multi-user support: pass ``user_id`` keyword to strengthen/weaken to
+        route per-user. Use :meth:`bond_for` to get a specific user's
+        :class:`Bond` instance directly.
+        """
+        return self._bonds
+
+    def bond_for(self, user_id: str) -> Bond:
+        """Return the per-user :class:`Bond` for ``user_id``.
+
+        Lazily creates the per-user bond on first access (strength=50,
+        count=0). Bonds are persisted across export/awaken so once a
+        user has a bond, it survives soul migration.
+        """
+        return self._bonds.for_user(user_id)
+
+    @property
+    def bonded_users(self) -> list[str]:
+        """List of user_ids that have their own per-user bonds.
+
+        Does not include the default bond's ``bonded_to`` (that's the
+        soul's primary user, exposed via ``identity.bonded_to``).
+        """
+        return self._bonds.users()
+
+    def migrate_to_multi_user(self) -> dict:
+        """Auto-migrate a legacy single-bond soul into the multi-user shape.
+
+        - If ``Identity.bonded_to`` is set and ``Identity.bonds`` is empty,
+          synthesise a :class:`BondTarget` so the spec list is populated.
+        - If memory entries have ``user_id=None`` and a ``bonded_to`` exists,
+          stamp them with the legacy user_id so per-user filtering surfaces
+          them when the legacy user queries by their own id.
+
+        Returns a summary dict::
+
+            {
+                "synthesized_bond_target": bool,
+                "memory_entries_stamped": int,
+                "default_user_id": str | None,
+            }
+
+        Idempotent — running it twice is a no-op.
+        """
+        result: dict = {
+            "synthesized_bond_target": False,
+            "memory_entries_stamped": 0,
+            "default_user_id": None,
+        }
+
+        # Pick a default user_id: prefer Identity.bonded_to, else first bond target.
+        default_uid = self._identity.bonded_to
+        if not default_uid and self._identity.bonds:
+            default_uid = self._identity.bonds[0].id
+        result["default_user_id"] = default_uid
+
+        # Synthesize BondTarget if missing.
+        if self._identity.bonded_to and not self._identity.bonds:
+            self._identity.bonds.append(BondTarget(id=self._identity.bonded_to, bond_type="human"))
+            result["synthesized_bond_target"] = True
+
+        # Stamp legacy memories with the default user_id.
+        if default_uid:
+            count = 0
+            for entry in self._memory._episodic._memories.values():
+                if entry.user_id is None:
+                    entry.user_id = default_uid
+                    count += 1
+            for entry in self._memory._semantic._facts.values():
+                if entry.user_id is None:
+                    entry.user_id = default_uid
+                    count += 1
+            for entry in self._memory._procedural._procedures.values():
+                if entry.user_id is None:
+                    entry.user_id = default_uid
+                    count += 1
+            result["memory_entries_stamped"] = count
+
+        return result
 
     @property
     def skills(self) -> SkillRegistry:
@@ -1729,6 +1867,10 @@ class Soul:
 
     def serialize(self) -> SoulConfig:
         """Serialize to a SoulConfig for storage/export."""
+        # The default bond lives on Identity.bond (set during __init__ from
+        # the same source). Per-user bonds get serialised into
+        # SoulConfig.bonds_per_user so they survive round-trips.
+        self._identity.bond = self._bonds.default
         return SoulConfig(
             version="1.0.0",
             identity=self._identity,
@@ -1741,4 +1883,5 @@ class Soul:
             skills=[s.model_dump(mode="json") for s in self._skills.skills],
             evaluation_history=[r.model_dump(mode="json") for r in self._evaluator._history],
             interaction_count=self._interaction_count,
+            bonds_per_user=self._bonds.all_bonds(),
         )

--- a/src/soul_protocol/runtime/state/manager.py
+++ b/src/soul_protocol/runtime/state/manager.py
@@ -150,7 +150,8 @@ class StateManager:
             return
         cutoff = now.timestamp() - window
         self._state.recent_interactions = [
-            ts for ts in self._state.recent_interactions
+            ts
+            for ts in self._state.recent_interactions
             if (ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts).timestamp() >= cutoff
         ]
 

--- a/src/soul_protocol/runtime/types.py
+++ b/src/soul_protocol/runtime/types.py
@@ -1,4 +1,9 @@
 # types.py — All Pydantic data models for the Digital Soul Protocol
+# Updated: 2026-04-29 (#46) — Multi-user soul support. MemoryEntry gains an
+#   optional ``user_id: str | None`` field. None = legacy/orphan entry that
+#   belongs to the soul's default bond and is visible to any user_id query.
+#   SoulConfig gains an optional ``bonds_per_user: dict[str, Bond]`` so the
+#   per-user bond registry survives export/awaken.
 # Updated: 2026-04-29 — Density-driven focus: SoulState gains focus_override and
 #   recent_interactions; Biorhythms gains focus_window_seconds, focus_high_threshold,
 #   focus_max_threshold. focus is now computed from interaction density unless
@@ -346,6 +351,11 @@ class MemoryEntry(BaseModel):
     # "org:sales:leads". Filtered at retrieval time before results reach
     # the LLM.
     scope: list[str] = Field(default_factory=list)
+    # v0.4.0 (#46) — Per-user attribution. None = legacy / orphan entry that
+    # belongs to the soul's default bond and is visible to any user_id query.
+    # When set, recall filters entries to those matching the requested
+    # user_id (plus None entries for back-compat).
+    user_id: str | None = None
 
 
 class CoreMemory(BaseModel):
@@ -521,6 +531,10 @@ class SoulConfig(BaseModel):
     evaluation_history: list[dict] = Field(default_factory=list)
     # F5 auto-consolidation — tracks observe() call count for consolidation triggers
     interaction_count: int = 0
+    # v0.4.0 (#46) — Per-user bond registry. The default bond lives on
+    # ``identity.bond`` for back-compat; this dict carries any extra per-user
+    # bonds that the runtime accumulates. Empty when only one user is bonded.
+    bonds_per_user: dict[str, Bond] = Field(default_factory=dict)
 
 
 # ============ Interaction (input to observe()) ============

--- a/tests/test_multi_user/__init__.py
+++ b/tests/test_multi_user/__init__.py
@@ -1,0 +1,2 @@
+# tests/test_multi_user/__init__.py — Tests for multi-user soul support (#46).
+# Created: 2026-04-29 (#46) — Test package for the v0.4.0 multi-user feature.

--- a/tests/test_multi_user/test_observe_recall.py
+++ b/tests/test_multi_user/test_observe_recall.py
@@ -1,0 +1,366 @@
+# tests/test_multi_user/test_observe_recall.py — Tests for multi-user soul (#46)
+# Created: 2026-04-29 (#46) — Covers user_id memory attribution + filtering,
+#   per-user bond strength, export/awaken round-trip with user_ids preserved,
+#   and the legacy soul auto-migration path.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from soul_protocol.runtime.soul import Soul
+from soul_protocol.runtime.types import (
+    Identity,
+    Interaction,
+    LifecycleState,
+    MemoryEntry,
+    MemoryType,
+    SoulConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Helper fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def soul():
+    """A bare soul with no engine — heuristic pipeline only."""
+    return await Soul.birth(name="Aria", archetype="multi-user companion")
+
+
+# ---------------------------------------------------------------------------
+# Memory attribution + filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_id_filter_isolates_memories(soul):
+    """3 alice memories + 2 bob memories — recall by user filters cleanly."""
+    # Write 3 alice memories
+    for content in ["alice loves apples", "alice has a dog", "alice plays piano"]:
+        entry = MemoryEntry(
+            type=MemoryType.SEMANTIC,
+            content=content,
+            importance=8,
+            user_id="alice",
+        )
+        await soul._memory.add(entry)
+
+    # Write 2 bob memories
+    for content in ["bob likes basketball", "bob lives in berlin"]:
+        entry = MemoryEntry(
+            type=MemoryType.SEMANTIC,
+            content=content,
+            importance=8,
+            user_id="bob",
+        )
+        await soul._memory.add(entry)
+
+    # Recall scoped to alice — should never surface bob entries
+    alice_results = await soul.recall(
+        "alice OR bob OR loves OR likes",
+        user_id="alice",
+        limit=20,
+    )
+    alice_user_ids = {r.user_id for r in alice_results}
+    assert "alice" in alice_user_ids
+    assert "bob" not in alice_user_ids
+
+    # Recall scoped to bob — should never surface alice entries
+    bob_results = await soul.recall(
+        "alice OR bob OR loves OR likes",
+        user_id="bob",
+        limit=20,
+    )
+    bob_user_ids = {r.user_id for r in bob_results}
+    assert "bob" in bob_user_ids
+    assert "alice" not in bob_user_ids
+
+
+@pytest.mark.asyncio
+async def test_user_id_none_returns_all(soul):
+    """Recall without user_id returns the union — back-compat behaviour."""
+    for uid, content in [
+        ("alice", "alice loves apples"),
+        ("alice", "alice has a dog"),
+        ("bob", "bob likes basketball"),
+        ("bob", "bob lives in berlin"),
+    ]:
+        await soul._memory.add(
+            MemoryEntry(
+                type=MemoryType.SEMANTIC,
+                content=content,
+                importance=8,
+                user_id=uid,
+            )
+        )
+
+    all_results = await soul.recall("alice OR bob", limit=20)
+    user_ids_seen = {r.user_id for r in all_results}
+    assert "alice" in user_ids_seen
+    assert "bob" in user_ids_seen
+
+
+@pytest.mark.asyncio
+async def test_user_id_legacy_entries_visible_to_all(soul):
+    """Entries with user_id=None (legacy/orphan) come back for any user_id query."""
+    # One legacy orphan + one alice + one bob
+    await soul._memory.add(
+        MemoryEntry(
+            type=MemoryType.SEMANTIC,
+            content="the soul prefers tea over coffee",
+            importance=8,
+            user_id=None,
+        )
+    )
+    await soul._memory.add(
+        MemoryEntry(
+            type=MemoryType.SEMANTIC,
+            content="alice owns a dog named Rex",
+            importance=8,
+            user_id="alice",
+        )
+    )
+    await soul._memory.add(
+        MemoryEntry(
+            type=MemoryType.SEMANTIC,
+            content="bob owns a cat named Whiskers",
+            importance=8,
+            user_id="bob",
+        )
+    )
+
+    alice_results = await soul.recall("tea OR Rex OR Whiskers", user_id="alice", limit=20)
+    contents = [r.content for r in alice_results]
+    # Legacy entry must appear
+    assert any("tea over coffee" in c for c in contents)
+    # Alice's own entry must appear
+    assert any("Rex" in c for c in contents)
+    # Bob's must not
+    assert not any("Whiskers" in c for c in contents)
+
+    bob_results = await soul.recall("tea OR Rex OR Whiskers", user_id="bob", limit=20)
+    contents = [r.content for r in bob_results]
+    assert any("tea over coffee" in c for c in contents)
+    assert any("Whiskers" in c for c in contents)
+    assert not any("Rex" in c for c in contents)
+
+
+# ---------------------------------------------------------------------------
+# Observe stamping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_observe_stamps_user_id(soul):
+    """observe(... user_id=x) writes memories that come back with user_id=x."""
+    interaction = Interaction(
+        user_input="my name is Alice and I love python",
+        agent_output="Nice to meet you Alice! Python is great.",
+    )
+    await soul.observe(interaction, user_id="alice")
+
+    # Pull every stored entry — observe should have written at least one
+    # semantic fact attributed to alice.
+    alice_entries = [
+        e
+        for e in (
+            list(soul._memory._episodic._memories.values())
+            + list(soul._memory._semantic._facts.values())
+            + list(soul._memory._procedural._procedures.values())
+        )
+        if e.user_id == "alice"
+    ]
+    assert alice_entries, (
+        "observe(user_id='alice') should write at least one alice-attributed memory"
+    )
+
+    # And nothing should be attributed to a different user
+    bob_entries = [
+        e
+        for e in (
+            list(soul._memory._episodic._memories.values())
+            + list(soul._memory._semantic._facts.values())
+            + list(soul._memory._procedural._procedures.values())
+        )
+        if e.user_id == "bob"
+    ]
+    assert not bob_entries
+
+
+# ---------------------------------------------------------------------------
+# Per-user bond strength
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_user_bond_strength(soul):
+    """strengthen(amount, user_id='alice') only bumps alice, never bob."""
+    soul.bond.strengthen(10.0, user_id="alice")
+    alice_strength = soul.bond_for("alice").bond_strength
+    bob_strength = soul.bond_for("bob").bond_strength
+    default_strength = soul.bond.default.bond_strength
+
+    # Alice bumped from 50 → 50 + 10*(50/100) = 55.0
+    assert alice_strength == pytest.approx(55.0)
+    # Bob is fresh — still 50.0
+    assert bob_strength == pytest.approx(50.0)
+    # Default bond unchanged — only the per-user bond moved
+    assert default_strength == pytest.approx(50.0)
+
+    # Strengthen default (no user_id) — should not touch alice/bob
+    soul.bond.strengthen(10.0)
+    assert soul.bond.default.bond_strength == pytest.approx(55.0)
+    # Alice still where we left it
+    assert soul.bond_for("alice").bond_strength == pytest.approx(55.0)
+
+
+@pytest.mark.asyncio
+async def test_observe_strengthens_per_user_bond_when_user_id_given(soul):
+    """observe(... user_id='alice') should bump alice's bond, not the default."""
+    starting_default = soul.bond.default.bond_strength
+
+    interaction = Interaction(
+        user_input="hello, I love this conversation",
+        agent_output="thanks, glad to be useful!",
+    )
+    await soul.observe(interaction, user_id="alice")
+
+    # Alice's bond went up
+    assert soul.bond_for("alice").bond_strength > 50.0
+    # Default bond didn't move
+    assert soul.bond.default.bond_strength == pytest.approx(starting_default)
+
+
+# ---------------------------------------------------------------------------
+# Export / awaken round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_export_round_trip_preserves_user_ids(tmp_path: Path, soul):
+    """Memories' user_ids and per-user bond strengths survive export+awaken."""
+    # Create a mix of memories tagged for two users
+    await soul._memory.add(
+        MemoryEntry(
+            type=MemoryType.SEMANTIC,
+            content="alice prefers oat milk",
+            importance=7,
+            user_id="alice",
+        )
+    )
+    await soul._memory.add(
+        MemoryEntry(
+            type=MemoryType.SEMANTIC,
+            content="bob takes his coffee black",
+            importance=7,
+            user_id="bob",
+        )
+    )
+
+    # Touch both per-user bonds so they survive
+    soul.bond.strengthen(10.0, user_id="alice")
+    soul.bond.strengthen(5.0, user_id="bob")
+
+    # Export → awaken
+    out = tmp_path / "aria.soul"
+    await soul.export(out)
+    rebirth = await Soul.awaken(out)
+
+    # Memory user_ids preserved
+    facts = rebirth._memory._semantic.facts(include_superseded=True)
+    by_user = {f.content: f.user_id for f in facts}
+    assert by_user.get("alice prefers oat milk") == "alice"
+    assert by_user.get("bob takes his coffee black") == "bob"
+
+    # Per-user bonds preserved
+    assert rebirth.bonded_users == sorted(rebirth.bonded_users)
+    assert "alice" in rebirth.bonded_users
+    assert "bob" in rebirth.bonded_users
+    assert rebirth.bond_for("alice").bond_strength == pytest.approx(55.0)
+    assert rebirth.bond_for("bob").bond_strength == pytest.approx(52.5)
+
+
+# ---------------------------------------------------------------------------
+# Legacy auto-migration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_soul_auto_migrates_bonds():
+    """A soul loaded with only ``bonded_to`` set (no ``bonds``) populates ``bonds`` after awaken."""
+    # Construct a config the way pre-multi-bond souls were stored:
+    # bonded_to set, bonds list empty.
+    identity = Identity(
+        name="Legacy",
+        bonded_to="did:key:legacy-user-001",
+        bonds=[],
+    )
+    # Identity.model_post_init already auto-migrates — verify the runtime
+    # path also covers the case where bonds was empty at construction time.
+    config = SoulConfig(
+        identity=identity,
+        lifecycle=LifecycleState.ACTIVE,
+    )
+    s = Soul(config)
+
+    # bonds should be populated either by Identity.model_post_init or our
+    # migrate helper. Either path satisfies the contract.
+    assert s.identity.bonds, "Legacy soul awaken should populate bonds"
+    assert s.identity.bonds[0].id == "did:key:legacy-user-001"
+
+    # Force the migration helper too — should be idempotent.
+    info = s.migrate_to_multi_user()
+    assert info["default_user_id"] == "did:key:legacy-user-001"
+
+
+@pytest.mark.asyncio
+async def test_migrate_stamps_legacy_memory_entries():
+    """migrate_to_multi_user() stamps ``user_id`` on entries that lack one."""
+    identity = Identity(name="Old", bonded_to="user-001")
+    config = SoulConfig(identity=identity, lifecycle=LifecycleState.ACTIVE)
+    s = Soul(config)
+
+    # Drop a few orphan memories in (simulate pre-#46 storage)
+    await s._memory.add(
+        MemoryEntry(type=MemoryType.SEMANTIC, content="legacy fact 1", importance=5)
+    )
+    await s._memory.add(
+        MemoryEntry(type=MemoryType.SEMANTIC, content="legacy fact 2", importance=5)
+    )
+
+    info = s.migrate_to_multi_user()
+    assert info["memory_entries_stamped"] >= 2
+
+    facts = s._memory._semantic.facts(include_superseded=True)
+    for f in facts:
+        assert f.user_id == "user-001"
+
+
+# ---------------------------------------------------------------------------
+# Misc back-compat
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bond_proxy_back_compat(soul):
+    """soul.bond.bond_strength etc. still works through the registry proxy."""
+    # Reading still works
+    assert soul.bond.bond_strength == 50.0
+    assert soul.bond.interaction_count == 0
+
+    # Strengthen with no user_id mutates the default — proxy reflects it
+    soul.bond.strengthen(10.0)
+    assert soul.bond.bond_strength == pytest.approx(55.0)
+    assert soul.bond.interaction_count == 1
+
+
+@pytest.mark.asyncio
+async def test_bond_for_creates_bonds_lazily(soul):
+    """First call to bond_for(uid) creates a fresh Bond(strength=50)."""
+    assert soul.bonded_users == []
+    bond = soul.bond_for("first-time")
+    assert bond.bond_strength == 50.0
+    assert "first-time" in soul.bonded_users

--- a/uv.lock
+++ b/uv.lock
@@ -2277,7 +2277,7 @@ wheels = [
 
 [[package]]
 name = "soul-protocol"
-version = "0.3.4"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #46. First of three PRs for the v0.4.0 identity bundle. #41 (memory layers) and #42 (trust chain) ride on top of this.

## What's in

A single soul can now serve multiple users without their memories bleeding into each other.

- `MemoryEntry.user_id: str | None` — None means legacy/orphan, visible to every user_id query.
- `Soul.observe(interaction, *, user_id=None)` — stamps writes with the user_id and strengthens that user's bond.
- `Soul.recall(query, *, user_id=None)` — filters results to entries matching the user_id (plus None entries). Unset returns everything (pre-#46 behaviour).
- `BondRegistry` wraps the existing default `Bond` and a per-user dict. `Soul.bond` returns the registry; it quacks like a Bond for back-compat (`soul.bond.bond_strength` still works) and routes `strengthen`/`weaken` per user when given a `user_id`.
- `Soul.bond_for(user_id) -> Bond` for direct per-user access. `Soul.bonded_users` lists the registered user_ids.
- `Soul.migrate_to_multi_user()` for legacy souls — back-fills `bonds` from `bonded_to` and stamps orphan memories with the legacy user_id.
- Per-user bonds persist via `SoulConfig.bonds_per_user`. Default bond keeps living on `Identity.bond`.
- CLI: `soul observe --user <id>`, `soul recall --user <id>`. `soul status` shows per-user bonds when more than one is present.
- MCP: `soul_observe(user_id=...)`, `soul_recall(user_id=...)`. The recall payload now carries `user_id` per entry.

## What's not

- Memory layers / `domain` field / open-string `MemoryType` — that's #41.
- Trust chain / signed journal — that's #42.
- Multi-user dashboard UI — pocketpaw concern.

## Test plan

- [x] New `tests/test_multi_user/test_observe_recall.py` with 11 tests covering: user_id filter isolation, None returns all, legacy entries visible to every user, observe stamping, per-user bond strength, observe-strengthens-per-user, export/awaken round-trip, legacy soul auto-migration, migration stamps orphan entries, bond proxy back-compat, lazy bond creation.
- [x] Full suite: 2352 passed, 1 skipped (was 2342, +11 new tests).
- [x] `uv run ruff format .` and `uv run ruff check .` clean.
- [x] Touched docs in same PR: `api-reference.md`, `cli-reference.md`, `mcp-server.md`. CHANGELOG already had the entry from the release scaffold; verified it matches what shipped.

## Breaking changes

- `Soul.bond` now returns a `BondRegistry` (Bond-shaped proxy) instead of a `Bond`. Reads still work — every Bond attribute that callers touch (`bond_strength`, `interaction_count`, `bonded_to`, `bonded_at`) is proxied to the default bond. The change is invisible unless code does `isinstance(soul.bond, Bond)` (it isn't anymore — but nothing in the repo does this).
- `Soul.observe(...)` keeps the same positional `interaction` arg; `user_id` is keyword-only.
- `Soul.recall(...)` keyword args grow a new `user_id` slot; positional callers were already keyword-only past `query` so nothing breaks.

## Notes

- Recall fetches a 3x candidate pool when `user_id` filter is active so the post-filter result set still hits `limit`. Cheaper than threading the filter into every store search path.
- Per-user bonds are created lazily on first observe / `bond_for` / `strengthen(... user_id=)` so a soul that's only ever bonded to one human doesn't accumulate empty registry entries.
- `migrate_to_multi_user()` is idempotent — re-running it is safe and a no-op once the soul is already migrated.