### PR TITLE
docs(contributing): add base-branch callout so PRs target dev

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ uv run pytest tests/ -v
 
 ## Checklist
 
+- [ ] **Base branch is `dev`, not `main`** (see [CONTRIBUTING.md](../CONTRIBUTING.md))
 - [ ] Tests pass locally (`uv run pytest tests/`)
 - [ ] Lint passes (`uv run ruff check . && uv run ruff format --check .`)
 - [ ] No secrets or credentials in the diff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,9 @@
 
 Soul Protocol is an open standard plus a Python reference runtime for portable AI agent identity and memory. This guide is for anyone sending a PR or filing an issue. If you're applying for the LFDT mentorship program, also read [docs/lfdt-mentorship.md](docs/lfdt-mentorship.md) — it covers the mentee scope.
 
+> [!IMPORTANT]
+> **All PRs target `dev`, not `main`.** Releases roll up from `dev` to `main` via a single release PR. If you open a PR against `main` we'll ask you to retarget. Branch off `dev` from the start: `git checkout -b feat/my-thing origin/dev`.
+
 ## Quick start
 
 The full setup walkthrough lives in [docs/getting-started.md](docs/getting-started.md). The short version:


### PR DESCRIPTION
## What this changes

Both LFDT mentee PRs in this cohort ([#232](https://github.com/qbtrix/soul-protocol/pull/232), [#237](https://github.com/qbtrix/soul-protocol/pull/237)) opened against `main` instead of `dev`. The dev-vs-main rule was in `CONTRIBUTING.md` but buried as one bullet inside "Submitting a PR" alongside Conventional Commits and lint. A skim of the PR template missed it entirely.

Two surgical adds:

1. **Callout block at the top of `CONTRIBUTING.md`**: a GitHub-flavoured `> [!IMPORTANT]` admonition right after the doc heading, before Quick Start. Includes the starter command for branching off `dev`.
2. **First checklist item in `.github/PULL_REQUEST_TEMPLATE.md`**: "Base branch is `dev`, not `main`" with a link back to CONTRIBUTING.md. This is the one a contributor sees in the PR compose form before they hit submit.

No code change. No test impact.

## How to test

Visual review: the callout renders correctly on github.com (GitHub admonition syntax). The PR template change appears in the compose form for the next PR.
