### PR TITLE
chore(version): bump to 0.5.0.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "soul-protocol"
-version = "0.4.0"
+version = "0.5.0.dev0"
 description = "The open standard for portable AI identity and memory"
 readme = "README.md"
 license = "MIT"

--- a/src/soul_protocol/__init__.py
+++ b/src/soul_protocol/__init__.py
@@ -235,4 +235,4 @@ __all__ = [
     "score_of",
 ]
 
-__version__ = "0.4.0"
+__version__ = "0.5.0.dev0"


### PR DESCRIPTION
Bumps the dev-branch version string from 0.4.0 to 0.5.0.dev0 (PEP 440 pre-release) so `soul --version` reflects the v0.5.0 surface that's actually running. Release PR (dev → main) will flip this to `0.5.0` final.