### PR TITLE
fix(memory): split significance gate so entity extraction runs on chitchat (#220)

### DIFF
--- a/src/soul_protocol/runtime/memory/manager.py
+++ b/src/soul_protocol/runtime/memory/manager.py
@@ -1157,18 +1157,22 @@ class MemoryManager:
 
         # --- 5. Extract entities (with provenance metadata) ---
         # --- 6. Update self-model ---
-        # Short-circuit: skip expensive LLM steps 5 & 6 for low-significance
-        # interactions when the config flag is enabled. The `significant` flag
-        # accounts for both the initial significance gate (step 2) AND
-        # fact-based promotion (step 4b), so we only skip when the interaction
-        # truly had no meaningful content.
-        skip_deep = not significant and self._settings.skip_deep_processing_on_low_significance
+        # Two independent gates as of #220:
+        # - Self-model update is gated by ``skip_deep_processing_on_low_significance``.
+        #   Chitchat doesn't add signal to the self-model, so the gate stays.
+        # - Entity extraction now runs on every interaction by default (so the
+        #   graph keeps growing under low-significance daily use). Set
+        #   ``always_extract_entities=False`` on MemorySettings to restore the
+        #   pre-#220 behaviour where the significance gate also dropped extraction.
+        sig_skip = not significant and self._settings.skip_deep_processing_on_low_significance
+        skip_self_model = sig_skip
+        skip_entities = sig_skip and not self._settings.always_extract_entities
 
         entities: list[dict] = []
-        if skip_deep:
+        if skip_entities:
             logger.debug(
                 "Low-significance short-circuit: skipping entity extraction "
-                "and self-model update (sig=%.3f)",
+                "(sig=%.3f, always_extract_entities=False)",
                 sig_value,
             )
         else:
@@ -1182,6 +1186,12 @@ class MemoryManager:
                     [e.get("name") for e in entities],
                 )
 
+        if skip_self_model:
+            logger.debug(
+                "Low-significance short-circuit: skipping self-model update (sig=%.3f)",
+                sig_value,
+            )
+        else:
             await self._cognitive.update_self_model(interaction, facts, self._self_model)
             logger.debug("Self-model updated")
 

--- a/src/soul_protocol/runtime/types.py
+++ b/src/soul_protocol/runtime/types.py
@@ -451,11 +451,19 @@ class MemorySettings(BaseModel):
     human_tokens: int = 500
     # F5 auto-consolidation — archive + reflect every N interactions
     consolidation_interval: int = 20
-    # When True, skip entity extraction (step 5) and self-model update (step 6)
-    # for interactions that are not significant after the full pipeline
-    # (including fact-based promotion in step 4b). Saves 2 LLM calls per
-    # low-value interaction.
+    # When True, skip the self-model update (step 6) for interactions that
+    # aren't significant after the full pipeline (including fact-based
+    # promotion in step 4b). Self-model gating is correct — chitchat doesn't
+    # add signal to the model.
     skip_deep_processing_on_low_significance: bool = True
+    # When True (default), run entity extraction (step 5) on every observed
+    # interaction regardless of significance. Trivial conversations still
+    # mention entities ("how's Alice?", "saw Project X update") and the
+    # graph should track them at reduced cost. Set False to restore pre-#220
+    # behaviour where significance-skipping also dropped entity extraction;
+    # in that mode the entity graph plateaus quickly under low-significance
+    # daily use. (#220)
+    always_extract_entities: bool = True
     # LLM-based reranking on recall. Off by default because it adds an LLM
     # call on every smart_recall invocation. Callers who need relevance
     # quality over latency can opt in by constructing MemorySettings with

--- a/tests/test_memory/test_memory.py
+++ b/tests/test_memory/test_memory.py
@@ -279,14 +279,40 @@ class TestSignificanceShortCircuit:
         mgr._cognitive.update_self_model = AsyncMock()
         return mgr
 
-    async def test_skips_extraction_on_trivial_interaction(self, mocked_manager):
-        """Low-significance interaction should skip steps 5 and 6 when the
-        default flag is on."""
+    async def test_skips_self_model_on_trivial_interaction(self, mocked_manager):
+        """Low-significance interaction should skip the self-model update.
+
+        After #220, entity extraction is decoupled — it runs by default
+        regardless of significance so the entity graph keeps growing under
+        chitchat. Only the self-model update stays gated by significance.
+        See ``test_skips_extraction_with_legacy_flag`` below for the legacy
+        path that drops both together.
+        """
         from unittest.mock import AsyncMock
 
         mgr = mocked_manager
         mgr._cognitive.assess_significance = AsyncMock(return_value=self._trivial_score())
         assert mgr._settings.skip_deep_processing_on_low_significance is True
+        assert mgr._settings.always_extract_entities is True
+
+        result = await mgr.observe(Interaction(user_input="ok", agent_output="sure"))
+
+        # #220: entity extraction runs even on trivial interactions
+        mgr._cognitive.extract_entities.assert_called_once()
+        # Self-model gating preserved
+        mgr._cognitive.update_self_model.assert_not_called()
+        assert result["is_significant"] is False
+
+    async def test_skips_extraction_with_legacy_flag(self, mocked_manager):
+        """Pre-#220 behaviour: when ``always_extract_entities=False``, both
+        entity extraction and self-model are skipped on low-significance.
+        This is the escape hatch for callers who want the v0.4.x path back.
+        """
+        from unittest.mock import AsyncMock
+
+        mgr = mocked_manager
+        mgr._settings.always_extract_entities = False
+        mgr._cognitive.assess_significance = AsyncMock(return_value=self._trivial_score())
 
         result = await mgr.observe(Interaction(user_input="ok", agent_output="sure"))
 

--- a/tests/test_observe/test_entity_extraction_independence.py
+++ b/tests/test_observe/test_entity_extraction_independence.py
@@ -1,0 +1,84 @@
+# tests/test_observe/test_entity_extraction_independence.py
+# Created: 2026-04-30 (#220) — Regression tests proving entity extraction
+# runs on low-significance interactions (so the graph keeps growing under
+# daily chitchat) while the self-model update stays gated. Discovered by
+# the graph-traversal agent during PR #219 implementation: with the v0.4.x
+# behaviour the graph plateaus quickly because every chitchat dropped
+# entity extraction along with the self-model update.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from soul_protocol.runtime.soul import Soul
+from soul_protocol.runtime.types import Interaction, MemorySettings
+
+
+def _interaction(text: str) -> Interaction:
+    return Interaction(
+        user_input=text,
+        agent_output="ok",
+        timestamp=datetime.now(UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_entity_extraction_runs_on_low_significance_by_default():
+    """#220: trivial chitchat that mentions an entity should still grow the graph.
+
+    Uses heuristic extraction (no engine) — the heuristic recognizes
+    capitalized proper nouns. Without the #220 fix, low-significance
+    interactions short-circuit before extraction and the entity never
+    lands in the graph.
+    """
+    soul = await Soul.birth("Test", archetype="t")
+
+    # Trivial chitchat (won't pass the LIDA significance gate) that mentions
+    # a capitalized proper noun the heuristic extractor will pick up.
+    for _ in range(3):
+        await soul.observe(_interaction("hi, how is Alice doing?"))
+
+    # Default behaviour (always_extract_entities=True) — Alice should be
+    # in the graph despite the interactions being below the significance gate.
+    nodes = soul.graph.nodes()
+    names = {n.name for n in nodes}
+    assert "Alice" in names, (
+        f"Expected 'Alice' in graph after low-significance chitchat, got {names}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_always_extract_entities_field_present_on_settings():
+    """The new MemorySettings flag exists and defaults to True.
+
+    The end-to-end "legacy plateau" assertion is hard to write deterministically
+    because fact-based promotion in step 4b can flip ``significant`` to True
+    even on chitchat that mentions a name. This test pins down the field
+    contract instead.
+    """
+    settings = MemorySettings()
+    assert settings.always_extract_entities is True
+
+    settings_off = MemorySettings(always_extract_entities=False)
+    assert settings_off.always_extract_entities is False
+
+
+@pytest.mark.asyncio
+async def test_entity_extraction_independent_of_self_model_gate():
+    """Both gates are independent — turning the significance short-circuit
+    off entirely lets entity extraction AND self-model run unconditionally.
+    """
+    soul = await Soul.birth(
+        "Test",
+        archetype="t",
+        memory_settings=MemorySettings(skip_deep_processing_on_low_significance=False),
+    )
+
+    for _ in range(2):
+        await soul.observe(_interaction("hi, how is Bob doing?"))
+
+    nodes = soul.graph.nodes()
+    names = {n.name for n in nodes}
+    assert "Bob" in names


### PR DESCRIPTION
Discovered during PR #219 graph traversal implementation: the LIDA significance short-circuit gates **both** the self-model update AND entity extraction together. Self-model gating is correct (chitchat doesn't add signal to the model), but entity extraction should run on every interaction — trivial conversations still mention entities ("how's Alice?", "saw Project X update") and the graph should track them at reduced cost.

Without this fix the entity graph plateaus quickly under daily-use chitchat. The graph agent had to disable the short-circuit entirely to validate graph growth in PR #219's long-horizon test.

## Change

Split \`MemorySettings\` into two independent flags:

| Flag | Default | Gates |
|---|---|---|
| \`skip_deep_processing_on_low_significance\` | \`True\` | Self-model update on low-significance interactions |
| \`always_extract_entities\` (new) | \`True\` | Run entity extraction on every interaction regardless of significance |

Pre-#220 behaviour is restored by setting \`always_extract_entities=False\`.

## Test plan

- [x] Updated \`TestSignificanceShortCircuit\` to reflect the new contract — trivial interactions skip self-model but run extraction.
- [x] Added \`test_skips_extraction_with_legacy_flag\` to lock the v0.4.x escape hatch.
- [x] New \`tests/test_observe/test_entity_extraction_independence.py\` — end-to-end coverage on a real Soul instance proving the entity ends up in the graph.
- [x] Full suite: 2904 passing (+3 new, +1 reframed, no regressions).

Closes #220.