### PR TITLE
feat(cli):add fact-mode soul observe with dedup; deprecate remember

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- CLI memory ingestion upgrade (issue #231):
+  - Added fact mode to `soul observe`: `soul observe <path> "<fact>"` with tier/domain controls, dedup actions (`CREATE`/`SKIP`/`MERGE`), `--no-dedup`, and `--no-contradictions`.
+  - Added `Soul.observe_fact()` / `MemoryManager.observe_fact()` runtime path for fact-shaped input with tier-aware dedup and semantic contradiction supersession.
+  - Deprecated `soul remember` (warning emitted, command remains available as alias behavior).
+  - Added CLI tests for observe fact-mode dedup, contradiction handling, and no-dedup opt-out.
+
 ---
 
 ## [0.4.0] -- 2026-04-29

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ pip install -e ".[dev]"
 soul init "Aria" --archetype "The Compassionate Creator"
 soul inspect .soul/
 soul status .soul/
+soul observe .soul/ "User prefers concise PR summaries" --type semantic
 ```
 
 ### Python

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -514,7 +514,7 @@ soul export-a2a aria.soul -o card.json --url https://aria.example.com
 
 ### `soul remember`
 
-Store a memory directly in a soul. Use this when you already know what tier the memory belongs in and don't need the cognitive pipeline to decide for you (see `soul observe` for the pipeline-driven alternative).
+Deprecated alias for direct memory writes. Prefer `soul observe <path> "<fact>"`, which supports dedup and contradiction checks for non-episodic tiers.
 
 ```bash
 # Semantic by default — facts the soul should know
@@ -563,6 +563,8 @@ soul remember aria.soul "NDA expires in March" --domain legal --importance 7
 Core memory (persona and human knowledge) is not writable through `remember`. Use `soul edit-core` instead.
 
 **Output:** A confirmation panel showing the stored text, tier, domain, importance, emotion, and memory ID. The soul is saved automatically.
+
+**Deprecation:** `soul remember` emits a deprecation warning and points to `soul observe`. Keep using it only when you explicitly want the legacy raw-append path.
 
 ---
 
@@ -644,14 +646,25 @@ soul layers .soul/ --json
 
 ### `soul observe`
 
-Process an interaction through the full cognitive pipeline. Runs sentiment detection, significance gating, memory storage, entity extraction, self-model updates, and evolution triggers.
+`soul observe` supports two modes:
+
+- Interaction mode (legacy): process a user/agent exchange through the full cognitive pipeline.
+- Fact mode (new): store one fact-shaped string with dedup (`CREATE`/`SKIP`/`MERGE`) and optional contradiction detection.
 
 ```bash
+# Interaction mode
 soul observe .soul/ --user-input "Hello" --agent-output "Hi there!"
 soul observe aria.soul --user-input "Tell me a joke" --agent-output "Why did..." --channel discord
 
 # Multi-user (#46) — attribute the memory to one user
 soul observe aria.soul --user-input "Hi" --agent-output "Hello!" --user alice
+
+# Fact mode (semantic default)
+soul observe aria.soul "User prefers Python over JavaScript" --importance 8
+
+# Tier/domain controls in fact mode
+soul observe aria.soul "Shipped v0.3 today" --type episodic --no-dedup
+soul observe aria.soul "Q3 revenue up 12 percent" --type semantic --domain finance
 ```
 
 **Arguments:**
@@ -659,17 +672,29 @@ soul observe aria.soul --user-input "Hi" --agent-output "Hello!" --user alice
 | Argument | Required | Description |
 |----------|----------|-------------|
 | `PATH` | Yes | Path to a soul file or `.soul/` directory. |
+| `TEXT` | No | Fact text for fact mode. Omit for interaction mode. |
 
 **Options:**
 
 | Option | Description |
 |--------|-------------|
-| `--user-input TEXT` | User's message. **Required.** |
-| `--agent-output TEXT` | Agent's response. **Required.** |
+| `--user-input TEXT` | User's message (interaction mode). |
+| `--agent-output TEXT` | Agent's response (interaction mode). |
 | `--channel TEXT` | Channel name. Defaults to `cli`. |
+| `--importance, -i INT` | Importance score (fact mode). Default `5`. |
+| `--emotion, -e TEXT` | Emotion tag (fact mode). |
+| `--type, -t [episodic\|semantic\|procedural\|social]` | Tier for fact mode. Default `semantic`. |
+| `--domain, -d TEXT` | Domain sub-namespace. Default `default`. |
+| `--no-dedup` | Disable fact-mode dedup and force raw append. |
+| `--no-contradictions` | Disable fact-mode contradiction detection. |
 | `--user TEXT` | Attribute observed memories to this `user_id` (#46). The per-user bond is strengthened instead of the default bond. |
 
-**Output:** Prints the soul's mood and energy after processing the interaction. Saves the soul automatically.
+**Output:**
+
+- Interaction mode prints mood + energy after processing.
+- Fact mode prints the dedup action, relevant IDs/similarity, and contradiction count.
+
+Use either `TEXT` (fact mode) or `--user-input` + `--agent-output` (interaction mode), not both.
 
 ---
 
@@ -1448,3 +1473,4 @@ The CLI reads and writes these formats:
 | `.yaml` / `.yml` | Yes | Yes | Human-editable config |
 | `.json` | Yes | Yes | Full SoulConfig serialization |
 | `.md` | Yes | Yes | Markdown (read: SOUL.md parser; write: DNA-only export) |
+

--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -62,6 +62,7 @@ import asyncio
 import builtins
 import json
 import sys
+import warnings
 import zipfile
 from datetime import datetime
 from pathlib import Path
@@ -1076,6 +1077,17 @@ def remember_cmd(path, text, importance, emotion, memory_type, domain):
       soul remember aria.soul "Shipped v0.3" --type episodic --importance 8
       soul remember aria.soul "Q3 revenue up 12%" --domain finance --importance 8
     """
+    warnings.warn(
+        "soul remember is deprecated; use 'soul observe <path> \"<fact>\"' instead. "
+        "Use '--no-dedup' on observe for raw append behavior.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    console.print(
+        "[yellow]DeprecationWarning:[/yellow] `soul remember` is deprecated. "
+        "Use `soul observe <path> \"<fact>\"` (or add `--no-dedup` for raw writes)."
+    )
+
     from soul_protocol.runtime.types import MemoryType
 
     tier = MemoryType(memory_type.lower())
@@ -1653,9 +1665,45 @@ def _save_soul(soul, path):
 
 @cli.command("observe")
 @click.argument("path", type=click.Path(exists=True))
-@click.option("--user-input", "user_input", required=True, help="User's message")
-@click.option("--agent-output", "agent_output", required=True, help="Agent's response")
+@click.argument("text", required=False)
+@click.option("--user-input", "user_input", default=None, help="User's message")
+@click.option("--agent-output", "agent_output", default=None, help="Agent's response")
 @click.option("--channel", default="cli", help="Channel name (default: cli)")
+@click.option(
+    "--importance",
+    "-i",
+    type=click.IntRange(1, 10),
+    default=5,
+    help="Importance score 1-10 (default: 5, fact mode only)",
+)
+@click.option("--emotion", "-e", type=str, default=None, help="Emotion tag (fact mode only)")
+@click.option(
+    "--type",
+    "-t",
+    "memory_type",
+    type=click.Choice(["episodic", "semantic", "procedural", "social"], case_sensitive=False),
+    default="semantic",
+    help="Memory tier for fact mode (default: semantic)",
+)
+@click.option(
+    "--domain",
+    "-d",
+    type=str,
+    default="default",
+    help="Domain sub-namespace inside the layer (default: default).",
+)
+@click.option(
+    "--no-dedup",
+    is_flag=True,
+    default=False,
+    help="Disable dedup for fact mode and always append a new memory.",
+)
+@click.option(
+    "--no-contradictions",
+    is_flag=True,
+    default=False,
+    help="Disable contradiction detection for fact mode.",
+)
 @click.option(
     "--user",
     "user_id",
@@ -1663,36 +1711,125 @@ def _save_soul(soul, path):
     help="Attribute the observed memory to this user_id (multi-user souls, #46). "
     "Per-user bond is strengthened instead of the default bond.",
 )
-def observe_cmd(path, user_input, agent_output, channel, user_id):
-    """Process an interaction through the full cognitive pipeline.
+def observe_cmd(
+    path,
+    text,
+    user_input,
+    agent_output,
+    channel,
+    importance,
+    emotion,
+    memory_type,
+    domain,
+    no_dedup,
+    no_contradictions,
+    user_id,
+):
+    """Observe either an interaction or a single fact-shaped memory.
 
-    Runs sentiment detection, significance gating, memory storage,
-    entity extraction, self-model updates, and evolution triggers.
+    Interaction mode (legacy): pass ``--user-input`` and ``--agent-output``.
+    Fact mode (new): pass ``TEXT`` and optional dedup/contradiction flags.
 
     \b
     Examples:
       soul observe .soul/ --user-input "Hello" --agent-output "Hi there!"
-      soul observe aria.soul --user-input "Tell me a joke" --agent-output "Why did..." --channel discord
-      soul observe aria.soul --user-input "Hi" --agent-output "Hello!" --user alice
+      soul observe aria.soul "User prefers Python over JavaScript"
+      soul observe aria.soul "User moved to Amsterdam" --type semantic --importance 8
+      soul observe aria.soul "Shipped v0.3 today" --type episodic --no-dedup
     """
+    from soul_protocol.runtime.types import MemoryType
+
+    has_interaction_flags = user_input is not None or agent_output is not None
+    has_fact_text = text is not None
+    if has_fact_text and has_interaction_flags:
+        console.print(
+            "[red]Use either fact mode (`soul observe <path> \"<text>\"`) "
+            "or interaction mode (`--user-input` + `--agent-output`), not both.[/red]"
+        )
+        raise SystemExit(1)
+    if not has_fact_text and not has_interaction_flags:
+        console.print(
+            "[red]Provide either a fact text argument or both "
+            "`--user-input` and `--agent-output`.[/red]"
+        )
+        raise SystemExit(1)
+    if has_interaction_flags and (user_input is None or agent_output is None):
+        console.print("[red]Interaction mode requires both --user-input and --agent-output.[/red]")
+        raise SystemExit(1)
 
     async def _observe():
         from soul_protocol.runtime.soul import Soul
         from soul_protocol.runtime.types import Interaction
 
         soul = await Soul.awaken(path)
-        interaction = Interaction(
-            user_input=user_input,
-            agent_output=agent_output,
-            channel=channel,
-        )
-        await soul.observe(interaction, user_id=user_id)
+        if has_fact_text:
+            tier = MemoryType(memory_type.lower())
+            result = await soul.observe_fact(
+                text,
+                memory_type=tier,
+                importance=importance,
+                emotion=emotion,
+                domain=domain,
+                user_id=user_id,
+                dedup=False if no_dedup else None,
+                detect_contradictions=False if no_contradictions else None,
+            )
+        else:
+            interaction = Interaction(
+                user_input=user_input,
+                agent_output=agent_output,
+                channel=channel,
+            )
+            await soul.observe(interaction, user_id=user_id, domain=domain)
+            result = None
 
         # Save
         if Path(path).is_dir():
             await soul.save_local(path)
         else:
             await soul.export(path, include_keys=True)
+
+        if has_fact_text and result is not None:
+            action = result.get("action", "CREATE")
+            if action == "SKIP":
+                panel_title = "Memory Skipped"
+                summary = (
+                    f"  Action      [yellow]{action}[/yellow]\n"
+                    f"  Existing ID [dim]{result.get('match_id')}[/dim]\n"
+                    f"  Similarity  [magenta]{result.get('match_similarity', 0.0):.2f}[/magenta]"
+                )
+            elif action == "MERGE":
+                panel_title = "Memory Merged"
+                summary = (
+                    f"  Action      [yellow]{action}[/yellow]\n"
+                    f"  Old ID      [dim]{result.get('match_id')}[/dim]\n"
+                    f"  New ID      [dim]{result.get('new_id')}[/dim]\n"
+                    f"  Similarity  [magenta]{result.get('match_similarity', 0.0):.2f}[/magenta]"
+                )
+            else:
+                panel_title = "Memory Stored"
+                summary = (
+                    f"  Action      [green]{action}[/green]\n"
+                    f"  New ID      [dim]{result.get('new_id')}[/dim]"
+                )
+            contradictions = result.get("contradictions", [])
+            contradictions_line = (
+                f"\n  Contradictions [red]{len(contradictions)}[/red]" if contradictions else ""
+            )
+            console.print(
+                Panel(
+                    f"[bold]{soul.name}[/bold] observed fact:\n\n"
+                    f"  [cyan]{text}[/cyan]\n\n"
+                    f"  Tier        [magenta]{memory_type.lower()}[/magenta]\n"
+                    f"  Domain      [magenta]{domain}[/magenta]\n"
+                    f"  Importance  [yellow]{importance}/10[/yellow]\n"
+                    f"  Emotion     {emotion or '[dim]none[/dim]'}\n"
+                    f"{summary}{contradictions_line}",
+                    title=panel_title,
+                    border_style="green",
+                )
+            )
+            return
 
         mood = soul.state.mood.value
         energy = soul.state.energy

--- a/src/soul_protocol/runtime/memory/manager.py
+++ b/src/soul_protocol/runtime/memory/manager.py
@@ -111,7 +111,7 @@ from soul_protocol.runtime.memory.attention import (
 )
 from soul_protocol.runtime.memory.contradiction import ContradictionDetector
 from soul_protocol.runtime.memory.core import CoreMemoryManager
-from soul_protocol.runtime.memory.dedup import reconcile_fact
+from soul_protocol.runtime.memory.dedup import _jaccard_similarity, reconcile_fact
 from soul_protocol.runtime.memory.episodic import EpisodicStore
 from soul_protocol.runtime.memory.graph import KnowledgeGraph
 from soul_protocol.runtime.memory.procedural import ProceduralStore
@@ -889,6 +889,147 @@ class MemoryManager:
 
     async def add_episodic(self, interaction: Interaction) -> str:
         return await self._episodic.add(interaction)
+
+    def _entries_for_type(
+        self,
+        memory_type: MemoryType,
+        *,
+        domain: str | None = None,
+        include_superseded: bool = False,
+    ) -> list[MemoryEntry]:
+        """Return entries for one built-in memory tier."""
+        if memory_type == MemoryType.SEMANTIC:
+            entries = self._semantic.facts(include_superseded=include_superseded)
+        elif memory_type == MemoryType.PROCEDURAL:
+            entries = self._procedural.entries()
+        elif memory_type == MemoryType.SOCIAL:
+            entries = self._social.entries()
+        elif memory_type == MemoryType.EPISODIC:
+            entries = self._episodic.entries()
+        else:
+            entries = []
+        if domain is not None:
+            entries = [entry for entry in entries if entry.domain == domain]
+        return entries
+
+    async def observe_fact(
+        self,
+        content: str,
+        *,
+        memory_type: MemoryType = MemoryType.SEMANTIC,
+        importance: int = 5,
+        emotion: str | None = None,
+        domain: str = "default",
+        user_id: str | None = None,
+        dedup: bool | None = None,
+        detect_contradictions: bool | None = None,
+    ) -> dict:
+        """Store a fact-shaped input with optional dedup + contradiction checks.
+
+        This is a CLI-friendly path for direct memory writes that should still
+        pass through the semantic reconciliation pipeline.
+        """
+        if memory_type == MemoryType.CORE:
+            raise ValueError("observe_fact does not support core memories")
+
+        if dedup is None:
+            dedup = memory_type != MemoryType.EPISODIC
+        if detect_contradictions is None:
+            detect_contradictions = memory_type != MemoryType.EPISODIC
+
+        existing = self._entries_for_type(memory_type, domain=domain, include_superseded=False)
+
+        best_match: MemoryEntry | None = None
+        best_similarity = 0.0
+        for candidate in existing:
+            if candidate.superseded_by is not None:
+                continue
+            sim = _jaccard_similarity(content, candidate.content)
+            if sim > best_similarity:
+                best_similarity = sim
+                best_match = candidate
+
+        action = "CREATE"
+        created_id: str | None = None
+        if dedup:
+            if best_match is not None and best_similarity > 0.85:
+                action = "SKIP"
+            elif best_match is not None and best_similarity >= 0.6:
+                action = "MERGE"
+
+        if action in {"CREATE", "MERGE"}:
+            entry = MemoryEntry(
+                type=memory_type,
+                content=content,
+                importance=importance,
+                emotion=emotion,
+                domain=domain,
+                user_id=user_id,
+            )
+            created_id = await self.add(entry)
+            if action == "MERGE" and best_match is not None:
+                best_match.superseded_by = created_id
+
+        contradictions: list[dict] = []
+        contradiction_enabled = (
+            detect_contradictions and memory_type == MemoryType.SEMANTIC and created_id is not None
+        )
+        if contradiction_enabled:
+            all_semantic = self._semantic.facts(include_superseded=False)
+            for cr in await self._contradiction_detector.detect(content, all_semantic):
+                if not cr.is_contradiction or not cr.old_memory_id:
+                    continue
+                if cr.old_memory_id == created_id:
+                    continue
+                for existing_fact in all_semantic:
+                    if existing_fact.id == cr.old_memory_id:
+                        existing_fact.superseded = True
+                        existing_fact.superseded_by = created_id
+                        break
+                contradictions.append(
+                    {
+                        "old_id": cr.old_memory_id,
+                        "new_id": created_id,
+                        "reason": cr.reason,
+                        "confidence": cr.confidence,
+                    }
+                )
+
+            already_superseded = {c["old_id"] for c in contradictions}
+            for cr in await self._contradiction_detector.detect_heuristic(content, all_semantic):
+                if not cr.is_contradiction or not cr.old_memory_id:
+                    continue
+                if cr.old_memory_id == created_id or cr.old_memory_id in already_superseded:
+                    continue
+                for existing_fact in all_semantic:
+                    if existing_fact.id == cr.old_memory_id:
+                        existing_fact.superseded = True
+                        existing_fact.superseded_by = created_id
+                        break
+                already_superseded.add(cr.old_memory_id)
+                contradictions.append(
+                    {
+                        "old_id": cr.old_memory_id,
+                        "new_id": created_id,
+                        "reason": cr.reason,
+                        "confidence": cr.confidence,
+                    }
+                )
+
+        return {
+            "action": action,
+            "memory_type": memory_type.value,
+            "memory_id": created_id or (best_match.id if best_match is not None else None),
+            "new_id": created_id,
+            "match_id": best_match.id if best_match is not None else None,
+            "match_similarity": best_similarity if best_match is not None else 0.0,
+            "domain": domain,
+            "importance": importance,
+            "emotion": emotion,
+            "contradictions": contradictions,
+            "dedup_enabled": dedup,
+            "contradictions_enabled": contradiction_enabled,
+        }
 
     async def observe(
         self,

--- a/src/soul_protocol/runtime/soul.py
+++ b/src/soul_protocol/runtime/soul.py
@@ -1339,6 +1339,43 @@ class Soul:
             logger.debug("Recall returned no results: query_len=%d", len(query))
         return results
 
+    async def observe_fact(
+        self,
+        content: str,
+        *,
+        memory_type: MemoryType = MemoryType.SEMANTIC,
+        importance: int = 5,
+        emotion: str | None = None,
+        domain: str = "default",
+        user_id: str | None = None,
+        dedup: bool | None = None,
+        detect_contradictions: bool | None = None,
+    ) -> dict:
+        """Store fact-shaped input with optional dedup/contradiction checks."""
+        result = await self._memory.observe_fact(
+            content,
+            memory_type=memory_type,
+            importance=importance,
+            emotion=emotion,
+            domain=domain,
+            user_id=user_id,
+            dedup=dedup,
+            detect_contradictions=detect_contradictions,
+        )
+        if result.get("new_id"):
+            self._safe_append_chain(
+                "memory.write",
+                {
+                    "user_id": user_id,
+                    "domain": domain,
+                    "layer": memory_type.value,
+                    "count": 1,
+                    "ids": [result["new_id"]],
+                    "action": result.get("action"),
+                },
+            )
+        return result
+
     async def smart_recall(
         self,
         query: str,

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -79,6 +79,7 @@ def test_remember_command(tmp_path):
 
     assert result.exit_code == 0
     assert "Memory Stored" in result.output
+    assert "deprecated" in result.output.lower()
     assert "User prefers dark mode" in result.output
     assert "7/10" in result.output
 
@@ -184,6 +185,105 @@ def test_remember_rejects_invalid_type(tmp_path):
 
     # core is a valid MemoryType but not allowed via CLI (core is persona-level)
     assert result.exit_code != 0
+
+
+def test_observe_fact_mode_defaults_to_semantic(tmp_path):
+    """observe with a single text argument stores a semantic memory by default."""
+    runner = CliRunner()
+    soul_path = str(tmp_path / "observe-fact-default.soul")
+    runner.invoke(cli, ["birth", "ObsFactDefault", "-o", soul_path])
+
+    result = runner.invoke(cli, ["observe", soul_path, "User prefers matcha", "-i", "7"])
+    assert result.exit_code == 0, result.output
+    assert "Memory Stored" in result.output
+    assert "Action" in result.output
+
+    with zipfile.ZipFile(soul_path) as zf:
+        semantic = json.loads(zf.read("memory/semantic.json"))
+    assert len(semantic) == 1
+    assert semantic[0]["content"] == "User prefers matcha"
+
+
+def test_observe_fact_dedup_skip_and_merge(tmp_path):
+    """observe fact mode reports SKIP for exact dupes and MERGE for near dupes."""
+    runner = CliRunner()
+    soul_path = str(tmp_path / "observe-dedup.soul")
+    runner.invoke(cli, ["birth", "ObsDedup", "-o", soul_path])
+
+    created = runner.invoke(cli, ["observe", soul_path, "User prefers Python"])
+    assert created.exit_code == 0, created.output
+    assert "Action" in created.output
+    assert "CREATE" in created.output
+
+    skipped = runner.invoke(cli, ["observe", soul_path, "User prefers Python"])
+    assert skipped.exit_code == 0, skipped.output
+    assert "Memory Skipped" in skipped.output
+    assert "SKIP" in skipped.output
+
+    merged = runner.invoke(
+        cli,
+        ["observe", soul_path, "User prefers Python for backend development"],
+    )
+    assert merged.exit_code == 0, merged.output
+    assert "Memory Merged" in merged.output
+    assert "MERGE" in merged.output
+
+
+def test_observe_fact_no_dedup_allows_blunt_appends(tmp_path):
+    """--no-dedup bypasses reconciliation and appends duplicate facts."""
+    runner = CliRunner()
+    soul_path = str(tmp_path / "observe-no-dedup.soul")
+    runner.invoke(cli, ["birth", "ObsNoDedup", "-o", soul_path])
+
+    first = runner.invoke(cli, ["observe", soul_path, "User likes tea", "--no-dedup"])
+    second = runner.invoke(cli, ["observe", soul_path, "User likes tea", "--no-dedup"])
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+
+    with zipfile.ZipFile(soul_path) as zf:
+        semantic = json.loads(zf.read("memory/semantic.json"))
+    matches = [entry for entry in semantic if entry["content"] == "User likes tea"]
+    assert len(matches) == 2
+
+
+def test_observe_fact_contradiction_supersedes_old_fact(tmp_path):
+    """Contradicting semantic facts should supersede older entries."""
+    runner = CliRunner()
+    soul_path = str(tmp_path / "observe-contradiction.soul")
+    runner.invoke(cli, ["birth", "ObsContradiction", "-o", soul_path])
+
+    before = runner.invoke(cli, ["observe", soul_path, "User lives in NYC"])
+    assert before.exit_code == 0, before.output
+    after = runner.invoke(cli, ["observe", soul_path, "User moved to Amsterdam"])
+    assert after.exit_code == 0, after.output
+    assert "Contradictions" in after.output
+
+    with zipfile.ZipFile(soul_path) as zf:
+        semantic = json.loads(zf.read("memory/semantic.json"))
+    nyc = [entry for entry in semantic if "User lives in NYC" in entry["content"]]
+    assert nyc, semantic
+    assert nyc[0].get("superseded_by") is not None
+
+
+def test_observe_interaction_mode_still_works(tmp_path):
+    """Legacy interaction observe mode remains available."""
+    runner = CliRunner()
+    soul_path = str(tmp_path / "observe-interaction.soul")
+    runner.invoke(cli, ["birth", "ObsInteraction", "-o", soul_path])
+
+    result = runner.invoke(
+        cli,
+        [
+            "observe",
+            soul_path,
+            "--user-input",
+            "Hello",
+            "--agent-output",
+            "Hi there!",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Observed" in result.output
 
 
 def test_recall_with_query(tmp_path):

--- a/tests/test_cli/test_health_cleanup_repair.py
+++ b/tests/test_cli/test_health_cleanup_repair.py
@@ -127,7 +127,14 @@ class TestHealthCommand:
         # Add an episodic memory via observe
         runner.invoke(
             cli,
-            ["observe", soul_path, "--user", "I love cats", "--agent", "Cats are great!"],
+            [
+                "observe",
+                soul_path,
+                "--user-input",
+                "I love cats",
+                "--agent-output",
+                "Cats are great!",
+            ],
         )
 
         result = runner.invoke(cli, ["health", soul_path])


### PR DESCRIPTION
## What does this PR do?

Implements issue #231 by adding a dedup-aware fact ingestion path to the CLI and deprecating `soul remember` in favor of `soul observe`.

Fixes #231
- Added `observe_fact` runtime path:
  - `MemoryManager.observe_fact(...)`
  - `Soul.observe_fact(...)`
- Extended `soul observe` with **fact mode**:
  - `soul observe <path> "<fact>"`
  - Options: `--type`, `--importance`, `--domain`, `--emotion`
  - Opt-outs: `--no-dedup`, `--no-contradictions`
- Preserved existing **interaction mode**:
  - `--user-input` + `--agent-output`
- Added deprecation warning for `soul remember` with migration guidance.
- Updated docs and changelog.

## How to test

Added/updated CLI tests for:
- observe fact mode default semantic write
- dedup `SKIP` and `MERGE` paths
- `--no-dedup` blunt append
- contradiction supersession
- interaction-mode backward compatibility
- remember deprecation output
- fixed one legacy test invocation to current observe flags

## Checklist

- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint passes (`uv run ruff check . && uv run ruff format --check .`)
- [x] No secrets or credentials in the diff
- [x] PR title follows Conventional Commits (`feat:`, `fix:`, `docs:`, etc.)
