### PR TITLE
docs: refresh for v0.4.0 identity bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 <!-- README.md — soul-protocol open standard -->
-<!-- Updated: 2026-04-19 (v0.3.2) — retrieval infrastructure (Router, Broker
+<!-- Updated: 2026-04-29 (v0.4.0) — Identity bundle release: multi-user souls
+     (#46), user-defined memory layers + domain isolation (#41), Ed25519-signed
+     trust chain (#42). Plus rolled-in polish: density-driven focus (#194),
+     memory update primitives — supersede + forget --id (#193), wiki rebuild
+     (#186). Schema migrates automatically on awaken. Soul.export now defaults
+     to include_keys=False so shared souls cannot be impersonated. Test count
+     2371 → 2551.
+     Updated: 2026-04-19 (v0.3.2) — retrieval infrastructure (Router, Broker
      impl, ProjectionAdapter) pruned from soul-protocol; spec/retrieval.py
      now holds only the vocabulary (Protocols + types + exceptions) that a
      third-party implementation needs. Concrete orchestration moved to the
@@ -23,11 +30,11 @@
 
 # Soul Protocol
 
-**Portable AI identity, memory, and emotion -- plus an org-level journal and decision traces. An open standard.**
+**Portable AI identity, memory, and emotion -- plus an org-level journal, decision traces, and a verifiable trust chain. An open standard.**
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests: 2371 passing](https://img.shields.io/badge/tests-2371%20passing-brightgreen)](https://github.com/qbtrix/soul-protocol)
+[![Tests: 2551 passing](https://img.shields.io/badge/tests-2551%20passing-brightgreen)](https://github.com/qbtrix/soul-protocol)
 
 ---
 
@@ -41,6 +48,8 @@
 AI memory systems optimize for retrieval: find the most similar text, stuff it into context, move on. They treat persistence as an IQ problem. But what makes a companion feel real isn't similarity search. It's knowing what matters, what to forget, and who it's becoming.
 
 Soul Protocol gives AI agents persistent identity with psychology-informed memory. Your agent remembers selectively, forms emotional bonds, develops skills, and maintains a personality that evolves over time. The entire state exports as a portable `.soul` file. Switch LLMs, switch platforms, keep the soul.
+
+**v0.4.0 — Identity bundle (April 2026):** one soul can serve multiple users without bleeding context (`soul.observe(user_id=...)`), memory layers are open strings instead of a fixed enum (build a custom `social` or `finance` layer), domain isolation enforces who can read/write which slice, and every learning event, memory mutation, and bond change appends a signed entry to a verifiable trust chain. Read [docs/trust-chain.md](docs/trust-chain.md) for the threat model.
 
 As of v0.3.1, the protocol also covers the layer *above* a single soul: an org-scoped append-only event journal, a root governance agent, scope-tagged memory, decision traces (`agent.proposed` → `human.corrected` → `decision.graduated`), and a zero-copy retrieval router for federating external data without copying it into the org boundary.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,5 +1,11 @@
 <!--
   SPEC.md — Soul Protocol, the standard.
+  Updated: 2026-04-29 (v0.4.0 identity bundle) — added user_id and domain
+  fields on MemoryEntry, open-string layers replacing the fixed five-tier
+  enum (with the original five preserved as built-in layer names + new
+  optional 'social' layer), and the trust chain primitives (TrustEntry,
+  TrustChain, SignatureProvider, verification helpers). Bumped the
+  conformance level and noted the migration story for 0.3.x souls.
   Created: 2026-04-19 (feat/0.3.3-prune-retrieval-infra) — companion to the
   0.3.3 retrieval prune. This doc describes what Soul Protocol IS, as a
   standard, independent of our Python reference implementation. Anyone
@@ -14,7 +20,7 @@
 
 > Soul Protocol is a portable, open standard for persistent AI identity, memory, and retrieval. This document is language-agnostic. It describes what Soul Protocol is, independent of how our Python reference implementation happens to build it.
 
-Version: **0.3.3** (spec) · Status: **draft, breaking-change-free since 0.3**
+Version: **0.4.0** (spec) · Status: **draft, breaking-change-free since 0.3**
 
 If you are **building on top of our Python implementation**, start with [README.md](../README.md) and [docs/architecture.md](./architecture.md). If you are **implementing Soul Protocol in another language** (Rust, Go, TypeScript, etc.) or a custom runtime, this document is the authoritative contract.
 
@@ -22,13 +28,14 @@ If you are **building on top of our Python implementation**, start with [README.
 
 ## 1 · What Soul Protocol is
 
-Three concerns bundled into one standard:
+Four concerns bundled into one standard:
 
-1. **Identity** — every soul has a DID, a persona, OCEAN personality traits, values, and an evolution history.
-2. **Memory** — five tiers (core, episodic, semantic, procedural, graph) with psychology-informed activation semantics.
+1. **Identity** — every soul has a DID, a persona, OCEAN personality traits, values, and an evolution history. As of 0.4.0, a soul can serve multiple users, and memory entries can be attributed to a `user_id`.
+2. **Memory** — open-string layers (core, episodic, semantic, procedural, graph, social, plus any user-defined layer) with psychology-informed activation semantics and optional `domain` namespacing for context isolation.
 3. **Event substrate** — an append-only journal that records every consequential change to a soul or an org, scope-stamped and tamper-evident.
+4. **Trust chain** (0.4.0) — a per-soul append-only log of signed entries (memory writes, evolution steps, learning events, bond changes) so a soul can prove what it learned and where. Ed25519-signed Merkle-style hash chain, verifiable without an external key registry.
 
-A **.soul file** carries (1) and the relevant memory slice of (2) — it is a zip archive that any Soul Protocol implementation can read, write, and export from. An **org journal** carries (3) — a single SQLite database (or equivalent) that sits alongside one or more souls.
+A **.soul file** carries (1), the relevant memory slice of (2), and (4) — it is a zip archive that any Soul Protocol implementation can read, write, and export from. An **org journal** carries (3) — a single SQLite database (or equivalent) that sits alongside one or more souls.
 
 Everything else the reference implementation ships — psychology pipeline algorithms, retrieval orchestration, MCP server, CLI, web UI — is a *consumer* of this standard, not part of it.
 
@@ -42,16 +49,25 @@ A `.soul` file is a ZIP archive with a fixed directory layout. Any implementatio
 <name>.soul/
 ├── identity.json         — Identity (below)
 ├── dna.json              — DNA (personality traits + communication style + biorhythms)
-├── memory/
-│   ├── core.jsonl        — MemoryEntry records, tier=core
-│   ├── episodic.jsonl    — MemoryEntry records, tier=episodic
-│   ├── semantic.jsonl    — MemoryEntry records, tier=semantic
-│   ├── procedural.jsonl  — MemoryEntry records, tier=procedural
-│   └── graph.jsonl       — MemoryEntry records, tier=graph (entity relationships)
+├── memory/               — Built-in layer tier files (legacy flat layout)
+│   ├── core.jsonl        — MemoryEntry records, layer=core
+│   ├── episodic.jsonl    — MemoryEntry records, layer=episodic
+│   ├── semantic.jsonl    — MemoryEntry records, layer=semantic
+│   ├── procedural.jsonl  — MemoryEntry records, layer=procedural
+│   ├── graph.jsonl       — MemoryEntry records, layer=graph (entity relationships)
+│   ├── social.jsonl      — MemoryEntry records, layer=social (relationship memory) [optional, 0.4.0+]
+│   ├── _layout.json      — Optional layout marker (presence implies nested layout below) [0.4.0+]
+│   └── <layer>/<domain>/entries.jsonl  — Nested layout for non-default-domain or custom-layer entries [0.4.0+]
 ├── skills/
 │   └── <skill_name>.md   — Procedural capabilities with XP tracking
 ├── bonds/
 │   └── <bond_id>.json    — Relationship state (BondTarget records)
+├── trust_chain/          — Signed action history [0.4.0+, optional but expected if keys/ present]
+│   ├── chain.json        — Canonical TrustChain serialization
+│   └── entry_NNN.json    — One file per entry (NNN is zero-padded seq, for human inspection)
+├── keys/                 — Cryptographic identity for the trust chain [0.4.0+]
+│   ├── public.key        — Raw 32-byte Ed25519 public key (always shipped when the soul has signed at least once)
+│   └── private.key       — Raw 32-byte Ed25519 private key (shipped only when include_private=true on export)
 ├── evolution.jsonl       — Append-only history of personality / trait mutations
 └── manifest.json         — Container-level metadata (schema_version, created_at, owner)
 ```
@@ -60,9 +76,11 @@ A `.soul` file is a ZIP archive with a fixed directory layout. Any implementatio
 
 - All timestamps in files are ISO-8601 with timezone offset (UTC recommended). Naive datetimes are invalid.
 - JSONL files use one record per line, UTF-8, LF line endings, trailing newline optional.
-- `manifest.json` includes `schema_version: "0.3.3"` (or the version the file was written against).
+- `manifest.json` includes `schema_version: "0.4.0"` (or the version the file was written against).
 - A reader encountering a `schema_version` newer than it supports must fail loud, not silently drop fields.
 - File-level mutations are additive within a version: new fields may appear but existing fields do not disappear or change meaning without a major version bump.
+- A reader of a 0.4.0+ archive must accept either the legacy flat layout (`memory/<layer>.jsonl` only) or the nested layout (`memory/<layer>/<domain>/entries.jsonl`). Presence of `memory/_layout.json` indicates the nested layout is in use; absence implies flat. The two layouts must produce identical reader outputs for a soul whose entries all use `domain="default"`.
+- A reader of a 0.4.0+ archive must accept the absence of `trust_chain/` and `keys/` (legacy 0.3.x souls). When present, both directories' contents are subject to verification per §12.
 
 See `soul_protocol.spec.soul_file` in the reference impl for `pack_soul()` / `unpack_soul()` / `unpack_to_container()` — the codec surface any implementation must reproduce.
 
@@ -86,24 +104,28 @@ Identity {
 
 ## 4 · Memory
 
-### 4.1 · The five tiers
+### 4.1 · Built-in layers + open-string layer model (0.4.0)
 
-A `MemoryEntry` belongs to exactly one tier. The tiers are:
+A `MemoryEntry` belongs to exactly one **layer**. As of 0.4.0, the layer is an arbitrary string — implementations are not required to enforce a fixed enum. The reference implementation ships seven built-in layers with conventional names; user code may define additional ones.
 
-| Tier | Meaning | When to write |
+| Layer | Meaning | When to write |
 |---|---|---|
 | `core` | Identity-level facts always in context ("who am I") | Rarely — these are load-bearing |
 | `episodic` | Events that happened ("what occurred at time T") | Most interactions |
 | `semantic` | General knowledge ("what I know") | Facts the soul should recall, not events |
 | `procedural` | How-to knowledge, recipes, procedures | Skills, learned patterns |
 | `graph` | Entity relationships (soul→entity→entity edges) | Links between people, orgs, concepts |
+| `social` (0.4.0+) | Relationship memory — bonds, trust, communication preferences per user | When a soul updates how it relates to a specific user |
+| *user-defined* (0.4.0+) | Any string the implementation accepts | Application-specific namespaces |
+
+Pre-0.4.0 archives encode the layer in a `tier` field. 0.4.0+ archives encode it in `layer`. A reader **must** accept either field name; if both are present, `layer` wins.
 
 ### 4.2 · MemoryEntry
 
 ```
 MemoryEntry {
   id:           UUID
-  tier:         Literal["core", "episodic", "semantic", "procedural", "graph"]
+  layer:        str          # 0.4.0+ — see §4.1. Pre-0.4.0 readers see this as `tier`.
   content:      str
   importance:   float        # 0.0..10.0, caller-assigned baseline
   scope:        [str]        # DSP scope patterns — see §7
@@ -113,8 +135,20 @@ MemoryEntry {
   access_count: int          # incremented on recall
   last_accessed_at: datetime | None
   metadata:     dict[str, Any]
+
+  # Identity bundle (0.4.0)
+  user_id:      str | None   # The user this memory is attributed to.
+                             # None = orphan / soul-default. Filtering by
+                             # user_id includes None entries (legacy
+                             # back-compat).
+  domain:       str          # Sub-namespace within the layer. Default
+                             # "default". Use to isolate context, e.g.
+                             # "finance", "legal", "personal". Domain
+                             # isolation enforcement is application-layer.
 }
 ```
+
+Pre-0.4.0 souls have neither `user_id` nor `domain`. On read, an implementation must accept their absence and treat them as `user_id=None`, `domain="default"` so legacy entries surface in every recall.
 
 ### 4.3 · Psychology-informed activation (outputs, not algorithms)
 
@@ -385,27 +419,127 @@ A `CognitiveEngine` is the agent's thinking substrate — Claude, GPT-4, local O
 
 ---
 
+## 10A · Trust chain (0.4.0)
+
+Every soul carries an append-only log of signed entries — the trust chain. One entry per audit-worthy action: a memory write, a memory supersede, a forget, an evolution proposal, an evolution apply, a learning event, a bond change, or any other action a runtime considers significant. Reading a soul's chain answers "what did this soul do, and can I prove it?"
+
+### 10A.1 · TrustEntry
+
+```
+TrustEntry {
+  seq:          int         # monotonic 0-indexed
+  timestamp:    datetime    # UTC, ISO-8601
+  actor_did:    str         # DID of the signer (usually the soul's own DID)
+  action:       str         # dot-namespaced ("memory.write", "evolution.applied", ...)
+  payload_hash: str         # SHA-256 hex of the canonical JSON of the action's payload
+  prev_hash:    str         # SHA-256 hex of the previous entry, or GENESIS_PREV_HASH for seq=0
+  signature:    str         # base64 of the raw signature bytes
+  algorithm:    str         # signing algorithm; default "ed25519"
+  public_key:   str         # base64 of the raw public key used to verify (32 bytes for ed25519)
+}
+```
+
+The full payload is **not stored** — only its SHA-256 hash. This keeps the chain compact and avoids redundant storage of memory contents that already live in their own tier files. A verifier with the original payload and the chain entry can prove the payload existed at signing time.
+
+### 10A.2 · Canonical encoding
+
+Both signers and verifiers must use the same canonical JSON encoding:
+
+- Sorted keys
+- Separators `(",", ":")` (no whitespace)
+- `ensure_ascii=true` (unicode escaped)
+- Datetimes serialized via `isoformat()`, UTC-normalized
+
+The hash of an entry is computed over the canonical JSON of every field **except `signature`** (the signature is the result of signing; it cannot be part of its own input). This hash is what the next entry's `prev_hash` must equal.
+
+### 10A.3 · GENESIS_PREV_HASH
+
+```
+GENESIS_PREV_HASH = "0" * 64
+```
+
+A constant 64 hex zeros. Anchors the chain at seq=0; an attacker cannot pretend to lop off the head since the genesis prev_hash is fixed.
+
+### 10A.4 · TrustChain
+
+```
+TrustChain {
+  did:     str
+  entries: [TrustEntry]   # ordered ascending by seq, no gaps
+}
+```
+
+### 10A.5 · SignatureProvider (Protocol)
+
+```
+SignatureProvider {
+  algorithm:  str
+  public_key: str
+
+  sign(message: bytes) -> str         # returns base64 signature
+  verify(message: bytes, signature: str, public_key: str) -> bool
+}
+```
+
+The reference implementation ships `Ed25519SignatureProvider`. Other implementations may add P-256, secp256k1, etc. — provided the `algorithm` field on each entry identifies which one was used.
+
+### 10A.6 · Verification contract
+
+A conforming verifier checks each entry sequentially. The chain is valid iff every entry passes:
+
+1. **Chain link.** For seq=0: `prev_hash == GENESIS_PREV_HASH`. For seq>0: `prev_hash` matches `compute_entry_hash(prev_entry)` AND `seq == prev.seq + 1`.
+2. **Signature.** `verify(canonical_json_minus_signature, signature, public_key) == true`.
+3. **No duplicates.** No two entries share a `seq` value.
+4. **Future timestamps.** Entry's timestamp is no more than 60 seconds beyond the verifier's local clock (skew tolerance).
+
+The verifier returns the seq of the first failure plus a reason string. An empty chain is trivially valid.
+
+### 10A.7 · Identity binding
+
+The chain itself proves *some key* signed these entries. To prove **this soul** signed them, an implementation must additionally check that every entry's `public_key` matches the soul's loaded keystore public key. The reference implementation enforces this in `Soul.verify_chain()`. Implementations that only verify chain-internal consistency MUST NOT claim "soul X performed these actions" — they can only claim "this is a self-consistent chain."
+
+### 10A.8 · Threat model summary
+
+The chain detects: tampering with past entries, forged signatures, mid-chain insertion, reordering, replay, future-timestamped entries.
+
+The chain does NOT defend against: head truncation (a receiver-side concern — pin the latest known head externally), private-key compromise (rotate keys), censorship of which actions get recorded (the chain only attests to what was signed), payload confidentiality (only hashes on the chain — protect the payload files themselves), or external-time correctness (use a timestamping service if you need that).
+
+### 10A.9 · Optionality
+
+The trust chain is **optional** for 0.4.0 conformance. Souls without a `keys/` or `trust_chain/` directory in their archive remain valid 0.4.0 souls — they simply cannot prove provenance. An implementation that wants to claim full 0.4.0 conformance must also support the chain (read, write, verify); a partial implementation that only handles identity + memory + journal is allowed to ship as "0.4.0 (no trust chain)."
+
+---
+
 ## 11 · Conformance
 
-An implementation **claims Soul Protocol 0.3.3 compliance** when it can:
+An implementation **claims Soul Protocol 0.4.0 compliance** when it can:
 
-- [ ] Read and write `.soul` files at schema_version 0.3.3 (§2)
-- [ ] Honor the memory tier semantics, including activation decay and significance gating (§4)
+- [ ] Read and write `.soul` files at schema_version 0.4.0 (§2), accepting both the legacy flat memory layout and the nested `memory/<layer>/<domain>/entries.jsonl` layout
+- [ ] Honor the memory layer semantics including the open-string layer model and the `domain` namespacing (§4.1, §4.2)
+- [ ] Round-trip 0.3.x souls into 0.4.0 form (treat absent `user_id` as None, absent `domain` as `"default"`, absent `layer` as the legacy `tier` value)
 - [ ] Implement the `Journal.append` / `Journal.query` contract including `action_prefix` (§8)
 - [ ] Emit scope-non-empty `EventEntry` records with UTC timestamps (§8)
 - [ ] Round-trip `.soul` files produced by the reference impl without field loss (§2)
 - [ ] Implement the `CognitiveEngine` protocol (§10)
 
+**Optional extension — Trust Chain (§10A):**
+
+- [ ] Read, write, and verify `TrustChain` records
+- [ ] Bind verification to the loaded keystore public key (§10A.7) — required if claiming "verifiable history" in marketing
+- [ ] Generate Ed25519 keypairs and sign new entries
+
+An implementation may claim "0.4.0 (no trust chain)" if it implements all the required boxes but skips the trust chain extension.
+
 Retrieval infrastructure (Router/Broker/Adapter implementations) is explicitly NOT required for compliance — it is application-layer.
 
-A conformance test suite lives in the reference implementation under `tests/conformance/` (planned — 0.4.0).
+A conformance test suite lives in the reference implementation under `tests/conformance/` (planned — 0.4.x).
 
 ---
 
 ## 12 · Versioning
 
 - **Patch** (0.3.1 → 0.3.3) — additive fields, new query parameters, new exported types. Non-breaking.
-- **Minor** (0.3.x → 0.4.0) — backward-compatible structural changes. Implementations may need to upgrade but old `.soul` files still read.
+- **Minor** (0.3.x → 0.4.0) — backward-compatible structural changes. Implementations may need to upgrade but old `.soul` files still read. The 0.4.0 minor introduced multi-user attribution (`user_id`), open-string layers + `domain` namespacing, and the optional trust chain.
 - **Major** (0.x → 1.0) — reserved for the first stable release.
 
 The reference implementation may release patch versions faster than the spec. Spec versions advance only when the contract changes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,8 +2,8 @@
 
 > Current implementation architecture, module dependencies, memory layers, and data flow.
 
-**Date:** 2026-04-19
-**Version:** 0.3.2
+**Date:** 2026-04-30
+**Version:** 0.4.0
 
 > ⚠️  **This document describes our Python reference implementation.** If you are implementing Soul Protocol in another language, read [SPEC.md](./SPEC.md) instead — it is the language-agnostic contract. The patterns below (SQLite-backed journal, Damasio/ACT-R/LIDA pipeline, this specific module layout) are one way to honor the spec, not the only way.
 
@@ -16,6 +16,8 @@ This doc covers the per-soul implementation — how a single `.soul` file works,
 **v0.3 adds an org layer** (multi-soul + event journal + decision traces) on top of the per-soul model. The org layer is specified separately in `org-journal-spec.md` as a framework-agnostic protocol. Section 7 of this doc summarizes how *this codebase* implements that spec; for the spec itself, see the dedicated doc.
 
 **v0.3.2 retrieval pruning note:** `engine/retrieval/` has been removed from soul-protocol. The concrete `RetrievalRouter`, `InMemoryCredentialBroker`, and `ProjectionAdapter` implementations now live in pocketpaw (the reference agent runtime). The spec-level vocabulary (`SourceAdapter` / `AsyncSourceAdapter` / `CredentialBroker` protocols, `Credential`, `RetrievalRequest`, `RetrievalCandidate`, `DataRef`, and the `RetrievalError` hierarchy) lives in `soul_protocol.spec.retrieval`. This enforces the rule that anything application-layer (orchestration, credential brokering, adapter registration) is a consumer of the spec, not part of it.
+
+**v0.4.0 identity bundle note:** three new top-level subsystems landed. `MemoryEntry` gained `user_id` and `domain` fields plus an open-string `layer` model — `runtime/memory/` exposes a generic `LayerView` accessor and a new `social.py` layer store. `runtime/middleware/domain_isolation.py` enforces domain allow-lists. The trust chain primitives live in `spec/trust.py` (TrustEntry, TrustChain, SignatureProvider, verification helpers); the runtime concrete signer is `runtime/crypto/ed25519.py` (Ed25519SignatureProvider) with `runtime/crypto/keystore.py` for I/O. `runtime/trust/manager.py` owns the chain. The Soul class wires append hooks into observe / supersede / forget_one / propose_evolution / approve_evolution / learn / bond mutations. `Soul.verify_chain()` binds verification to the loaded keystore's public key so a chain replacement attack on a shared soul (`include_keys=False`) is detectable.
 
 ---
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -338,6 +338,63 @@ The default is `TokenOverlapStrategy`, which uses Jaccard token overlap (fractio
 See [CognitiveEngine Guide](cognitive-engine.md) for full documentation on search strategies.
 
 
+## Identity Bundle Concepts (v0.4.0)
+
+The 0.4.0 release adds three new top-level concepts to a single soul. None of these require the org layer; they all work on a standalone soul.
+
+### Multi-User Soul
+
+A soul can serve multiple users — a support agent answering 100 customers, a family assistant, a coding buddy that pairs with several teammates. Pass `user_id` to `observe()` and `recall()` to scope memory and bond strength per user.
+
+```python
+await soul.observe(interaction, user_id="alice")
+await soul.observe(interaction, user_id="bob")
+
+# Alice-scoped recall — sees alice's memories + legacy (None-attributed) entries
+mems = await soul.recall("project", user_id="alice")
+
+# Each user has their own bond
+soul.bond_for("alice").bond_strength  # alice's bond
+soul.bond_for("bob").bond_strength    # independent
+```
+
+Per-user bonds live in a `BondRegistry`; the default bond stays available for legacy single-user code.
+
+### Memory Layers (open strings) + Domains
+
+`MemoryType` is no longer a fixed enum at the spec layer. The runtime ships seven built-in layers — `core`, `episodic`, `semantic`, `procedural`, `graph`, `social`, plus any user-defined string. `manager.layer("custom_namespace").store(entry)` is valid.
+
+Within a layer, `MemoryEntry.domain` is a sub-namespace defaulting to `"default"`. Use it to isolate context: `"finance"`, `"legal"`, `"personal"`. A `DomainIsolationMiddleware` wraps a soul and enforces a domain allow-list — reads silently filter, writes raise `DomainAccessError`. Use it to give a sub-agent a sandboxed view of the soul without handing them full access.
+
+```python
+finance_view = DomainIsolationMiddleware(soul, allowed_domains=["finance"])
+await finance_view.remember("Q3 revenue $4.2M", domain="finance")  # ok
+await finance_view.remember("Friend's birthday March 5", domain="personal")  # DomainAccessError
+```
+
+The new `social` layer is for relationship memory — bonds, trust signals, communication preferences per user.
+
+### Trust Chain
+
+Every memory write, supersede, forget, evolution proposal, evolution apply, learning event, and bond change appends a signed entry to the soul's trust chain. The chain is an Ed25519-signed Merkle-style hash chain — alter any past entry and every entry after it is invalid.
+
+```python
+ok, reason = soul.verify_chain()  # True or (False, "<reason> at seq N")
+log = soul.audit_log()             # human-readable timeline
+```
+
+`Soul.export(include_keys=False)` (the new default) drops the private signing key from the archive. The recipient can verify the chain but cannot append new entries — the soul is shareable without giving away signing power. See [docs/trust-chain.md](trust-chain.md) for the full threat model.
+
+### How they fit together
+
+- **Multi-user** attributes memories to a `user_id`.
+- **Layers + domains** organize memories into namespaces.
+- **Trust chain** signs every consequential change so the soul's history is verifiable.
+
+A soul can use any subset. Single-user souls in the default domain with no chain still work — every new field has a backward-compatible default.
+
+---
+
 ## Org-Level Concepts (v0.3.1)
 
 Everything above describes a single soul. A soul can live on its own forever — a personal assistant doesn't need an org. But when multiple agents and humans share context, audit history, and access boundaries, the **org layer** provides the container.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -337,6 +337,15 @@ See the [CognitiveEngine Guide](cognitive-engine.md) for details.
 - **[Decision Traces](decision-traces.md)** -- `agent.proposed` → `human.corrected` → `decision.graduated` event chains
 - **[Manual Testing](manual-testing.md)** -- Hands-on walkthrough for every org-layer primitive
 
+### What's new in v0.4.0 — Identity bundle
+
+- **Multi-user souls** -- `soul.observe(user_id="alice")` and `soul.recall(user_id="alice")` filter memory and bond context per user. One soul can serve multiple humans without bleeding context.
+- **Memory layers as open strings** -- `MemoryType` is no longer a fixed enum at the spec layer. The runtime ships seven built-in layers (`core`, `episodic`, `semantic`, `procedural`, `graph`, `social`, plus user-defined). `manager.layer("custom_layer").store(entry)` works.
+- **Domain isolation** -- `MemoryEntry.domain` (default `"default"`) namespaces memories. `DomainIsolationMiddleware(soul, allowed_domains=["finance"])` sandboxes a soul to a domain allow-list.
+- **Trust chain** -- every memory write, supersede, forget, evolution event, and bond change appends an Ed25519-signed entry. `soul verify` checks chain integrity. `soul audit` shows the timeline. `Soul.export(include_keys=False)` is the new default — shared souls cannot be impersonated.
+- **Density-driven focus** -- `SoulState.focus` is computed from a sliding window of recent interactions. `soul.feel(focus="max")` for manual lock; `soul.feel(focus="auto")` reverts.
+- **Memory update primitives** -- `soul supersede` writes a new memory and links the old via `superseded_by`; `soul forget --id` for audited single-id deletion.
+
 ### What's new in v0.3.1
 
 - `soul org init / status / destroy` -- bootstrap a governance journal with a root agent

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,7 @@
 <!-- Covers: Documentation index, quick links to all guides (including integrations), version info, project links -->
+<!-- Updated: 2026-04-29 — v0.4.0 identity bundle: added Trust Chain entry,
+     bumped Current release to 0.4.0, mentioned multi-user souls + memory
+     layers + domain isolation in the at-a-glance example. -->
 <!-- Updated: 2026-04-14 — v0.3.1: added org-journal-spec, org, decision-traces,
      manual-testing entries; bumped Current release to 0.3.1. -->
 <!-- Updated: 2026-03-13 — added Tier 1.5 soul inject guide link -->
@@ -28,6 +31,7 @@ A soul remembers. A soul grows. A soul migrates.
 | [Org Management](org.md) | `soul org init / status / destroy` walkthrough |
 | [Org Journal Spec](org-journal-spec.md) | Framework-agnostic protocol: journal, root agent, retrieval router, credential broker |
 | [Decision Traces](decision-traces.md) | `agent.proposed` → `human.corrected` → `decision.graduated` event chains |
+| [Trust Chain](trust-chain.md) | Verifiable action history — Ed25519-signed Merkle-style chain, threat model, key management (v0.4.0) |
 | [Manual Testing](manual-testing.md) | Hands-on validation for the v0.3 org-layer primitives |
 
 
@@ -38,22 +42,34 @@ from soul_protocol import Soul, Interaction
 
 soul = await Soul.birth(name="Aria", values=["empathy", "creativity"])
 
-await soul.observe(Interaction(
-    user_input="I love building with Python",
-    agent_output="Python is a great choice!",
-    channel="chat",
-))
+# v0.4.0 — multi-user observe + domain stamping
+await soul.observe(
+    Interaction(
+        user_input="I love building with Python",
+        agent_output="Python is a great choice!",
+        channel="chat",
+    ),
+    user_id="alice",
+    domain="default",
+)
 
-memories = await soul.recall("Python")
+# Recall scoped to alice's view, default domain
+memories = await soul.recall("Python", user_id="alice", domain="default")
+
+# Verify the trust chain — every observe / supersede / forget appended a signed entry
+ok, reason = soul.verify_chain()
+assert ok, reason
+
 prompt = soul.to_system_prompt()
 
+# Share without leaking signing power (default include_keys=False)
 await soul.export("aria.soul")
 ```
 
 
 ## Version
 
-Current release: **v0.3.1**
+Current release: **v0.4.0** (April 2026 — identity bundle: multi-user souls, memory layers + domain isolation, trust chain)
 
 Requires Python 3.11+.
 


### PR DESCRIPTION
Catch up on the doc files that didn't get touched in the sub-PRs (#195, #196, #197). The api-reference, cli-reference, mcp-server, memory-architecture, and trust-chain docs were already updated; this PR covers everything else.

## Files changed

- **README.md** — header dates + test count badge bumped, new v0.4.0 paragraph in the intro positioning
- **docs/index.md** — Trust Chain entry in the doc index, at-a-glance code sample uses multi-user observe / domain recall / verify_chain, bumped Current release to 0.4.0
- **docs/SPEC.md** (the headless standard) — version 0.3.3 → 0.4.0, four concerns instead of three (added trust chain), updated .soul file format diagram with trust_chain/ + keys/ + nested memory layout, open-string layer model in §4.1 with the original five preserved as built-in names + new "social" + user-defined, user_id and domain added to MemoryEntry in §4.2, brand-new §10A on the trust chain (TrustEntry, TrustChain, SignatureProvider Protocol, canonical encoding, verification contract, identity binding, threat model summary, optionality carve-out), §11 conformance updated for 0.4.0
- **docs/getting-started.md** — "What's new in v0.4.0" block above the 0.3.x entries
- **docs/core-concepts.md** — "Identity Bundle Concepts (v0.4.0)" section above the org-level section, covers multi-user attribution, layers + domains, and the trust chain with code samples matching index.md
- **docs/architecture.md** — version 0.3.2 → 0.4.0, date refresh, v0.4.0 paragraph in §0 noting where the new modules live (spec/trust, runtime/crypto, runtime/trust, runtime/middleware, runtime/memory/social, the LayerView accessor, and the keystore binding in Soul.verify_chain)

## Why a PR (not a direct push)

The branch-guard hook blocks direct pushes to main. Captain green-lit the docs refresh — this PR is the same flow with the lighter ceremony (no review required, merge when CI is green).

No code changes.