### PR TITLE
ci: run pytest matrix on PRs targeting dev (#241)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,17 @@
-# CI — lint and test on every PR and push to main.
+# CI — lint and test on every PR and push to main or dev.
+# Updated: 2026-05-13 (#241) — Added dev to the trigger list so PRs targeting
+#   dev get pytest matrix coverage. Without this, the entire v0.5.0 captain
+#   push merged to dev with only the PR Quality Gate (Conventional Commits +
+#   secrets scan + check-quality lint) for signal; pytest only ran on the
+#   eventual dev → main release PR.
 # Updated: 2026-03-05 — Lint errors fixed, lint job now blocks PRs.
 name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read


### PR DESCRIPTION
## What this changes

Extends `.github/workflows/ci.yml` triggers so PRs targeting `dev` get the same pytest matrix (3.11/3.12/3.13) plus lint job that PRs targeting `main` already get. Three-line diff in the `on:` block.

## Why

The PR Quality Gate (`pr-quality-gate.yml`) runs on every PR and covers Conventional Commit titles, secrets scan, and the `check-quality` lint pass. But the pytest matrix from `ci.yml` only triggered on `[main]`. Result: the entire v0.5.0 captain push (11 PRs merged to dev between 2026-04-30 and 2026-05-02) shipped without per-PR pytest coverage. Local test runs were the only signal. Regressions in any single PR would only surface on the eventual `dev` → `main` release PR.

For a release with schema changes (#192 memory primitives, #108/#190 graph overhaul) and bug-fix surfaces (#234, in-flight #238), per-PR pytest is the difference between catching a regression on the PR vs. catching it after 9 PRs already merged.

## Cost

CI cost scales linearly with the dev-branch PR rate. During v0.5.x that's ~3 PRs/week, which is well inside the GitHub Actions free tier.

## Verification

This PR itself doesn't get pytest CI: it targets `dev` and the old workflow doesn't fire there yet, which is exactly the gap we're closing. After merge, the next PR targeting `dev` should show the test matrix in its checks. The three mentee PRs (#236, #232, #237) will pick up CI on their next push.

Closes #241.
