### PR TITLE
docs(mentorship): contributing guide + LFDT mentor readiness

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+# .github/ISSUE_TEMPLATE/bug_report.yml — bug report form
+# Added: 2026-05-02 — Initial issue templates for soul-protocol.
+# Captures soul --version, Python, OS, and a clean repro.
+
+name: Bug report
+description: Something broke or behaved unexpectedly.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of what went wrong.
+      placeholder: "soul export aria.soul --password X failed with KeyError: 'salt'"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      description: What you thought would happen instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Minimal commands or code to reproduce. The smaller the better.
+      placeholder: |
+        1. soul init Aria
+        2. soul export aria.soul --password test123
+        3. See traceback
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: soul-version
+    attributes:
+      label: Soul version
+      description: Output of `soul --version`.
+      placeholder: "0.4.0"
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Output of `python --version`.
+      placeholder: "3.12.3"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "macOS 14.5 / Ubuntu 24.04 / Windows 11"
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Logs, screenshots, related issues. Optional.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# .github/ISSUE_TEMPLATE/config.yml — issue template chooser config
+# Added: 2026-05-02 — Disables blank issues, points at LFDT mentorship doc
+# and GitHub Discussions for non-bug threads.
+
+blank_issues_enabled: false
+contact_links:
+  - name: LFDT Mentorship
+    url: https://github.com/qbtrix/soul-protocol/blob/dev/docs/lfdt-mentorship.md
+    about: Scope, expectations, and how to apply for the LF Decentralized Trust mentorship.
+  - name: GitHub Discussions
+    url: https://github.com/qbtrix/soul-protocol/discussions
+    about: Open-ended questions, design discussions, show-and-tell.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+# .github/ISSUE_TEMPLATE/feature_request.yml — feature request form
+# Added: 2026-05-02 — Initial issue templates for soul-protocol.
+
+name: Feature request
+description: Suggest a new feature or improvement.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What's the actual problem you're hitting? (Please don't pitch a solution here yet.)
+      placeholder: "Importing a .soul file from another machine fails because the key file is local-only."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you fix it? Sketch the API, file format change, or behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you think about? Why is the proposal better?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to related issues, prior art, design notes. Optional.

--- a/.github/ISSUE_TEMPLATE/mentorship_question.yml
+++ b/.github/ISSUE_TEMPLATE/mentorship_question.yml
@@ -1,0 +1,39 @@
+# .github/ISSUE_TEMPLATE/mentorship_question.yml — LFDT mentorship questions
+# Added: 2026-05-02 — For LFDT voluntary-track mentee applicants and
+# participants asking scope or process questions before/during the program.
+
+name: Mentorship question
+description: Question about the LFDT mentorship — scope, expectations, application process.
+title: "mentorship: "
+labels: ["mentorship-question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest. Before filing, please skim [docs/lfdt-mentorship.md](../../blob/dev/docs/lfdt-mentorship.md) — most common questions are answered there. If your question is private (e.g., personal background, conflict-of-interest concerns), email prakash@qbtrix.com instead.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: One question per issue keeps threads useful for future applicants.
+    validations:
+      required: true
+
+  - type: textarea
+    id: already-read
+    attributes:
+      label: What have you already read?
+      description: e.g., the mentorship doc, a specific section of the architecture doc, the trust chain page.
+      placeholder: "I read docs/lfdt-mentorship.md and docs/trust-chain.md."
+    validations:
+      required: true
+
+  - type: input
+    id: background
+    attributes:
+      label: Your background (one sentence)
+      description: One line on where you're coming from technically — helps me calibrate the answer.
+      placeholder: "Backend Python dev, two years, no prior crypto work."
+    validations:
+      required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+<!-- CONTRIBUTING.md — soul-protocol contributor guide -->
+<!-- Added: 2026-05-02 — Initial contributor guide written for the LFDT
+     mentorship program window. Points at existing docs rather than
+     duplicating them, names the mentor (Prakash), and sets expectations
+     on PR style (Conventional Commits, target dev, one concern per PR). -->
+
+# Contributing to Soul Protocol
+
+Soul Protocol is an open standard plus a Python reference runtime for portable AI agent identity and memory. This guide is for anyone sending a PR, filing an issue, or thinking about contributing through the LFDT mentorship program.
+
+## Quick start
+
+The full setup walkthrough lives in [docs/getting-started.md](docs/getting-started.md). The short version:
+
+```bash
+git clone https://github.com/qbtrix/soul-protocol.git
+cd soul-protocol
+uv sync
+uv run pytest tests/
+```
+
+If `uv sync` finishes and the test suite is green, you're good to go. The repo uses [uv](https://github.com/astral-sh/uv), not pip, for development. Python 3.11 or newer.
+
+## Codebase orientation
+
+The reference implementation lives in `src/soul_protocol/`:
+
+- `spec/` — language-agnostic protocol types. Pydantic models for identity, memory, the `.soul` container, journal, decisions, retrieval. No I/O, no opinions. Anything that ships in `.soul` files is defined here.
+- `runtime/` — the Python reference runtime. Memory tiers (`memory/`), psychology pipeline (`cognitive/`), trust chain (`trust/`), Ed25519 signing (`crypto/`), `.soul` export/import (`export/`). Opinionated, batteries-included.
+- `engine/` — org-layer engine. SQLite WAL journal and credential broker.
+- `cli/` — Click entry points (`soul`, `soul org`, `soul template`, etc.).
+- `mcp/` — MCP server (24 tools, 3 resources).
+
+Architecture diagrams and module dependencies are in [docs/architecture.md](docs/architecture.md). The language-agnostic contract is in [docs/SPEC.md](docs/SPEC.md). Read those before any structural change.
+
+## Running tests
+
+```bash
+uv run pytest tests/
+```
+
+Tests use `pytest-asyncio` for async coroutines. New features should land with tests. Bug fixes should land with a failing test that your fix turns green.
+
+## Submitting a PR
+
+A few conventions to keep merges clean:
+
+- **Branch off `dev`**, not `main`. PRs target `dev`. Releases roll up from `dev` to `main`.
+- **One concern per PR.** A bug fix and an unrelated refactor go in two PRs.
+- **Conventional Commits** in the PR title: `feat:`, `fix:`, `docs:`, `chore:`, `test:`, `refactor:`. Examples: `feat(trust): rotate signing keys`, `fix(memory): prevent duplicate seq on observe race`.
+- **Tests required** for new features. Bug fixes need a regression test.
+- **Lint clean.** `uv run ruff check .` and `uv run ruff format --check .` should both pass.
+- The PR template asks for a 2-3 sentence summary, how to test, and a checklist. Fill them out — it makes review faster.
+
+## Code style
+
+Ruff handles formatting and linting. Config is in `pyproject.toml`. Run `uv run ruff format .` before pushing.
+
+## Finding a first issue
+
+Issues tagged [`good first issue`](https://github.com/qbtrix/soul-protocol/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are scoped, well-described, and a good entry point. They tend to live in `runtime/trust/`, `runtime/export/`, and the docs. If you want to chat about scope before opening a PR, GitHub Discussions is the right place.
+
+## Reporting bugs
+
+File an issue using the bug report template. The template asks for `soul --version`, your Python version, OS, repro steps, and expected vs actual behavior. Templates live under `.github/ISSUE_TEMPLATE/`.
+
+For security issues, please email prakash@qbtrix.com instead of opening a public issue.
+
+## LFDT Mentorship
+
+Soul Protocol joined the [Linux Foundation Decentralized Trust Mentorship Program](https://github.com/LF-Decentralized-Trust-Mentorships/mentorship-program/issues/75) in May 2026. Prakash (`@pocketpaw`, prakash@qbtrix.com) is the mentor. The full mentee scope, suggested 12-week shape, and how to apply are in [docs/lfdt-mentorship.md](docs/lfdt-mentorship.md). Mentee applicants should read that doc first.
+
+## Scope
+
+Things this repo accepts:
+
+- New memory tiers, layers, or query strategies that fit the existing protocol
+- Extensions to the `.soul` file format (versioned, backward-compatible)
+- Runtime adapters (cognitive engines, embedding providers, eternal storage backends)
+- Cross-language schema work and reference test vectors
+- Documentation, examples, tutorials, fixtures
+- Bug fixes and test coverage
+
+Out of scope:
+
+- Provider-specific glue that doesn't generalize (e.g., a single proprietary platform's wire format)
+- UI work — soul-protocol is CLI plus library. Frontend belongs in consuming projects like PocketPaw.
+- Anything that imports from a consumer project. The reverse dependency direction is what makes the protocol portable.
+
+If you're unsure, open a Discussion before writing code.
+
+## Code of Conduct
+
+This project follows the [Linux Foundation Code of Conduct](https://lfprojects.org/policies/code-of-conduct/). Be kind, assume good faith, prefer questions over accusations. Maintainers may remove comments or contributors that violate it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,14 @@
 <!-- Added: 2026-05-02 — Initial contributor guide written for the LFDT
      mentorship program window. Points at existing docs rather than
      duplicating them, names the mentor (Prakash), and sets expectations
-     on PR style (Conventional Commits, target dev, one concern per PR). -->
+     on PR style (Conventional Commits, target dev, one concern per PR).
+     Updated: 2026-05-02 — humanizer pass: dropped two rule-of-three
+     phrases (opening sentence and Code of Conduct line) per the
+     workspace /humanize gate. -->
 
 # Contributing to Soul Protocol
 
-Soul Protocol is an open standard plus a Python reference runtime for portable AI agent identity and memory. This guide is for anyone sending a PR, filing an issue, or thinking about contributing through the LFDT mentorship program.
+Soul Protocol is an open standard plus a Python reference runtime for portable AI agent identity and memory. This guide is for anyone sending a PR or filing an issue. If you're applying for the LFDT mentorship program, also read [docs/lfdt-mentorship.md](docs/lfdt-mentorship.md) — it covers the mentee scope.
 
 ## Quick start
 
@@ -91,4 +94,4 @@ If you're unsure, open a Discussion before writing code.
 
 ## Code of Conduct
 
-This project follows the [Linux Foundation Code of Conduct](https://lfprojects.org/policies/code-of-conduct/). Be kind, assume good faith, prefer questions over accusations. Maintainers may remove comments or contributors that violate it.
+This project follows the [Linux Foundation Code of Conduct](https://lfprojects.org/policies/code-of-conduct/). Maintainers may remove comments or contributors that violate it.

--- a/README.md
+++ b/README.md
@@ -496,6 +496,14 @@ pytest tests/   # 2297 tests
 
 ---
 
+## Contributing & Mentorship
+
+PRs and issues are welcome. Setup, conventions, and scope are in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Soul Protocol is part of the [LF Decentralized Trust mentorship program](docs/lfdt-mentorship.md) (voluntary track, opened May 2026). Mentee scope, suggested 12-week shape, and how to apply live in [docs/lfdt-mentorship.md](docs/lfdt-mentorship.md).
+
+---
+
 ## License
 
 [MIT](LICENSE)

--- a/docs/lfdt-mentorship.md
+++ b/docs/lfdt-mentorship.md
@@ -2,7 +2,12 @@
 <!-- Added: 2026-05-02 — Created for the LF Decentralized Trust voluntary
      track. Tracks LFDT issue #75. Names Prakash as mentor. Spells out
      the four deliverables, a suggested 12-week shape, what mentees can
-     expect from review, and how to apply once LFX wires the platform. -->
+     expect from review, and how to apply once LFX wires the platform.
+     Updated: 2026-05-02 — humanizer pass: rewrote Deliverable 2 and 4
+     (dropped stacked rule-of-three patterns), the skills-section LF-loop
+     bullet, the blog-post bullet (removed tailing negation), and the
+     closing "Why this matters" paragraph (which had three stacked
+     forced triples) per the workspace /humanize gate. -->
 
 # LFDT Mentorship — Soul Protocol
 
@@ -18,11 +23,11 @@ Four deliverables make up the technical scope:
 
 **1. AES-256-GCM encrypted `.soul` file export and import.** The `.soul` archive currently supports password-derived encryption via scrypt; we want to harden the protocol around AEAD with explicit IV handling, associated-data binding, and round-trip tests against externally generated ciphertexts. A working export/import path that interops cleanly with future runtimes is the goal.
 
-**2. Machine-derived key management.** Today, signing keys live next to the soul. We want a key model that survives migration between machines without leaking the private key into the shared file. This means deriving keys from a host secret, supporting key rotation, and keeping the public key embedded in the chain so verification stays simple for receivers.
+**2. Machine-derived key management.** Today, signing keys live alongside the soul, which makes migration between machines awkward. We want keys derived from a host secret instead, so the private key stays on the owner's machine while the public key rides along in the chain for receivers to verify against. Add rotation support so a leaked or rotated key can be retired without invalidating the whole identity.
 
 **3. Digital signature verification on import.** Every `.soul` import should verify the trust chain's signatures against the embedded public key before any state is loaded. The chain primitives already exist in `spec/trust.py` and `runtime/trust/manager.py`; the import path needs to call them and refuse loads on broken chains. Read [docs/trust-chain.md](trust-chain.md) for the threat model.
 
-**4. Cross-runtime test suite.** Souls move between runtimes. We want a fixture set plus pytest harness that round-trips a soul through PocketPaw, LangChain, and CrewAI integrations and asserts memory, identity, and chain state survive each hop without loss. This is the deliverable that turns "portable in theory" into "portable in CI."
+**4. Cross-runtime test suite.** Souls move between runtimes. We want a fixture set plus pytest harness that round-trips a soul through PocketPaw, LangChain, and CrewAI and asserts the memory and chain state survive each hop. The point is to back the "portable" claim with CI evidence rather than just a spec doc.
 
 Plus the supporting work: a clean Python SDK surface for export/import, developer documentation for each new feature, and a reflective blog post at the end of the program on the [LF Decentralized Trust blog](https://www.lfdecentralizedtrust.org/blog).
 
@@ -44,7 +49,7 @@ Most of the work happens in `runtime/crypto/`, `runtime/trust/`, `runtime/export
 - Applied cryptography in Python (AES-GCM, Ed25519, scrypt, key derivation patterns)
 - Protocol design — versioning, backward compatibility, threat modelling
 - Modern Python packaging (uv, hatch, optional extras, wheel hygiene)
-- Open source contribution workflow at LF scale (PR review cadence, RFC-style design notes, changelog discipline)
+- The LF-scale OSS contribution loop — PR review, RFC-style design notes for non-trivial changes, changelog hygiene
 
 ## What I commit to as mentor
 
@@ -57,7 +62,7 @@ Most of the work happens in `runtime/crypto/`, `runtime/trust/`, `runtime/export
 
 - **PR cadence.** Roughly one substantive PR per week is a healthy rhythm. Some weeks will have two small ones, some weeks will have a single larger one. We'll talk about scope before each one.
 - **Public questions.** If you're stuck for more than half a day, post in GitHub Discussions or the program channel. Other mentees benefit from the same answer.
-- **A reflective blog post** at the end of the program on the LF Decentralized Trust blog. Honest and specific, not promotional.
+- **A reflective blog post** at the end of the program on the LF Decentralized Trust blog. Write what worked and what didn't. We're not looking for marketing copy.
 - **A short demo session** (15-20 min) covering what shipped and one design decision you'd make differently in hindsight.
 
 ## How to apply
@@ -73,4 +78,4 @@ A short note on your background and what draws you to portable agent identity is
 
 ## Why this matters
 
-AI agents currently lose their context every time they cross runtimes. Memory, personality, and learned behavior are pinned to whatever system created them. A portable, cryptographically verifiable identity format would let agents move with their users, prove what they learned and when, and survive the runtime they were born on. That's a problem worth a few months of focused work, and it sits at a useful intersection of applied cryptography, protocol design, and AI infrastructure.
+Right now an AI agent forgets who it is when it changes runtimes. Move it from PocketPaw to LangChain and you've started over: no memories, no signed identity, no continuity with the user it was working with. A portable file format with cryptographic verification fixes that. It's a small enough problem to scope into a 12-week mentorship, and the work sits across applied cryptography and protocol design — which makes it a useful first OSS contribution in either area.

--- a/docs/lfdt-mentorship.md
+++ b/docs/lfdt-mentorship.md
@@ -1,0 +1,76 @@
+<!-- docs/lfdt-mentorship.md — LFDT mentorship scope, shape, and how to apply -->
+<!-- Added: 2026-05-02 — Created for the LF Decentralized Trust voluntary
+     track. Tracks LFDT issue #75. Names Prakash as mentor. Spells out
+     the four deliverables, a suggested 12-week shape, what mentees can
+     expect from review, and how to apply once LFX wires the platform. -->
+
+# LFDT Mentorship — Soul Protocol
+
+## About the program
+
+Soul Protocol is part of the [Linux Foundation Decentralized Trust Mentorship Program](https://github.com/LF-Decentralized-Trust-Mentorships/mentorship-program/issues/75) on the voluntary track. The program window opened on May 1, 2026. The project tracking issue is [LF-Decentralized-Trust-Mentorships/mentorship-program#75](https://github.com/LF-Decentralized-Trust-Mentorships/mentorship-program/issues/75).
+
+The mentor is Prakash (`@pocketpaw`, prakash@qbtrix.com). I maintain Soul Protocol and the related agent runtime PocketPaw, and I will be your point of contact through the program.
+
+## What you'll work on
+
+Four deliverables make up the technical scope:
+
+**1. AES-256-GCM encrypted `.soul` file export and import.** The `.soul` archive currently supports password-derived encryption via scrypt; we want to harden the protocol around AEAD with explicit IV handling, associated-data binding, and round-trip tests against externally generated ciphertexts. A working export/import path that interops cleanly with future runtimes is the goal.
+
+**2. Machine-derived key management.** Today, signing keys live next to the soul. We want a key model that survives migration between machines without leaking the private key into the shared file. This means deriving keys from a host secret, supporting key rotation, and keeping the public key embedded in the chain so verification stays simple for receivers.
+
+**3. Digital signature verification on import.** Every `.soul` import should verify the trust chain's signatures against the embedded public key before any state is loaded. The chain primitives already exist in `spec/trust.py` and `runtime/trust/manager.py`; the import path needs to call them and refuse loads on broken chains. Read [docs/trust-chain.md](trust-chain.md) for the threat model.
+
+**4. Cross-runtime test suite.** Souls move between runtimes. We want a fixture set plus pytest harness that round-trips a soul through PocketPaw, LangChain, and CrewAI integrations and asserts memory, identity, and chain state survive each hop without loss. This is the deliverable that turns "portable in theory" into "portable in CI."
+
+Plus the supporting work: a clean Python SDK surface for export/import, developer documentation for each new feature, and a reflective blog post at the end of the program on the [LF Decentralized Trust blog](https://www.lfdecentralizedtrust.org/blog).
+
+## Suggested 12-week shape
+
+This is a shape, not a contract. We'll calibrate in week 1.
+
+| Weeks | Focus |
+|---|---|
+| 1-2 | Onboarding. Read [docs/architecture.md](architecture.md), [docs/SPEC.md](SPEC.md), [docs/trust-chain.md](trust-chain.md). Run the test suite. Ship one PR against a `good first issue` to learn the review loop. |
+| 3-6 | AES-256-GCM encrypted export and import, plus the machine-derived key management piece. Land each as its own PR with tests. Update the relevant docs in the same PR. |
+| 7-9 | Signature verification on import. Harden the trust chain code path so import refuses broken chains. Add fixtures with deliberately tampered chains. |
+| 10-12 | Cross-runtime test suite (PocketPaw, LangChain, CrewAI). Write the blog post. Final demo session. |
+
+Most of the work happens in `runtime/crypto/`, `runtime/trust/`, `runtime/export/`, and the corresponding `tests/` paths. The `.soul` file format is documented in [docs/SPEC.md](SPEC.md).
+
+## Skills you'll pick up
+
+- Applied cryptography in Python (AES-GCM, Ed25519, scrypt, key derivation patterns)
+- Protocol design — versioning, backward compatibility, threat modelling
+- Modern Python packaging (uv, hatch, optional extras, wheel hygiene)
+- Open source contribution workflow at LF scale (PR review cadence, RFC-style design notes, changelog discipline)
+
+## What I commit to as mentor
+
+- Async PR reviews within 48 hours on weekdays
+- A weekly 30-minute sync (video or written, your call)
+- Pairing on hard problems — debugging crypto round trips, designing the key derivation model, anything that gets stuck for more than a day
+- Pointers to relevant prior art and people in the LF orbit when your work touches their projects
+
+## What I'm looking for
+
+- **PR cadence.** Roughly one substantive PR per week is a healthy rhythm. Some weeks will have two small ones, some weeks will have a single larger one. We'll talk about scope before each one.
+- **Public questions.** If you're stuck for more than half a day, post in GitHub Discussions or the program channel. Other mentees benefit from the same answer.
+- **A reflective blog post** at the end of the program on the LF Decentralized Trust blog. Honest and specific, not promotional.
+- **A short demo session** (15-20 min) covering what shipped and one design decision you'd make differently in hindsight.
+
+## How to apply
+
+Applications run through the LFX Mentorship platform. The program manager Christina Harter is wiring it now; the application link will appear on the [program issue](https://github.com/LF-Decentralized-Trust-Mentorships/mentorship-program/issues/75) when ready. Once it's live, this page will link directly to the LFX form.
+
+In the meantime, scope or background questions can go to:
+
+- [GitHub Discussions](https://github.com/qbtrix/soul-protocol/discussions) for anything public
+- prakash@qbtrix.com for anything you'd rather discuss directly
+
+A short note on your background and what draws you to portable agent identity is a good way to start.
+
+## Why this matters
+
+AI agents currently lose their context every time they cross runtimes. Memory, personality, and learned behavior are pinned to whatever system created them. A portable, cryptographically verifiable identity format would let agents move with their users, prove what they learned and when, and survive the runtime they were born on. That's a problem worth a few months of focused work, and it sits at a useful intersection of applied cryptography, protocol design, and AI infrastructure.


### PR DESCRIPTION
## Summary
- New `CONTRIBUTING.md` covering setup, PR conventions, scope, finding a first issue
- New `docs/lfdt-mentorship.md` with the LFDT mentee scope, suggested 12-week shape, and how to apply
- Issue templates in `.github/ISSUE_TEMPLATE/` (bug, feature, mentorship question)
- Small README insertion linking to both new docs

The LFDT Decentralized Trust Mentorship voluntary-track window opened May 1, 2026. This PR makes the repo legible to incoming applicants and gives the program manager something polished to point at. A companion PR/issue batch creates the four mentorship-deliverable issues and tags scoped trust-module issues as `good first issue`.

Tracking: LF-Decentralized-Trust-Mentorships/mentorship-program#75

## Test plan
- [ ] CONTRIBUTING.md renders correctly on GitHub
- [ ] All internal links resolve (`docs/architecture.md`, `docs/getting-started.md`, etc.)
- [ ] Issue templates load when clicking "New issue"
- [ ] No duplication with existing docs