### PR TITLE
fix(mcp): soul_forget always reports total_deleted=0

### DIFF
--- a/src/soul_protocol/mcp/server.py
+++ b/src/soul_protocol/mcp/server.py
@@ -1220,10 +1220,14 @@ async def soul_forget(
             "status": "deleted",
             "soul": s.name,
             "query": query,
-            "total_deleted": result.get("total_deleted", 0),
-            "tiers": result.get("tiers", {}),
-        }
-    )
+            "total_deleted": result.get("total", 0),
+            "tiers": {
+                k: len(v)
+                for k, v in result.items()
+                if k != "total" and isinstance(v, list)
+            },
+         }
+     )
 
 
 @mcp.tool


### PR DESCRIPTION
## What does this PR do?

Fixes the `soul_forget` MCP tool always reporting `total_deleted: 0 and tiers: {}` regardless of how many memories were actually erased. The handler was reading `result.get("total_deleted", 0)` and `result.get("tiers", {})` but `MemoryManager.forget()` returns keys `total, episodic, semantic, and procedural`. The CLI was corrected for this same mismatch in an earlier commit (see cli/main.py header line 19–20) but mcp/server.py was never updated.

Fixes #245 

## How to test

 **Reproduce before the fix:**
 1. Start the MCP server and birth a soul
 2. Call soul_observe a few times with "Alice" content
3. Call soul_forget with query="Alice", confirm=True
4. Check response — total_deleted is always 0 before this fix
5. 
```
uv run pytest tests/test_mcp_sampling_engine.py tests/test_gdpr_deletion.py -v
```

## Checklist

- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint passes (`uv run ruff check . && uv run ruff format --check .`)
- [x] No secrets or credentials in the diff
- [x] PR title follows Conventional Commits (`feat:`, `fix:`, `docs:`, etc.)
