### PR TITLE
feat(trust): adding digital signature verification on import

### DIFF
--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -3146,7 +3146,7 @@ def verify_cmd(path, as_json):
         from soul_protocol.runtime.soul import Soul
         from soul_protocol.spec.trust import chain_integrity_check
 
-        soul = await Soul.awaken(path)
+        soul = await Soul.awaken(path, allow_unverified=True)
         summary = chain_integrity_check(soul.trust_chain)
 
         # Compute time span (first → last entry)
@@ -3221,7 +3221,7 @@ def audit_cmd(path, action_prefix, limit, as_json):
     async def _audit():
         from soul_protocol.runtime.soul import Soul
 
-        soul = await Soul.awaken(path)
+        soul = await Soul.awaken(path, allow_unverified=True)
         log = soul.audit_log(action_prefix=action_prefix, limit=limit)
 
         if as_json:

--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -3130,7 +3130,10 @@ def repair_cmd(
 @cli.command("verify")
 @click.argument("path", type=click.Path(exists=True))
 @click.option("--json", "as_json", is_flag=True, default=False, help="Emit machine-readable JSON.")
-def verify_cmd(path, as_json):
+@click.option(
+    "--allow-unverified", is_flag=True, default=False, help="Bypass strict validation during load."
+)
+def verify_cmd(path, as_json, allow_unverified):
     """Verify the trust chain of a .soul file or directory.
 
     \b
@@ -3146,7 +3149,7 @@ def verify_cmd(path, as_json):
         from soul_protocol.runtime.soul import Soul
         from soul_protocol.spec.trust import chain_integrity_check
 
-        soul = await Soul.awaken(path, allow_unverified=True)
+        soul = await Soul.awaken(path, allow_unverified=allow_unverified)
         summary = chain_integrity_check(soul.trust_chain)
 
         # Compute time span (first → last entry)
@@ -3207,7 +3210,10 @@ def verify_cmd(path, as_json):
 )
 @click.option("--limit", type=int, default=None, help="Show only the most recent N entries.")
 @click.option("--json", "as_json", is_flag=True, default=False, help="Emit machine-readable JSON.")
-def audit_cmd(path, action_prefix, limit, as_json):
+@click.option(
+    "--allow-unverified", is_flag=True, default=False, help="Bypass strict validation during load."
+)
+def audit_cmd(path, action_prefix, limit, as_json, allow_unverified):
     """Print a human-readable timeline of signed actions.
 
     \b
@@ -3221,7 +3227,7 @@ def audit_cmd(path, action_prefix, limit, as_json):
     async def _audit():
         from soul_protocol.runtime.soul import Soul
 
-        soul = await Soul.awaken(path, allow_unverified=True)
+        soul = await Soul.awaken(path, allow_unverified=allow_unverified)
         log = soul.audit_log(action_prefix=action_prefix, limit=limit)
 
         if as_json:

--- a/src/soul_protocol/runtime/exceptions.py
+++ b/src/soul_protocol/runtime/exceptions.py
@@ -105,3 +105,12 @@ class DomainAccessError(SoulProtocolError):
             f"({', '.join(repr(a) for a in self.allowed) or 'none'}). "
             "DomainIsolationMiddleware blocks writes to disallowed domains."
         )
+
+
+class SoulTrustError(SoulProtocolError):
+    """Raised when a trust chain verification fails during soul operations."""
+
+    def __init__(self, reason: str, signer: str | None = None):
+        self.reason = reason
+        self.signer = signer
+        super().__init__(f"Trust chain validation failed: {reason}")

--- a/src/soul_protocol/runtime/soul.py
+++ b/src/soul_protocol/runtime/soul.py
@@ -982,14 +982,15 @@ class Soul:
         if verification_result.status == VerificationState.FAILED:
             if allow_unverified:
                 logger.warning(
-                    f"Awakening unverified soul. Signer: {verification_result.signer}, "
-                    f"Reason: {verification_result.reason}"
+                    "Awakening unverified soul. Signer: %s, Reason: %s",
+                    verification_result.signer,
+                    verification_result.reason,
                 )
             else:
                 logger.error("Soul import refused due to trust chain failure.")
                 raise SoulTrustError(
                     f"Refusing to awaken soul: {verification_result.reason}. "
-                    "Use --allow-unverified to override."
+                    "Pass allow_unverified=True to override."
                 )
         elif verification_result.status == VerificationState.WARNED:
             logger.warning(f"Trust chain warning: {verification_result.reason}")

--- a/src/soul_protocol/runtime/soul.py
+++ b/src/soul_protocol/runtime/soul.py
@@ -152,7 +152,7 @@ from .memory.manager import MemoryManager
 from .memory.strategy import SearchStrategy
 from .skills import Skill, SkillRegistry
 from .state.manager import StateManager
-from .trust.manager import TrustChainManager
+from .trust.manager import TrustChainManager, VerificationResult, VerificationState
 from .types import (
     DNA,
     Biorhythms,
@@ -578,7 +578,7 @@ class Soul:
         """
         return self._trust_chain_manager
 
-    def verify_chain(self) -> tuple[bool, str | None]:
+    def verify_chain(self) -> VerificationResult:
         """Verify the integrity of this soul's trust chain.
 
         Two-stage check:
@@ -592,8 +592,8 @@ class Soul:
         (e.g. a freshly-birthed soul before its first save). It is the
         load-time path — saved/awakened souls always have a public key.
 
-        Returns ``(True, None)`` on success, or
-        ``(False, "<reason> at seq N")`` on the first failure.
+        Returns a structured VerificationResult covering the passed, warned,
+        and failed states with a reason field.
         """
         import base64
 
@@ -602,7 +602,11 @@ class Soul:
             expected_pk = base64.b64encode(pub_bytes).decode("ascii")
             for entry in self._trust_chain_manager.chain.entries:
                 if entry.public_key != expected_pk:
-                    return False, f"public key mismatch at seq {entry.seq}"
+                    return VerificationResult(
+                        status=VerificationState.FAILED,
+                        reason=f"public key mismatch at seq {entry.seq}",
+                        signer=entry.public_key,
+                    )
         return self._trust_chain_manager.verify()
 
     def audit_log(
@@ -873,6 +877,7 @@ class Soul:
         search_strategy: SearchStrategy | None = None,
         password: str | None = None,
         eternal: EternalStorageManager | None = None,
+        allow_unverified: bool = False,
     ) -> Soul:
         """Awaken a Soul from a .soul file, directory, soul.json, soul.yaml, or soul.md.
 
@@ -888,6 +893,7 @@ class Soul:
             SoulDecryptionError,
             SoulEncryptedError,
             SoulFileNotFoundError,
+            SoulTrustError,
         )
 
         memory_data: dict = {}
@@ -970,6 +976,23 @@ class Soul:
         # Done after MemoryManager swap so any future reactive logic that
         # depends on memory state runs on the final manager.
         soul._restore_trust_chain(memory_data)
+
+        verification_result = soul.verify_chain()
+
+        if verification_result.status == VerificationState.FAILED:
+            if allow_unverified:
+                logger.warning(
+                    f"Awakening unverified soul. Signer: {verification_result.signer}, "
+                    f"Reason: {verification_result.reason}"
+                )
+            else:
+                logger.error("Soul import refused due to trust chain failure.")
+                raise SoulTrustError(
+                    f"Refusing to awaken soul: {verification_result.reason}. "
+                    "Use --allow-unverified to override."
+                )
+        elif verification_result.status == VerificationState.WARNED:
+            logger.warning(f"Trust chain warning: {verification_result.reason}")
 
         # F4 — Wire eternal storage
         soul._eternal = eternal

--- a/src/soul_protocol/runtime/soul.py
+++ b/src/soul_protocol/runtime/soul.py
@@ -605,7 +605,7 @@ class Soul:
                     return VerificationResult(
                         status=VerificationState.FAILED,
                         reason=f"public key mismatch at seq {entry.seq}",
-                        signer=entry.public_key,
+                        signer=getattr(entry, "actor_did", None),
                     )
         return self._trust_chain_manager.verify()
 
@@ -746,6 +746,14 @@ class Soul:
             human="",
         )
 
+        soul._safe_append_chain(
+            "lifecycle.birth",
+            {
+                "name": name,
+                "role": role,
+            },
+        )
+
         # F4 — Wire eternal storage
         soul._eternal = eternal
 
@@ -867,6 +875,16 @@ class Soul:
             old_soul.did,
             identity.did,
         )
+
+        soul._safe_append_chain(
+            "lifecycle.reincarnate",
+            {
+                "name": new_name,
+                "previous_did": old_soul.did,
+                "incarnation": identity.incarnation,
+            },
+        )
+
         return soul
 
     @classmethod
@@ -990,10 +1008,11 @@ class Soul:
                 logger.error("Soul import refused due to trust chain failure.")
                 raise SoulTrustError(
                     f"Refusing to awaken soul: {verification_result.reason}. "
-                    "Pass allow_unverified=True to override."
+                    "Pass allow_unverified=True to override.",
+                    signer=verification_result.signer,
                 )
         elif verification_result.status == VerificationState.WARNED:
-            logger.warning(f"Trust chain warning: {verification_result.reason}")
+            logger.warning("Trust chain warning: %s", verification_result.reason)
 
         # F4 — Wire eternal storage
         soul._eternal = eternal

--- a/src/soul_protocol/runtime/trust/manager.py
+++ b/src/soul_protocol/runtime/trust/manager.py
@@ -179,7 +179,7 @@ class TrustChainManager:
 
         if not self.chain.entries:
             return VerificationResult(
-                status=VerificationState.WARNED,
+                status=VerificationState.FAILED,
                 reason="Trust chain is completely absent or empty.",
                 signer=None,
             )

--- a/src/soul_protocol/runtime/trust/manager.py
+++ b/src/soul_protocol/runtime/trust/manager.py
@@ -41,9 +41,9 @@ class VerificationResult:
     signer: str | None = None
 
     def __iter__(self):
-        passed = self.status == VerificationState.PASSED
+        passed = self.status != VerificationState.FAILED
         yield passed
-        yield self.reason if not passed else None
+        yield self.reason if self.status != VerificationState.PASSED else None
 
     def __eq__(self, other):
         if isinstance(other, tuple):
@@ -177,14 +177,14 @@ class TrustChainManager:
     def verify(self) -> VerificationResult:
         """Run :func:`verify_chain` over this manager's chain and return a structured result."""
 
-        if not self.chain:
+        if not self.chain.entries:
             return VerificationResult(
-                status=VerificationState.FAILED,
-                reason="Trust chain is completely absent.",
+                status=VerificationState.WARNED,
+                reason="Trust chain is completely absent or empty.",
                 signer=None,
             )
 
-        latest_signer = self.chain.entries[-1].public_key if self.chain.entries else None
+        latest_signer = self.chain.entries[-1].actor_did if self.chain.entries else None
 
         is_valid, error_msg = verify_chain(self.chain)
 

--- a/src/soul_protocol/runtime/trust/manager.py
+++ b/src/soul_protocol/runtime/trust/manager.py
@@ -11,7 +11,9 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import UTC, datetime
+from enum import Enum
 from typing import Any
 
 from soul_protocol.spec.trust import (
@@ -24,6 +26,36 @@ from soul_protocol.spec.trust import (
     compute_payload_hash,
     verify_chain,
 )
+
+
+class VerificationState(Enum):
+    PASSED = "passed"
+    WARNED = "warned"
+    FAILED = "failed"
+
+
+@dataclass
+class VerificationResult:
+    status: VerificationState
+    reason: str
+    signer: str | None = None
+
+    def __iter__(self):
+        passed = self.status == VerificationState.PASSED
+        yield passed
+        yield self.reason if not passed else None
+
+    def __eq__(self, other):
+        if isinstance(other, tuple):
+            return tuple(self) == other
+        if isinstance(other, VerificationResult):
+            return (self.status, self.reason, self.signer) == (
+                other.status,
+                other.reason,
+                other.signer,
+            )
+        return False
+
 
 logger = logging.getLogger(__name__)
 
@@ -142,9 +174,32 @@ class TrustChainManager:
             return list(self.chain.entries)
         return [e for e in self.chain.entries if e.action.startswith(action_prefix)]
 
-    def verify(self) -> tuple[bool, str | None]:
-        """Run :func:`verify_chain` over this manager's chain."""
-        return verify_chain(self.chain)
+    def verify(self) -> VerificationResult:
+        """Run :func:`verify_chain` over this manager's chain and return a structured result."""
+
+        if not self.chain:
+            return VerificationResult(
+                status=VerificationState.FAILED,
+                reason="Trust chain is completely absent.",
+                signer=None,
+            )
+
+        latest_signer = self.chain.entries[-1].public_key if self.chain.entries else None
+
+        is_valid, error_msg = verify_chain(self.chain)
+
+        if not is_valid:
+            return VerificationResult(
+                status=VerificationState.FAILED,
+                reason=error_msg or "Trust chain signatures failed verification.",
+                signer=latest_signer,
+            )
+
+        return VerificationResult(
+            status=VerificationState.PASSED,
+            reason="Trust chain verified successfully.",
+            signer=latest_signer,
+        )
 
     def integrity(self) -> dict:
         """Return a summary :func:`chain_integrity_check` dict."""

--- a/tests/test_cli/test_org_init.py
+++ b/tests/test_cli/test_org_init.py
@@ -92,7 +92,6 @@ def test_rerun_without_force_refuses(tmp_path: Path) -> None:
         second.output + (second.stderr if hasattr(second, "stderr") else "")
     )
 
-
 def test_rerun_with_force_overwrites(tmp_path: Path) -> None:
     runner = CliRunner()
     data_dir = tmp_path / "org"

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -290,7 +290,7 @@ class TestSoulEncryptionIntegration:
 
         data = await pack_soul(soul.serialize(), password="bytes-pw")
 
-        restored = await Soul.awaken(data, password="bytes-pw")
+        restored = await Soul.awaken(data, password="bytes-pw", allow_unverified=True)
         assert restored.name == "Echo"
 
     async def test_export_without_password_backward_compat(self, tmp_path):

--- a/tests/test_memory_layers/test_back_compat_load.py
+++ b/tests/test_memory_layers/test_back_compat_load.py
@@ -127,7 +127,7 @@ async def test_full_legacy_awaken_round_trip(tmp_path: Path):
     soul_path = tmp_path / "legacy.soul"
     soul_path.write_bytes(archive)
 
-    soul = await Soul.awaken(soul_path)
+    soul = await Soul.awaken(soul_path, allow_unverified=True)
     facts = soul._memory._semantic.facts()
     assert any(f.content == "User likes Python" for f in facts)
     assert any(f.content == "User uses macOS" for f in facts)

--- a/tests/test_trust_chain/test_chain_integration.py
+++ b/tests/test_trust_chain/test_chain_integration.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import pytest
 
 from soul_protocol.runtime.soul import Soul
+from soul_protocol.runtime.trust.manager import VerificationState
 from soul_protocol.runtime.types import Interaction
 
 
@@ -15,7 +16,9 @@ from soul_protocol.runtime.types import Interaction
 async def test_soul_birth_creates_empty_chain():
     soul = await Soul.birth("TestSoul")
     assert soul.trust_chain.length == 0
-    assert soul.verify_chain() == (True, None)
+    result = soul.verify_chain()
+    assert result.status == VerificationState.WARNED
+    assert "empty" in result.reason.lower()
 
 
 @pytest.mark.asyncio

--- a/tests/test_trust_chain/test_chain_integration.py
+++ b/tests/test_trust_chain/test_chain_integration.py
@@ -13,12 +13,12 @@ from soul_protocol.runtime.types import Interaction
 
 
 @pytest.mark.asyncio
-async def test_soul_birth_creates_empty_chain():
+async def test_soul_birth_creates_initial_chain():
     soul = await Soul.birth("TestSoul")
-    assert soul.trust_chain.length == 0
+    assert soul.trust_chain.length == 1
+    assert soul.trust_chain.entries[0].action == "lifecycle.birth"
     result = soul.verify_chain()
-    assert result.status == VerificationState.WARNED
-    assert "empty" in result.reason.lower()
+    assert result.status == VerificationState.PASSED
 
 
 @pytest.mark.asyncio

--- a/tests/test_trust_chain/test_cli_verify_audit.py
+++ b/tests/test_trust_chain/test_cli_verify_audit.py
@@ -62,7 +62,7 @@ def test_soul_verify_tampered_chain_returns_one(tmp_path):
         chain_file.write_text(json.dumps(data, indent=2))
 
     runner = CliRunner()
-    result = runner.invoke(cli, ["verify", str(soul_dir)])
+    result = runner.invoke(cli, ["verify", str(soul_dir), "--allow-unverified"])
     assert result.exit_code == 1
     assert "failed" in result.output.lower() or "✗" in result.output
 

--- a/tests/test_trust_chain/test_import_verification.py
+++ b/tests/test_trust_chain/test_import_verification.py
@@ -1,0 +1,106 @@
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from soul_protocol.runtime.exceptions import SoulTrustError
+from soul_protocol.runtime.soul import Soul
+from soul_protocol.runtime.types import Interaction
+
+
+async def _build_signed_soul_dir(tmp_path: Path) -> Path:
+    soul = await Soul.birth("TestSoul")
+    await soul.observe(Interaction(user_input="hi", agent_output="hello"))
+    await soul.observe(Interaction(user_input="more", agent_output="ok"))
+    soul_dir = tmp_path / "test-soul"
+    await soul.save_local(soul_dir)
+    return soul_dir
+
+
+@pytest.mark.asyncio
+async def test_import_clean_chain_passes(tmp_path: Path):
+    soul_dir = await _build_signed_soul_dir(tmp_path)
+
+    # Should not raise any exceptions
+    soul = await Soul.awaken(soul_dir)
+    assert soul.name == "TestSoul"
+    assert soul.trust_chain.length >= 2
+
+
+@pytest.mark.asyncio
+async def test_import_tampered_chain_fails(tmp_path: Path):
+    soul_dir = await _build_signed_soul_dir(tmp_path)
+
+    # Tamper with the chain by modifying the signature
+    chain_file = soul_dir / "trust_chain" / "chain.json"
+    data = json.loads(chain_file.read_text())
+
+    sig = data["entries"][1]["signature"]
+    data["entries"][1]["signature"] = "AAAA" + sig[4:]
+    chain_file.write_text(json.dumps(data, indent=2))
+
+    with pytest.raises(SoulTrustError) as exc_info:
+        await Soul.awaken(soul_dir)
+
+    assert "Refusing to awaken soul:" in str(exc_info.value)
+    assert "signature" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_import_missing_signature_fails(tmp_path: Path):
+    soul_dir = await _build_signed_soul_dir(tmp_path)
+
+    # Tamper with the chain by clearing the signature entirely
+    chain_file = soul_dir / "trust_chain" / "chain.json"
+    data = json.loads(chain_file.read_text())
+    data["entries"][1]["signature"] = ""
+    chain_file.write_text(json.dumps(data, indent=2))
+
+    with pytest.raises(SoulTrustError) as exc_info:
+        await Soul.awaken(soul_dir)
+
+    assert "Refusing to awaken soul" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_import_key_rotation_mid_chain_fails(tmp_path: Path):
+    soul_dir = await _build_signed_soul_dir(tmp_path)
+
+    # Modify the public key of the last entry to simulate an unauthorized rotation
+    chain_file = soul_dir / "trust_chain" / "chain.json"
+    data = json.loads(chain_file.read_text())
+
+    # Generate a fake base64 public key (32 bytes)
+    import base64
+
+    fake_pub_key = base64.b64encode(b"X" * 32).decode("ascii")
+    data["entries"][1]["public_key"] = fake_pub_key
+
+    # Need to update payload hash and signature as well so it only fails on key binding/mismatch?
+    # Wait, if we just modify the key in the JSON, the signature will be invalid.
+    # But Soul.verify_chain checks pubkey binding FIRST! So it should raise mismatch.
+    chain_file.write_text(json.dumps(data, indent=2))
+
+    with pytest.raises(SoulTrustError) as exc_info:
+        await Soul.awaken(soul_dir)
+
+    assert "public key mismatch" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_import_allow_unverified_warns(tmp_path: Path, caplog):
+    soul_dir = await _build_signed_soul_dir(tmp_path)
+
+    # Tamper with the chain
+    chain_file = soul_dir / "trust_chain" / "chain.json"
+    data = json.loads(chain_file.read_text())
+    data["entries"][1]["signature"] = ""
+    chain_file.write_text(json.dumps(data, indent=2))
+
+    # Use allow_unverified=True, which should bypass the hard fail and instead log a warning
+    with caplog.at_level(logging.WARNING):
+        soul = await Soul.awaken(soul_dir, allow_unverified=True)
+
+    assert soul.name == "TestSoul"
+    assert any("Awakening unverified soul" in record.message for record in caplog.records)

--- a/tests/test_trust_chain/test_persistence.py
+++ b/tests/test_trust_chain/test_persistence.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from soul_protocol.runtime.soul import Soul
+from soul_protocol.runtime.trust.manager import VerificationState
 from soul_protocol.runtime.types import Interaction
 
 
@@ -119,4 +120,4 @@ async def test_legacy_archive_without_chain_still_loads(tmp_path: Path):
 
     soul2 = await Soul.awaken(stripped)
     assert soul2.trust_chain.length == 0
-    assert soul2.verify_chain() == (True, None)
+    assert soul2.verify_chain().status == VerificationState.WARNED

--- a/tests/test_trust_chain/test_persistence.py
+++ b/tests/test_trust_chain/test_persistence.py
@@ -118,6 +118,6 @@ async def test_legacy_archive_without_chain_still_loads(tmp_path: Path):
                 continue
             dst.writestr(item, src.read(item.filename))
 
-    soul2 = await Soul.awaken(stripped)
+    soul2 = await Soul.awaken(stripped, allow_unverified=True)
     assert soul2.trust_chain.length == 0
-    assert soul2.verify_chain().status == VerificationState.WARNED
+    assert soul2.verify_chain().status == VerificationState.FAILED


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change in 2-3 sentences. Link the issue it fixes. -->
This PR shifts the trust chain verification from a "fail-open" to a "fail-closed" security posture. It wires trust chain verification directly into the Soul.awaken() import path. If a .soul file has a tampered, missing, or broken trust chain, it will now hard-fail and refuse to load by raising a SoulTrustError. This strict verification can be bypassed using the newly introduced --allow-unverified flag, which will emit a WARNING log instead.

Fixes #227 

## How to test

<!-- Steps to verify the change works, or paste test output. -->

```
# Run the specific trust verification tests
uv run pytest tests/test_trust_chain/test_import_verification.py -v
```

## Checklist

- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint passes (`uv run ruff check . && uv run ruff format --check .`)
- [x] No secrets or credentials in the diff
- [x] PR title follows Conventional Commits (`feat:`, `fix:`, `docs:`, etc.)
