### PR TITLE
docs: refresh GAP-ANALYSIS + COMPARISON against 0.5.0.dev0 surface

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -1,110 +1,178 @@
-<!-- COMPARISON.md — Feature comparison matrix: Soul Protocol vs competing AI memory systems.
-     Created: 2026-03-08. Sources: WHITEPAPER.md sections 10/12, LAUNCH-STATUS.md benchmarks,
-     HARD-QUESTIONS.md competitive positioning. -->
+<!--
+  COMPARISON.md — soul-protocol vs other AI memory systems.
+  Updated: 2026-05-25 — rewrite against the 0.5.0.dev0 surface. Adds rows for
+  trust chain (signed action history), multi-user attribution + domain
+  isolation, soul-aware evals, autonomous optimization, graph traversal +
+  typed ontology, and dedup-aware writes. Previous version (2026-03-08) is
+  preserved in git history.
+  Created: 2026-03-08 — head-to-head feature matrix vs Mem0, MemGPT/Letta,
+  LangChain Memory, Cognee, and OpenAI Memory.
+-->
 
 # Comparison: Soul Protocol vs. AI Memory Systems
 
-How Soul Protocol compares to Mem0, MemGPT/Letta, LangChain Memory, Cognee, and OpenAI Memory. We try to be fair. Every system on this list solves real problems. The question is which problems you need solved.
+> [!NOTE]
+> **Last refreshed:** 2026-05-25 against soul-protocol **v0.5.0.dev0**.
+> **Previous version:** 2026-03-08, scored against soul-protocol 0.2.x. Preserved in git history.
+> Competitor capability claims reflect each project's latest stable release as of refresh date — links inline.
+
+How Soul Protocol compares to [Mem0](https://github.com/mem0ai/mem0), [MemGPT / Letta](https://github.com/letta-ai/letta), [LangChain Memory](https://python.langchain.com/docs/modules/memory/), [Cognee](https://github.com/topoteretes/cognee), and OpenAI Memory. We try to be fair. Every system on this list solves real problems. The question is which problems you need solved.
+
+Soul Protocol's pitch is differentiated, not dominant. Competitors do real things better — mature vector store ecosystems, longer production track records, deeper context-window management. The rows below name those wins, too.
 
 ---
 
-## Feature Matrix
+## 1 · Feature matrix
 
-| Feature | Soul Protocol | Mem0 | MemGPT / Letta | LangChain Memory | Cognee | OpenAI Memory |
-|---------|:---:|:---:|:---:|:---:|:---:|:---:|
-| **Portable identity** (.soul file) | Yes | No | No | No | No | No |
-| **Psychology pipeline** (somatic markers, significance gate, self-model) | Yes | No | No | No | No | No |
+| Dimension | Soul Protocol (0.5.0.dev0) | Mem0 | MemGPT / Letta | LangChain Memory | Cognee | OpenAI Memory |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Portable identity** (single-file `.soul` archive) | Yes | No | No | No | No | No |
+| **Multi-user attribution** (`user_id` on every memory) | Yes (0.4.0) | Per-user instance | Per-agent | Per-conversation | Per-dataset | Per-account |
+| **Domain isolation** (allow-list-enforced sub-namespaces) | Yes (0.4.0) | No | No | No | Yes (graph domains) | No |
+| **Signed action history** (Ed25519 trust chain, verifiable) | Yes (0.4.0 + hardening 0.5.0.dev0) | No | No | No | No | No |
 | **Personality model** (OCEAN Big Five, structured) | Yes | No | No | No | No | No |
 | **Significance gating** (LIDA — decide what's worth remembering) | Yes | No | No | No | No | No |
-| **Emotional memory** (somatic markers on every memory) | Yes | No | No | No | No | No |
+| **Emotional memory** (somatic markers per memory) | Yes | No | No | No | No | No |
 | **Self-model** (Klein — emergent identity from experience) | Yes | No | No | No | No | No |
 | **Activation decay** (ACT-R — recency + frequency scoring) | Yes | No | No | No | No | No |
-| **Knowledge graph** (temporal entity-relations) | Yes | No | No | No | Yes | No |
-| **Vector search** | Pluggable | Built-in | Via tools | Built-in | Built-in | Internal |
-| **Pluggable LLM** (any provider, including offline) | Yes | Partial | No (OpenAI-focused) | Yes | Yes | No (OpenAI only) |
+| **Memory update verbs** (`confirm`/`update`/`supersede`/`forget`/`purge`/`reinstate`, PE-gated) | Yes (0.5.0.dev0) | Add/update/delete | Function-call based | Buffer/summary clear | Graph CRUD | Add/forget |
+| **Dedup-aware writes** (`note()` with Jaccard + containment, CREATE/SKIP/MERGE) | Yes (0.5.0.dev0) | Partial (semantic dedup) | No | No | Graph-level merge | Yes (opaque) |
+| **Knowledge graph** (temporal entity-relations) | Yes (typed: 8 kinds + 8 predicates, 0.5.0.dev0) | No | No | Entity memory only | Yes (rich) | No |
+| **Graph traversal API** (`nodes/edges/path/subgraph/mermaid`) | Yes (0.5.0.dev0) | No | No | No | Yes | No |
+| **Soul-aware evals** (YAML spec, 5 scoring kinds, soul-state seeding) | Yes (0.5.0.dev0) | No | No | LangSmith (external) | No | No |
+| **Autonomous optimization** (`optimize` loop drives knobs from eval signal) | Yes (0.5.0.dev0) | No | No | No | No | No |
+| **Structured diff** (`soul diff` across identity, memory, trust chain) | Yes (0.5.0.dev0) | No | No | No | No | No |
+| **Vector search** | Pluggable (sentence-transformers, OpenAI, Ollama, TF-IDF, hash) | Built-in (mature, many stores) | Via tools | Built-in (via embeddings) | Built-in | Internal |
+| **Pluggable LLM** (any provider, including offline) | Yes (Anthropic / OpenAI / Ollama / LiteLLM / MCP-sampling / Callable) | Partial | No (OpenAI-focused) | Yes | Yes | No (OpenAI only) |
 | **Heuristic fallback** (zero LLM calls, zero cost) | Yes | No | No | No | No | No |
 | **Offline mode** (no network required) | Yes | No | No | Partial | No | No |
-| **Multi-language schemas** (JSON Schema for any language) | Yes | No | No | No | No | No |
-| **Open standard / RFC process** | Yes | No | No | No | No | No |
-| **Context window management** | No | No | Yes | No | No | No |
+| **Append-only org journal** (SQLite WAL, hash-chained, scope-stamped) | Yes (0.3.1) | No | No | No | No | No |
+| **Decision traces** (`agent.proposed` → `human.corrected` → `decision.graduated`) | Yes (0.3.1) | No | No | No | No | No |
+| **MCP server** (28+ tools, FastMCP-based) | Yes | Community wrapper | Community wrapper | No | No | No |
+| **Multi-language spec** (language-agnostic SPEC.md + conformance contract) | Yes (0.3.3, conformance suite pending) | No | No | No | No | No |
+| **Open standard / public RFC process** | Yes | No | No | No | No | No |
+| **Context window management** (paging in/out of LLM context) | No | No | Yes (core feature) | Partial | No | No |
 | **RAG pipeline** | No (use with) | Yes | Via tools | Yes | Yes | Internal |
-| **Production vector DB integrations** | Planned | Yes | Yes | Yes | Yes | Internal |
+| **Production-grade vector DB integrations** | Planned | Yes (broad ecosystem) | Yes | Yes (broad ecosystem) | Yes | Internal |
+| **Persistent graph DB backends** (Neo4j, etc.) | No | No | No | No | Yes | No |
 | **Managed cloud service** | No | Yes | Yes | No | Yes | Yes |
 
 ---
 
-## Benchmark Comparison
+## 2 · Benchmark snapshot
 
-Head-to-head results from our five-tier validation. Soul Protocol and Mem0 (v1.0.5) processed identical conversations, scored by the same LLM judge. Stateless baseline included for reference.
+Five-tier head-to-head from 2026-03 still stands as the most recent direct measurement. Soul Protocol and Mem0 (v1.0.5) processed identical conversations, scored by the same LLM judge. Stateless baseline included for reference.
 
 | Test | Soul Protocol | Mem0 v1.0.5 | Stateless Baseline |
-|------|:---:|:---:|:---:|
+|---|:---:|:---:|:---:|
 | **Overall** | **8.5** | 6.0 | 3.0 |
 | **Emotional Continuity** | **9.2** | 7.0 | 1.8 |
 | **Hard Recall** (fact buried under 30+ turns) | **7.8** | 5.1 | 4.2 |
 
-Component ablation (which parts of Soul Protocol actually matter):
+Component ablation — which parts of Soul Protocol actually matter:
 
 | Condition | Response Quality | Hard Recall | Emotional Continuity | Overall |
-|-----------|:---:|:---:|:---:|:---:|
-| **Full Soul** (personality + memory) | 8.3 +/- 0.3 | 8.4 +/- 0.4 | 9.3 +/- 0.2 | **8.7 +/- 0.2** |
-| **RAG Only** (memory, no personality) | 7.8 +/- 0.3 | 8.2 +/- 0.2 | 9.3 +/- 0.2 | 8.4 +/- 0.2 |
-| **Personality Only** (no memory) | 7.8 +/- 0.4 | 5.9 +/- 0.7 | 7.2 +/- 0.7 | 7.0 +/- 0.4 |
+|---|:---:|:---:|:---:|:---:|
+| **Full Soul** (personality + memory) | 8.3 ± 0.3 | 8.4 ± 0.4 | 9.3 ± 0.2 | **8.7 ± 0.2** |
+| **RAG Only** (memory, no personality) | 7.8 ± 0.3 | 8.2 ± 0.2 | 9.3 ± 0.2 | 8.4 ± 0.2 |
+| **Personality Only** (no memory) | 7.8 ± 0.4 | 5.9 ± 0.7 | 7.2 ± 0.7 | 7.0 ± 0.4 |
 
 Validation details: 5 judge models from 4 providers (Anthropic, Google, DeepSeek, Meta). 20/20 judgments favored Soul over stateless baseline. Total validation cost under $5. Full methodology in the [whitepaper](../WHITEPAPER.md#12-empirical-validation).
 
+The 0.5.0.dev0 features (memory update primitives, evals, optimize, graph traversal) were not part of this benchmark. The benchmark will re-run when 0.5.0 tags; new dimensions (multi-user separation, optimization-loop convergence, trust-chain verification overhead) will be added at that point.
+
 ---
 
-## How Each System Differs
+## 3 · How each system differs
 
-### Mem0
+### 3.1 · Mem0
 
 Mem0 is a persistent memory layer for LLM applications. It stores user facts and preferences in a vector database and retrieves them via similarity search. It does this well and has production-ready integrations with major vector stores.
 
-**Where Soul Protocol differs:** Mem0 treats memory as a retrieval problem. Soul Protocol treats it as an identity problem. Mem0 stores facts. Soul Protocol stores facts with emotional context (somatic markers), filters what's worth storing (significance gate), lets memories strengthen or fade based on usage (ACT-R decay), and builds an emergent self-concept from accumulated experience (Klein self-model). In benchmarks, both systems beat a stateless baseline, but Soul Protocol scored 8.5 overall vs. Mem0's 6.0, with the largest gap in emotional continuity (9.2 vs. 7.0).
+**Where Soul Protocol differs.** Mem0 treats memory as a retrieval problem. Soul Protocol treats it as an identity problem with memory hanging off the identity. Mem0 stores facts. Soul Protocol stores facts with emotional context (somatic markers), filters what's worth storing (significance gate), lets memories strengthen or fade based on usage (ACT-R decay), and builds an emergent self-concept from accumulated experience (Klein self-model).
 
-Mem0 has no concept of portable identity. There is no file format, no personality model, and no way to move a memory state between platforms.
+As of 0.4.0/0.5.0.dev0, Soul Protocol also carries:
 
-### MemGPT / Letta
+- A signed, verifiable history of every memory mutation (the trust chain) — Mem0 has no equivalent. You cannot prove what a Mem0 store contained at time T.
+- Multi-user attribution with domain isolation enforcement — Mem0 is per-user-instance; serving multiple users from one store with allow-listed namespaces is not native.
+- Memory update verbs gated by prediction error and a one-hour reconsolidation window — Mem0 has update/delete but no cog-sci-grounded gating.
+- A `note()` writer with Jaccard + containment dedup that returns CREATE/SKIP/MERGE — Mem0's dedup runs implicitly during indexing.
+
+**Where Mem0 wins.** Production-grade vector DB integrations across the major stores (Chroma, Pinecone, Qdrant, Weaviate, pgvector). Mature managed cloud. Longer production track record at scale. If you just need "remember what the user said earlier" with a hosted backend, Mem0 is the simpler deploy.
+
+In the 2026-03 benchmark, both beat a stateless baseline; Soul scored 8.5 overall vs Mem0's 6.0, with the largest gap in emotional continuity (9.2 vs 7.0). That benchmark predates Soul Protocol's 0.4/0.5 additions.
+
+Mem0 has no concept of portable identity. There is no file format, no personality model, no signed history, and no way to move a memory state between platforms.
+
+### 3.2 · MemGPT / Letta
 
 MemGPT solves a specific and important problem: how to give an LLM access to more memory than fits in a single context window. It pages memory in and out, uses function calls to manage retrieval, and effectively gives an LLM an operating system for its own context.
 
-**Where Soul Protocol differs:** MemGPT manages *what fits in the prompt*. Soul Protocol defines *who the agent is*. MemGPT doesn't have personality, portable identity, emotional markers, or a self-model. Soul Protocol doesn't manage context windows. The two are complementary: a MemGPT system could use Soul Protocol for the identity layer that gets paged into context.
+**Where Soul Protocol differs.** MemGPT manages *what fits in the prompt*. Soul Protocol defines *who the agent is*. MemGPT doesn't have personality, portable identity, emotional markers, a self-model, signed history, or domain isolation. Soul Protocol doesn't manage context windows.
 
-### LangChain Memory
+The two are complementary: a MemGPT system could use Soul Protocol for the identity + signed-history layer that gets paged into context.
+
+**Where MemGPT / Letta wins.** Context window management is the canonical problem MemGPT was built for; Soul Protocol has nothing in that lane. Letta's hosted service is mature. If your primary problem is "my conversations don't fit in 200k tokens and I need automated paging," reach for MemGPT.
+
+### 3.3 · LangChain Memory
 
 LangChain provides memory modules for RAG pipelines: conversation buffers, summary buffers, entity memory, vector store-backed retrieval. These are retrieval infrastructure components.
 
-**Where Soul Protocol differs:** LangChain memory answers "how do I find relevant context?" Soul Protocol answers "who is this AI and what does it remember?" LangChain has no significance filtering (everything gets stored), no emotional tagging, no activation decay, no self-model, and no portable file format. Soul Protocol's memory pipeline decides *whether* to store something before deciding *how* to retrieve it.
+**Where Soul Protocol differs.** LangChain memory answers "how do I find relevant context?" Soul Protocol answers "who is this AI and what does it remember?" LangChain has no significance filtering (everything gets stored), no emotional tagging, no activation decay, no self-model, no portable file format, no signed history, and no eval / optimize loop. Soul Protocol's memory pipeline decides *whether* to store something before deciding *how* to retrieve it.
 
-### Cognee
+**Where LangChain wins.** Ecosystem breadth. If you're already deep in LangChain, the buffer / summary / entity memory modules drop in with one import and integrate with every chain / agent primitive in the framework. LangSmith provides external evaluation tooling that's more mature than Soul Protocol's in-tree `soul eval`.
 
-Cognee builds knowledge graphs from unstructured data with domain isolation. It has strong graph construction and query capabilities with production integrations.
+### 3.4 · Cognee
 
-**Where Soul Protocol differs:** Cognee's knowledge graph is locked to its runtime. Soul Protocol's knowledge graph is portable (temporal edges serialize into the `.soul` file) and comes alongside four other memory tiers. Soul Protocol adds identity, personality, emotional memory, and significance gating that Cognee doesn't address. Cognee has stronger graph-specific features (domain isolation, advanced queries) than Soul Protocol's current graph implementation.
+Cognee builds knowledge graphs from unstructured data with domain isolation. It has strong graph construction and query capabilities with production integrations and persistent graph DB backends.
 
-### OpenAI Memory
+**Where Soul Protocol differs.** Cognee's knowledge graph is locked to its runtime. Soul Protocol's knowledge graph is portable (entities + typed edges serialize into the `.soul` file with `graph.entity_added` / `graph.relation_added` trust-chain hooks) and comes alongside seven other memory layers. Soul Protocol adds identity, personality, emotional memory, significance gating, signed history, and the eval / optimize loop that Cognee doesn't address.
+
+The 0.5.0.dev0 graph work narrowed the historical gap: Soul Protocol now ships eight built-in entity kinds, eight relation predicates, and a `Soul.graph` view with `path` / `subgraph` / `to_mermaid` / `reachable`. Graph mutations are signed into the trust chain.
+
+**Where Cognee wins.** Persistent graph DB backends (Neo4j and friends) — Soul Protocol's graph is in-memory dict + adjacency-list, fine for soul-sized graphs but not for enterprise knowledge graphs at scale. Cognee's graph construction from unstructured corpora is more mature. If your application is more about structured knowledge over a large corpus than companion identity, Cognee's graph-first approach is the better fit.
+
+### 3.5 · OpenAI Memory
 
 OpenAI's built-in memory stores facts about users across conversations within the OpenAI ecosystem. It's automatic, requires no setup, and works well within ChatGPT and the API.
 
-**Where Soul Protocol differs:** OpenAI Memory is per-account, per-platform. You cannot export it, move it to another provider, or inspect the raw data. Soul Protocol is a portable file you own. Rename it to `.zip`, read the JSON, load it with Claude today and Ollama tomorrow. OpenAI Memory also has no personality model, no emotional markers, and no self-model. It stores facts; Soul Protocol stores identity.
+**Where Soul Protocol differs.** OpenAI Memory is per-account, per-platform. You cannot export it, move it to another provider, inspect the raw data, or verify what was stored when. Soul Protocol is a portable file you own: rename it to `.zip`, read the JSON, load it with Claude today and Ollama tomorrow. The trust chain proves the soul's history hasn't been tampered with. The eval framework lets you measure whether the soul is actually behaving as you want.
+
+OpenAI Memory also has no personality model, no emotional markers, no self-model, no domain isolation, no eval / optimize loop, and no signed history. It stores facts; Soul Protocol stores identity.
+
+**Where OpenAI wins.** Zero-config. If you're building exclusively on OpenAI's platform and want "it just works," there's no setup required. The flip side is total vendor lock-in.
 
 ---
 
-## When to Use What
+## 4 · When to use what
 
 Not every project needs Soul Protocol. Here's an honest guide.
 
-**Use Mem0 if** you need a production-ready persistent memory layer with minimal setup, you're building a standard chatbot that needs to remember user preferences, and you don't need portable identity or emotional context. Mem0 is simpler to deploy and has mature vector store integrations.
+**Use Mem0 if** you need a production-ready persistent memory layer with minimal setup, you're building a standard chatbot that needs to remember user preferences, and you don't need portable identity, signed history, or emotional context. Mem0 is simpler to deploy and has mature vector store integrations.
 
-**Use MemGPT/Letta if** your primary problem is context window management. If your agent needs to work with very long conversations and you need to page information in and out of context efficiently, MemGPT is purpose-built for that.
+**Use MemGPT / Letta if** your primary problem is context window management. If your agent needs to work with very long conversations and you need to page information in and out of context efficiently, MemGPT is purpose-built for that.
 
-**Use LangChain Memory if** you're already in the LangChain ecosystem and need basic conversation persistence. Buffer memory and entity memory are straightforward to add to an existing chain. If you just need "remember what the user said earlier in this conversation," LangChain memory modules are sufficient.
+**Use LangChain Memory if** you're already in the LangChain ecosystem and need basic conversation persistence. Buffer memory and entity memory are straightforward to add to an existing chain.
 
-**Use Cognee if** your primary need is building and querying knowledge graphs from unstructured data with strong domain isolation. If your application is more about structured knowledge than companion identity, Cognee's graph-first approach may be a better fit.
+**Use Cognee if** your primary need is building and querying knowledge graphs from large unstructured corpora with strong domain isolation and a persistent graph DB. Soul Protocol's graph is portable but in-memory; Cognee's is enterprise-scale.
 
-**Use OpenAI Memory if** you're building exclusively on OpenAI's platform and want zero-config persistence. It just works, with no additional infrastructure.
+**Use OpenAI Memory if** you're building exclusively on OpenAI's platform and want zero-config persistence. It just works, with no additional infrastructure — and no portability or auditability.
 
-**Use Soul Protocol if** you're building an AI companion that needs to feel like someone rather than something. If your agent needs a persistent personality that evolves, memories that carry emotional weight, a sense of self that develops from experience, and the ability to move between platforms without losing its identity. Soul Protocol is designed for long-lived AI relationships, not single-session retrieval.
+**Use Soul Protocol if** you're building an AI agent that needs to feel like someone rather than something — and that needs to be auditable, portable, and measurable. Specifically:
 
-Soul Protocol also works alongside these systems. You can use Mem0 or LangChain for retrieval and Soul Protocol for the identity layer on top. The `CognitiveEngine` interface means any LLM backend works, and the `.soul` file format means the identity is never locked to one platform.
+- You need an agent with a persistent personality that evolves, memories that carry emotional weight, and a sense of self that develops from experience.
+- You need to **move identity between platforms** without losing memory or behavior.
+- You need to **prove** what your agent learned and when (the trust chain — required for compliance, reputation systems, or shared-soul deployments).
+- You need **multi-user attribution and domain isolation** in a single soul (one agent serving multiple humans with enforced context separation).
+- You need to **measure and improve** the agent against held-out cases (the `soul eval` + `soul optimize` loop).
+- You need **dedup-aware writes** so repeated similar facts collapse instead of accumulating duplicates.
+
+Soul Protocol also works alongside the systems above. You can use Mem0 or LangChain for retrieval and Soul Protocol for the identity + signed-history layer on top. The `CognitiveEngine` interface means any LLM backend works, and the `.soul` file format means the identity is never locked to one platform.
+
+---
+
+## 5 · What this doc does not cover
+
+- Specific competitor performance benchmarks under load. The 2026-03 numbers compare quality, not latency / throughput / cost-per-write.
+- Hosted-service economics. Mem0 / Letta / Cognee / OpenAI Memory all run cloud services with different pricing models; soul-protocol is self-hosted only at this layer.
+- Forward compatibility. Each competitor evolves; rows above were verified against latest stable releases as of refresh date. File an issue if a row goes stale.

--- a/docs/GAP-ANALYSIS.md
+++ b/docs/GAP-ANALYSIS.md
@@ -1,559 +1,215 @@
+<!--
+  GAP-ANALYSIS.md — what is shipped vs what is missing in soul-protocol.
+  Updated: 2026-05-25 — rewrite against 0.5.0.dev0 surface. Previous version
+  (2026-03-06, scored against the 0.2.2 vision baseline) is preserved in git
+  history. Most of the original "missing" rows have shipped through the 0.3.x
+  spec/runtime work, the 0.4.0 identity bundle (multi-user, layers + domains,
+  trust chain), and the 0.5.0.dev0 memory + evaluation primitives.
+-->
+
 # Soul Protocol — Gap Analysis
 
-> Vision docs vs implementation reality. What's built, what's missing, and what's beyond the original spec.
+> [!NOTE]
+> **Last refreshed:** 2026-05-25 against soul-protocol **v0.5.0.dev0** (CHANGELOG `[Unreleased]` + last tagged release `0.4.0`).
+> **Previous version:** March 2026, scored against the 0.2.2 vision baseline. Preserved in git history.
 
-**Date:** 2026-03-06
-**Codebase version:** 0.2.2 (dev branch, commit eaaeebd)
+This document is a working answer to one question: **what is genuinely missing from soul-protocol today?** It's written for two readers — a third-party runtime author deciding whether the spec is complete enough to target, and a contributor looking for a real gap to close.
 
----
-
-## 1. Executive Summary
-
-Soul Protocol has implemented roughly **65-70% of the vision** described across the four DSP specification documents. The core experience loop --- birth a soul, give it a personality, observe interactions, remember facts, recall memories, save and migrate --- is fully functional. The implementation went significantly beyond the vision in several areas (psychology-informed memory, cognitive engine, self-model emergence) while leaving the entire eternal storage tier and several CLI commands unbuilt.
-
-### Key Strengths
-
-- **Memory system is more sophisticated than the vision.** The implementation added ACT-R activation decay, somatic markers, significance gating, spreading activation, and a self-model --- none of which were in the original spec.
-- **Full parse/export pipeline.** All four input formats (md, yaml, json, .soul) are supported with round-trip fidelity.
-- **Cognitive Engine pattern.** The `CognitiveEngine` protocol allows LLM-enhanced cognition while the `HeuristicEngine` provides zero-dependency fallback --- a clean architecture not in the vision.
-- **MCP server.** 10 tools, 3 resources, 2 prompts for AI agent integration. Not in any vision doc.
-- **Solid test coverage.** 981 tests across 56 test files.
-
-### Key Gaps
-
-- **Eternal storage is entirely unbuilt.** No IPFS, Arweave, or blockchain integration. Local-only.
-- **Lifecycle is incomplete.** Only `BORN`, `ACTIVE`, `DORMANT`, `RETIRED` exist. The vision specifies `UNBORN`, `ESSENCE`, `REINCARNATED`, and a full retirement-with-farewell flow.
-- **Skills/XP system is missing.** The vision describes leveled skills with XP progression. Zero implementation.
-- **No vector/embedding search.** Recall uses token overlap and ACT-R heuristics, not semantic vectors.
-- **No memory compression/consolidation pipeline.** The SimpleMem-inspired summarization, deduplication, and pruning are not implemented beyond basic reflection.
-- **Bond system is minimal.** `bonded_to` is a string field with no `bondStrength` tracking or evolution.
-- **No integration adapters.** The vision describes LangChain, Vercel AI SDK, and raw API adapters. None exist.
-- **JSON Schema is not published.** The vision describes a formal `$schema` at `soul-protocol.org/schema/v1.json`. The `schemas/` directory exists but no validation schema is shipped.
+Every "shipped" row is grounded in `CHANGELOG.md`, `docs/SPEC.md`, or `src/soul_protocol/`. Every "missing" row was verified against the same sources before being listed.
 
 ---
 
-## 2. Feature Matrix
+## 1 · Status header
 
-### 2.1 Identity System
-
-| Feature | Vision Doc | Status | Files | Notes |
-|---------|-----------|--------|-------|-------|
-| Soul name | DSP.md | DONE | `types.py` (Identity) | Required field |
-| Archetype | DSP.md | DONE | `types.py` (Identity) | Optional string |
-| DID generation | DSP.md | DONE | `identity/did.py` | `did:soul:{name}-{hex}` format |
-| Birth certificate | DSP.md | NOT STARTED | -- | Vision has bornAt, birthplace, witnesses, genesisHash; implementation has none of these |
-| Bond (bonded_to) | DSP.md | PARTIAL | `types.py` (Identity) | String field only. No bondStrength, bondedAt, or bond evolution |
-| Origin story | DSP.md, IMPL-SPEC | DONE | `types.py` (Identity) | `origin_story` field |
-| Prime directive | IMPL-SPEC | DONE | `types.py` (Identity) | `prime_directive` field |
-| Core values | DSP.md | DONE | `types.py` (Identity) | List of strings, wired into significance scoring |
-| Public key / crypto identity | DSP.md | NOT STARTED | -- | Vision has `publicKey` on soul.json; not implemented |
-| Human DID (did:human:) | DSP.md | NOT STARTED | -- | `bonded_to` is freeform string, not DID-format |
-
-### 2.2 DNA / Personality
-
-| Feature | Vision Doc | Status | Files | Notes |
-|---------|-----------|--------|-------|-------|
-| OCEAN personality model | DSP.md, IMPL-SPEC | DONE | `types.py` (Personality) | 5 traits, 0.0-1.0, defaults to 0.5 |
-| Communication style | IMPL-SPEC | DONE | `types.py` (CommunicationStyle) | warmth, verbosity, humor_style, emoji_usage |
-| Biorhythms | IMPL-SPEC | DONE | `types.py` (Biorhythms) | chronotype, social_battery, energy_regen_rate |
-| DNA-to-system-prompt | DSP.md, IMPL-SPEC | DONE | `dna/prompt.py` | Includes OCEAN, comm style, state, core memory |
-| DNA-to-markdown | IMPL-SPEC | DONE | `dna/prompt.py` | `dna_to_markdown()` for export |
-| dna.md in .soul file | DSP.md | DONE | `export/pack.py` | Included in zip archive |
-| Dynamic preferences (`{{DYNAMIC_PREFERENCES}}`) | DSP.md | NOT STARTED | -- | Vision shows template variables in dna.md; not implemented |
-
-### 2.3 Memory System
-
-| Feature | Vision Doc | Status | Files | Notes |
-|---------|-----------|--------|-------|-------|
-| Working memory (volatile) | MEM-ARCH | NOT STARTED | -- | Vision describes session context buffer; runtime manages this externally |
-| Core memory (always loaded) | MEM-ARCH, DSP.md | DONE | `memory/core.py` | persona + human fields, self-editable |
-| Self-editing core memory | MEM-ARCH | DONE | `soul.py` (`edit_core_memory`) | Append-based editing via MemoryManager |
-| Episodic memory | DSP.md, MEM-ARCH | DONE | `memory/episodic.py` | Full store with add, search, remove |
-| Semantic memory | DSP.md, MEM-ARCH | DONE | `memory/semantic.py` | Fact store with dedup |
-| Procedural memory | DSP.md, MEM-ARCH | DONE | `memory/procedural.py` | How-to store |
-| Knowledge graph | MEM-ARCH | DONE | `memory/graph.py`, `memory/graph_view.py`, `memory/graph_types.py` | v0.5.0 (#108, #190): typed entity ontology (8 built-in kinds + open string), 8 built-in relation predicates, edge weight, entity provenance. `Soul.graph` returns a `GraphView` with `nodes`/`edges`/`neighbors`/`path`/`subgraph`/`to_mermaid`. `Soul.recall(graph_walk=...)` filters by traversal; `page_token` paginates; `token_budget` falls back to L0 abstracts. |
-| Archival memory | MEM-ARCH | NOT STARTED | -- | Vision describes compressed conversation transcripts; not implemented |
-| Memory recall (keyword) | MEM-ARCH | DONE | `memory/recall.py`, `memory/search.py` | Token overlap + ACT-R activation |
-| Memory recall (vector/embedding) | MEM-ARCH | NOT STARTED | -- | SearchStrategy protocol exists but no embedding implementation |
-| Memory consolidation (merge/prune) | MEM-ARCH | PARTIAL | `memory/manager.py` (`consolidate`) | Only via CognitiveEngine reflection; no automatic scheduled consolidation |
-| Memory compression (SimpleMem-style) | MEM-ARCH | NOT STARTED | -- | No summarization, no recursive consolidation |
-| Importance-based pruning | MEM-ARCH | NOT STARTED | -- | `importance_threshold` in settings but no pruning logic |
-| Semantic deduplication | MEM-ARCH | PARTIAL | `memory/manager.py` | Token-overlap dedup in `extract_facts`; no embedding-based dedup |
-| Memory forget/remove | DSP.md, MEM-ARCH | DONE | `soul.py`, `memory/manager.py`, `cli/main.py` | Remove by query/entity/timestamp/id. CLI is dry-run by default; `--apply` writes a `.soul.bak`. `--id` added 2026-04-27 for surgical single-id deletion (audited via `Soul.forget_one`). |
-| User-driven memory supersede | -- | DONE | `soul.py`, `memory/manager.py`, `cli/main.py` | 2026-04-27. `Soul.supersede(old_id, new_content, ...)` writes new entry, sets `old.superseded_by = new.id`, appends to `supersede_audit`. Old entry is filtered from search by default but kept on disk for provenance. CLI: `soul supersede`. |
-| Hybrid inline+external storage | MEM-ARCH | NOT STARTED | -- | No vector DB, no external storage links |
-| Embedding interface | MEM-ARCH | PARTIAL | `memory/strategy.py` | `SearchStrategy` protocol exists; no embedding providers |
-| Storage backend interface | MEM-ARCH | DONE | `storage/protocol.py` | Protocol defined but only file backend implemented |
-| Memory in .soul file | MEM-ARCH, DSP.md | DONE | `export/pack.py`, `export/unpack.py` | All tiers serialized into zip |
-| Fact conflict resolution | -- | DONE | `memory/manager.py` | v0.2.2 feature, superseded_by field |
-| Fact extraction (heuristic) | -- | DONE | `memory/manager.py` | 18+ regex patterns |
-| Entity extraction | -- | DONE | `memory/manager.py` | Tech terms + proper noun detection |
-
-### 2.4 State / Feelings
-
-| Feature | Vision Doc | Status | Files | Notes |
-|---------|-----------|--------|-------|-------|
-| Mood enum | DSP.md | DONE | `types.py` (Mood) | 8 moods (vision has 6, implementation adds satisfied + concerned) |
-| Energy (0-100) | DSP.md | DONE | `types.py` (SoulState) | Float with clamping |
-| Focus levels | DSP.md | DONE | `types.py` (SoulState) | String: low/medium/high |
-| Social battery (0-100) | DSP.md | DONE | `types.py` (SoulState) | Float with clamping |
-| Last interaction timestamp | DSP.md | DONE | `types.py` (SoulState) | Updated on each observe() |
-| Streak tracking | DSP.md | NOT STARTED | -- | Vision shows `streak: 7`; not implemented |
-| `feel()` method | DSP.md | DONE | `soul.py`, `state/manager.py` | Delta-based updates |
-| State serialization | DSP.md | DONE | `export/pack.py` | state.json in .soul file |
-| Mood inertia (EMA smoothing) | -- | DONE | `state/manager.py` | v0.3 feature, not in vision |
-| Sentiment-driven mood | -- | DONE | `state/manager.py` | SomaticMarker -> Mood mapping |
-
-### 2.5 Evolution
-
-| Feature | Vision Doc | Status | Files | Notes |
-|---------|-----------|--------|-------|-------|
-| Evolution modes | DSP.md, IMPL-SPEC | DONE | `types.py` (EvolutionMode) | disabled, supervised, autonomous |
-| Mutation proposal | DSP.md | DONE | `evolution/manager.py` | With immutability guards |
-| Mutation approval/rejection | DSP.md | DONE | `evolution/manager.py` | For supervised mode |
-| Auto-apply (autonomous mode) | DSP.md | DONE | `evolution/manager.py` | Auto-approved on proposal |
-| Evolution history | DSP.md | DONE | `types.py` (EvolutionConfig) | List of Mutation records |
-| Mutable/immutable trait config | IMPL-SPEC | DONE | `types.py` (EvolutionConfig) | With top-level category guards |
-| Mutation rate | DSP.md | PARTIAL | `types.py` (EvolutionConfig) | Field exists but not used in trigger logic |
-| Automatic evolution triggers | DSP.md | NOT STARTED | `evolution/manager.py` | `check_triggers()` is a no-op placeholder |
-| `requiresApproval` per-mutation | DSP.md | NOT STARTED | -- | Approval is mode-based, not per-mutation |
-
-### 2.6 Lifecycle
-
-| Feature | Vision Doc | Status | Files | Notes |
-|---------|-----------|--------|-------|-------|
-| UNBORN state | DSP.md | NOT STARTED | -- | Vision has it; implementation starts at BORN |
-| BORN / ALIVE state | DSP.md | DONE | `types.py` (LifecycleState) | Called BORN and ACTIVE |
-| DORMANT state | DSP.md | DONE | `types.py` (LifecycleState) | Defined but no transition logic |
-| RETIRING state | DSP.md | NOT STARTED | -- | Vision has a transitional retiring state |
-| ESSENCE state | DSP.md | NOT STARTED | -- | "Form dissolved, essence preserved" |
-| REINCARNATED state | DSP.md | NOT STARTED | -- | No reincarnation system |
-| `Soul.birth()` | DSP.md | DONE | `soul.py` | Async classmethod with full config |
-| `Soul.awaken()` | DSP.md | DONE | `soul.py` | From .soul file, directory, json, yaml, md |
-| `Soul.retire()` | DSP.md | DONE | `soul.py` | With preserve_memories option |
-| `Soul.reincarnate()` | DSP.md | NOT STARTED | -- | Not implemented |
-| `Soul.fromMarkdown()` | DSP.md | DONE | `soul.py` | `from_markdown()` classmethod |
-| `Soul.migrate()` | DSP.md | PARTIAL | `soul.py` | `export()` creates .soul file; no `migrate()` method per se |
-| Age calculation | DSP.md | PARTIAL | -- | `born` field exists; no `age`/`ageInDays` properties |
-
-### 2.7 Eternal Storage
-
-| Feature | Vision Doc | Status | Files | Notes |
-|---------|-----------|--------|-------|-------|
-| Local .soul file | ETERNAL | DONE | `export/pack.py`, `storage/file.py` | Zip archive format |
-| IPFS archiving | ETERNAL | NOT STARTED | -- | No IPFS integration |
-| IPFS pinning services | ETERNAL | NOT STARTED | -- | No Pinata/web3.storage |
-| Arweave archiving | ETERNAL | NOT STARTED | -- | No Arweave integration |
-| Blockchain birth registration | ETERNAL | NOT STARTED | -- | No smart contract |
-| Soul recovery from external | ETERNAL | NOT STARTED | -- | Only local recovery |
-| Manifest with eternal links | ETERNAL | NOT STARTED | -- | SoulManifest exists but has no eternal storage fields |
-| Encryption at rest | ETERNAL | DONE | `crypto/encrypt.py` | Fernet + PBKDF2, but not wired into save/export by default |
-| `soul archive` CLI | ETERNAL | NOT STARTED | -- | No archive command |
-| `soul recover` CLI | ETERNAL | NOT STARTED | -- | No recovery command |
-| Soul discovery (on-chain) | ETERNAL | NOT STARTED | -- | No on-chain queries |
-
-### 2.8 CLI Commands
-
-| Feature | Vision Doc | Status | Files | Notes |
-|---------|-----------|--------|-------|-------|
-| `soul birth` | DSP.md, IMPL-SPEC | DONE | `cli/main.py` | With OCEAN flags, --config, --from-file |
-| `soul init` | -- | DONE | `cli/main.py` | Creates .soul/ project folder (beyond vision) |
-| `soul inspect` | IMPL-SPEC | DONE | `cli/main.py` | Rich TUI with OCEAN bars, memory, self-model |
-| `soul status` | DSP.md, IMPL-SPEC | DONE | `cli/main.py` | Quick view with progress bars |
-| `soul export` | IMPL-SPEC | DONE | `cli/main.py` | soul, json, yaml, md formats |
-| `soul migrate` | IMPL-SPEC | DONE | `cli/main.py` | SOUL.md to .soul conversion |
-| `soul retire` | DSP.md | DONE | `cli/main.py` | With confirmation prompt |
-| `soul list` | -- | DONE | `cli/main.py` | Lists saved souls in ~/.soul/ |
-| `soul archive` | DSP.md, ETERNAL | NOT STARTED | -- | Arweave archiving command |
-| `soul recover` | ETERNAL | NOT STARTED | -- | Recovery from external storage |
-
-### 2.9 Parsers
-
-| Feature | Vision Doc | Status | Files | Notes |
-|---------|-----------|--------|-------|-------|
-| soul.md parser | IMPL-SPEC | DONE | `parsers/markdown.py` | YAML frontmatter + section splitting |
-| soul.yaml parser | IMPL-SPEC | DONE | `parsers/yaml_parser.py` | PyYAML + Pydantic validation |
-| soul.json parser | IMPL-SPEC | DONE | `parsers/json_parser.py` | Pydantic model_validate_json |
-| .soul archive parser | IMPL-SPEC | DONE | `export/unpack.py` | Zip extraction with memory tiers |
-| Parser auto-detection | IMPL-SPEC | DONE | `soul.py` (`awaken`) | Routes by file extension |
-
-### 2.10 Integration Adapters
-
-| Feature | Vision Doc | Status | Files | Notes |
-|---------|-----------|--------|-------|-------|
-| LangChain adapter | IMPL-SPEC | NOT STARTED | -- | Vision has langchain.ts |
-| Vercel AI SDK adapter | IMPL-SPEC | NOT STARTED | -- | Vision has vercel-ai.ts |
-| Raw LLM adapter | IMPL-SPEC | NOT STARTED | -- | Vision has raw.ts |
-| `toSystemPrompt()` | DSP.md | DONE | `soul.py`, `dna/prompt.py` | Core integration point |
-| `observe()` hook | DSP.md | DONE | `soul.py` | Psychology-informed pipeline |
-| `context_for()` | -- | DONE | `soul.py` | Per-turn context block (beyond vision) |
-
-### 2.11 Skills / XP System
-
-| Feature | Vision Doc | Status | Files | Notes |
-|---------|-----------|--------|-------|-------|
-| Skills manifest | DSP.md | NOT STARTED | -- | No skills module |
-| XP progression | DSP.md, IMPL-SPEC | NOT STARTED | -- | No XP tracking |
-| Skill levels | DSP.md | NOT STARTED | -- | No leveling system |
-| Skill config | IMPL-SPEC | NOT STARTED | -- | Vision describes per-skill config |
-
-### 2.12 Encryption / Security
-
-| Feature | Vision Doc | Status | Files | Notes |
-|---------|-----------|--------|-------|-------|
-| AES-256 encryption | ETERNAL | PARTIAL | `crypto/encrypt.py` | Uses Fernet (AES-128-CBC), not AES-256-GCM as spec'd |
-| PBKDF2 key derivation | ETERNAL | DONE | `crypto/encrypt.py` | 480,000 iterations |
-| Passphrase-based encryption | ETERNAL | DONE | `crypto/encrypt.py` | Salt prepended to ciphertext |
-| Encrypted .soul export | ETERNAL | NOT STARTED | -- | encrypt/decrypt functions exist but not wired into pack/unpack |
-| Key management | IMPL-SPEC | NOT STARTED | -- | Vision has identity/keys.ts; not implemented |
-| Hardware wallet support | ETERNAL | NOT STARTED | -- | Future vision item |
-
-### 2.13 JSON Schema
-
-| Feature | Vision Doc | Status | Files | Notes |
-|---------|-----------|--------|-------|-------|
-| Published JSON Schema | IMPL-SPEC | NOT STARTED | `schemas/` dir exists | No actual schema file generated |
-| `$schema` reference in soul.json | IMPL-SPEC | NOT STARTED | -- | Vision references soul-protocol.org/schema/v1.json |
+| Aspect | State |
+|---|---|
+| Spec version | **0.4.0** (`docs/SPEC.md`) |
+| Reference runtime | **0.5.0.dev0** (`pyproject.toml`, on `dev`; tagged release pending) |
+| Last shipped release | 0.4.0 — 2026-04-29 ("identity bundle") |
+| Standard vs runtime split | Headless standard since 0.3.3; spec lives in `soul_protocol.spec.*` |
+| Conformance suite | Planned (`tests/conformance/`, target 0.4.x) — not shipped yet |
+| Module layout | `spec/` (contract) · `runtime/` (reference impl) · `engine/` (org journal) · `cli/` · `mcp/` · `optimize/` · `eval/` |
 
 ---
 
-## 3. Architecture Comparison
+## 2 · What is now shipped
 
-### 3.1 Vision Package Structure (from DSP-IMPLEMENTATION-SPEC.md)
+Capabilities that the March 2026 gap analysis listed as missing or partial but have since landed. Each row carries the release that introduced it so a downstream reader can pin a minimum version.
 
-```
-packages/soul-protocol/
-  src/
-    index.ts
-    soul.ts
-    types/
-      identity.ts, dna.ts, memory.ts, state.ts, evolution.ts
-    parsers/
-      markdown.ts, yaml.ts, json.ts, archive.ts
-    identity/
-      did.ts, keys.ts, bond.ts
-    dna/
-      personality.ts, communication.ts, biorhythms.ts, prompt-generator.ts
-    memory/
-      core.ts, episodic.ts, semantic.ts, procedural.ts, graph.ts,
-      recall.ts, consolidate.ts
-    state/
-      mood.ts, energy.ts, focus.ts
-    evolution/
-      mutations.ts, approval.ts, history.ts
-    storage/
-      interface.ts, local.ts, indexeddb.ts, file.ts, memory.ts
-    export/
-      pack.ts, unpack.ts
-    crypto/
-      encrypt.ts, decrypt.ts, keys.ts
-    utils/
-      embeddings.ts, similarity.ts, validators.ts
-  cli/
-    commands/
-      birth.ts, inspect.ts, migrate.ts, export.ts, status.ts, retire.ts
-  adapters/
-    langchain.ts, vercel-ai.ts, raw.ts
-  schemas/
-    v1.json
-```
+### 2.1 · Identity, multi-user, and access control
 
-### 3.2 Actual Implementation Structure
+| Capability | Since | Notes |
+|---|---|---|
+| Multi-user souls (`user_id` on `MemoryEntry`, `Soul.observe`, `Soul.recall`) | 0.4.0 (#46) | One soul, multiple humans, per-user context isolation. Filters include `None` entries for legacy back-compat. |
+| Open-string memory layers + `domain` namespacing | 0.4.0 (#41) | `LAYER_CORE`/`EPISODIC`/`SEMANTIC`/`PROCEDURAL`/`SOCIAL` as built-in constants, plus arbitrary user-defined layers. `domain` defaults to `"default"`. |
+| `social` layer + `SocialStore` | 0.4.0 (#41) | Relationship memory tier for per-user bond / preference / trust signal storage. |
+| `DomainIsolationMiddleware` + `DomainAccessError` | 0.4.0 (#41) | Allow-list enforcement on cross-domain reads and writes. |
+| Per-user bond strength + `BondTarget` list | 0.2.5 → 0.4.0 | `Identity.bonds: list[BondTarget]` replaces the deprecated `bonded_to` string; auto-migration on load. |
+| System prompt safety guardrails (`Soul.to_system_prompt`) | 0.3.3 (#185) | Default safety section declines requests for core memory, bond details, evolution history. Opt out for transparent deployments. |
+| `Soul.public_profile()` | 0.3.3 (#185) | Safe-to-expose subset of identity for registries / agent cards. Excludes memory contents and bond details. |
+| `MemoryVisibility` tier (`PUBLIC`/`BONDED`/`PRIVATE`) | 0.2.5 (#114) | Recall is filtered by requester identity and bond strength. |
 
-```
-src/soul_protocol/
-  __init__.py              # Public API, version
-  soul.py                  # Main Soul class
-  types.py                 # ALL models in single file (not split by domain)
-  exceptions.py            # Custom exception hierarchy
+### 2.2 · Trust chain (signed action history)
 
-  cli/
-    main.py                # Click CLI (all commands in one file)
+| Capability | Since | Notes |
+|---|---|---|
+| Ed25519-signed Merkle-style chain (`TrustEntry`, `TrustChain`) | 0.4.0 (#42) | Spec primitives in `soul_protocol.spec.trust`; verifier helpers `verify_chain`, `verify_entry`, `chain_integrity_check`, `compute_payload_hash`, `compute_entry_hash`. |
+| `Ed25519SignatureProvider` + `Keystore` | 0.4.0 (#42) | Public/private key pair stored under `keys/`. `Soul.export(include_keys=False)` (default) keeps chain verifiable without leaking the signing key. |
+| Auto-append hooks on consequential actions | 0.4.0 (#42) | Memory writes (observe), supersedes, forgets, evolution proposed/applied, learning events, and bond strengthen/weaken all sign automatically. |
+| `soul verify` + `soul audit` CLI + `soul_verify` / `soul_audit` MCP tools | 0.4.0 (#42) | `verify` exits 1 on tampering; `audit` prints a Rich timeline filterable by action prefix. |
+| Timestamp monotonicity in `verify_chain` | 0.5.0.dev0 (#199) | Rejects entries backdated by more than 60s past the previous entry; closes a head-replacement backdating gap. |
+| Strict canonical JSON for hashing | 0.5.0.dev0 (#200) | `_canonical_json` raises `TypeError` on non-JSON-native values rather than `default=str`-coercing; hash determinism across Python versions enforced. |
+| Public-API typing guard on `compute_payload_hash` | 0.5.0.dev0 (#205) | Refuses `BaseModel` inputs at the entry point; prevents dict-vs-model hash drift. |
+| Key rotation allow-list (`Keystore.previous_public_keys`) | 0.5.0.dev0 (#204) | `verify_chain` accepts the current key OR any allow-listed prior key; default empty list preserves 0.4.0 strict behaviour. `keys/previous.keys` persists alongside the active pair. |
+| Non-cryptographic `TrustEntry.summary` | 0.5.0.dev0 (#201) | Short human-readable description per entry, excluded from canonical bytes so it's editable without breaking verification. `soul audit` renders a Summary column. |
+| Structured chain-append-failure logging | 0.5.0.dev0 (#202) | `runtime.chain_append_skipped` + `runtime.bond_callback_failed` at WARNING; routine read-only skips stay at DEBUG. |
+| Touch-time chain pruning | 0.5.0.dev0 (#203) | `Biorhythms.trust_chain_max_entries` (default 0 = unbounded); positive values compress old entries into a signed `chain.pruned` marker. New `soul prune-chain` CLI + `soul_prune_chain` MCP tool. Full archival design deferred to 0.5.x. |
 
-  cognitive/               # ** NOT IN VISION **
-    engine.py              # CognitiveEngine protocol + HeuristicEngine
-    prompts.py             # LLM prompt templates
+### 2.3 · Memory primitives and update verbs
 
-  crypto/
-    encrypt.py             # Fernet + PBKDF2 (encrypt + decrypt combined)
+| Capability | Since | Notes |
+|---|---|---|
+| Vector / embedding search | 0.2.5 → present | `runtime/embeddings/` ships `HashEmbedder`, `TFIDFEmbedder`, `SentenceTransformerProvider`, `OpenAIEmbeddingProvider`, `OllamaEmbeddingProvider`, `VectorSearchStrategy`. `get_embedding_provider()` factory with lazy imports. |
+| Real cognitive engine adapters | 0.2.5 → present | `AnthropicEngine`, `OpenAIEngine`, `OllamaEngine`, `LiteLLMEngine`, `CallableEngine`, `MCPSamplingEngine` under `runtime/cognitive/adapters/`. |
+| Dream cycle (offline batch consolidation) | 0.3.0 | `Soul.dream()` + `soul dream` CLI. Topic clusters, recurring procedures, behavioural trends, graph consolidation, cross-tier synthesis. Pure heuristic, no LLM required. |
+| Smart recall (LLM rerank with prompt-injection defence) | 0.3.0 | `Soul.smart_recall()`. Hardened with content sanitisation, `BEGIN/END MEMORIES` fence, 30s timeout, clean fallback to heuristic order. |
+| Significance short-circuit | 0.3.0 | `observe()` skips entity extraction + self-model update on low-significance interactions when fact extraction also returns nothing. |
+| Archival tier + auto-consolidation | 0.2.9 | `MemoryManager.archive_old_memories()` compresses episodic > 48h into `ConversationArchive`. `observe()` auto-triggers every `consolidation_interval` interactions. |
+| Progressive recall (L0 abstract overflow) | 0.2.9 | `recall(progressive=True)` returns primary entries + abstract overflow. |
+| Supersede with two-way provenance | 0.4.0 (#193) → 0.5.0.dev0 (#192) | `Soul.supersede(old_id, new_content)` sets `old.superseded_by = new.id` AND `new.supersedes = old.id`. `Soul.last_recall_provenance` walks back to the oldest known version. |
+| `Soul.confirm`, `Soul.update`, `Soul.forget`, `Soul.purge`, `Soul.reinstate` | 0.5.0.dev0 (#192) | Prediction-error gated, one-hour reconsolidation window. `confirm` refreshes activation (PE ~0); `update` patches in place (PE 0.2-0.85, recall-within-window); `supersede` ≥0.85; `forget` shifts to weight-decay (0.05, below recall floor); `purge` is the GDPR hard-delete with `.soul.bak`; `reinstate` restores weight to 1.0. Out-of-band PE raises `PredictionErrorOutOfBandError`; out-of-window `update` raises `ReconsolidationWindowClosedError`. |
+| Dedup-aware writes (`Soul.note`) | 0.5.0.dev0 (#231) | Runs new content through `reconcile_fact()` (Jaccard + containment) before storing. Returns `{action: "CREATE"\|"SKIP"\|"MERGE", id, existing_id, similarity}`. Episodic memories bypass dedup (events are unique by time). Per-domain isolation. New `soul note` CLI. |
+| `MemoryEntry` additive fields | 0.5.0.dev0 (#192) | `retrieval_weight: float = 1.0`, `supersedes: str \| None = None`, `prediction_error: float \| None = None`. Pydantic backfills on awaken — pre-0.5 souls round-trip without migration code. |
+| `MemoryManager.recall(min_weight=0.1)` + `Soul.recall(include_superseded=True)` | 0.5.0.dev0 (#192) | Filter by retrieval weight; opt-in surfacing of superseded back-edges. |
 
-  dna/
-    prompt.py              # dna_to_system_prompt + dna_to_markdown
+### 2.4 · Graph traversal and typed entity ontology
 
-  evolution/
-    manager.py             # Single file (vision has 3 files)
+| Capability | Since | Notes |
+|---|---|---|
+| `Soul.graph` view with `nodes/edges/neighbors/path/subgraph/to_mermaid/reachable/stats` | 0.5.0.dev0 (#108, #190) | In-memory dict + adjacency-list backing; `to_dict`/`from_dict` round-trip; pre-0.5.0 graphs load cleanly. |
+| Eight built-in entity kinds | 0.5.0.dev0 (#190) | `person`, `place`, `org`, `concept`, `tool`, `document`, `event`, `relation` — plus open-string extension. |
+| Eight built-in relation predicates | 0.5.0.dev0 (#190) | `mentions`, `related`, `depends_on`, `contributes_to`, `causes`, `follows`, `supersedes`, `owned_by` — plus open-string. |
+| `Soul.recall(graph_walk={...})` with pagination + budget | 0.5.0.dev0 (#190) | `{"start": entity_id, "depth": 2, "edge_types": [...]}`; `page_token` + `token_budget`; new `RecallResults` carries `next_page_token`, `total_estimate`, `truncated_for_budget`. Legacy callers still get `list[MemoryEntry]`. |
+| Trust-chain hooks for graph mutations | 0.5.0.dev0 (#190) | `observe()` appends `graph.entity_added` and `graph.relation_added` for net-new entities/edges. |
+| `soul graph` CLI group | 0.5.0.dev0 (#190) | `nodes`/`edges`/`neighbors`/`path`/`mermaid`, all with `--json`. Plus `soul_graph_query` MCP tool. |
 
-  export/
-    pack.py                # .soul zip creation
-    unpack.py              # .soul zip extraction
+### 2.5 · Evaluation, optimization, and diff tooling
 
-  identity/
-    did.py                 # DID generation only (no keys.ts, no bond.ts)
+| Capability | Since | Notes |
+|---|---|---|
+| Soul-aware evals (YAML + runner) | 0.5.0.dev0 (#160) | `soul_protocol.eval` ships `runner.py`, `schema.py`, `scoring.py`. Five scoring kinds: `keyword`, `regex`, `semantic` (Jaccard + containment), `judge` (LLM-as-judge), `structural`. `respond` vs `recall` modes; deterministic fallback without an engine. New `soul eval` CLI + `soul_eval` MCP tool. Five example specs under `tests/eval_examples/`. Full doc at `docs/eval-format.md`. |
+| Autonomous self-improvement (`soul optimize`) | 0.5.0.dev0 (#142) | `soul_protocol.optimize.OptimizeRunner`, `optimize()` entry point, `Knob` protocol + four built-in knobs (`OceanTraitKnob`, `PersonaTextKnob`, `SignificanceThresholdKnob`, `BondThresholdKnob`), `Proposer` (LLM + heuristic fallback), `OptimizeResult`/`OptimizeStep` models. Defaults to dry-run; `--apply` keeps wins and writes one `soul.optimize.applied` trust-chain entry per kept change. New `soul optimize` CLI + `soul_optimize` MCP tool. Full doc at `docs/soul-optimize.md`. |
+| Structured `soul diff` | 0.5.0.dev0 (#191) | Soul-level (not byte-level) comparison across identity, OCEAN/DNA, state, core memory, memories per layer + per domain, bond, skills, trust chain, self-model, evolution. Formats: text (Rich), `--format json` (`SoulDiff` Pydantic dump), `--format markdown`. New public API: `soul_protocol.runtime.diff_souls`, `SoulDiff`, `SchemaMismatchError`. |
 
-  mcp/                     # ** NOT IN VISION **
-    server.py              # FastMCP server (10 tools, 3 resources, 2 prompts)
+### 2.6 · Journal + decision traces
 
-  memory/
-    core.py                # CoreMemoryManager
-    episodic.py            # EpisodicStore
-    semantic.py            # SemanticStore
-    procedural.py          # ProceduralStore
-    graph.py               # KnowledgeGraph
-    manager.py             # MemoryManager facade (1037 lines)
-    recall.py              # RecallEngine with ACT-R scoring
-    search.py              # Token overlap scoring + tokenizer
-    activation.py          # ** NOT IN VISION ** ACT-R activation
-    attention.py           # ** NOT IN VISION ** Significance gating
-    self_model.py          # ** NOT IN VISION ** Klein's self-concept
-    sentiment.py           # ** NOT IN VISION ** Somatic markers
-    strategy.py            # ** NOT IN VISION ** Pluggable SearchStrategy
+| Capability | Since | Notes |
+|---|---|---|
+| Append-only org journal (SQLite WAL) | 0.3.1 (#172) | Atomic `seq` allocation, opportunistic hash chain for tamper evidence. `EventEntry`, `Actor`, `DataRef` in `soul_protocol.spec.journal`. |
+| `Journal.query(action_prefix=...)` + `Journal.append` returns committed entry | 0.3.3 (#179) | The five spec primitives that any conforming impl must provide. |
+| Decision traces (`agent.proposed`, `human.corrected`, `decision.graduated`) | 0.3.1 (#168) | Causation chains, cluster recurring patterns. |
+| `decision.outcome_attached` journal action | post-0.4.0 (#255) | Attach observed outcomes to a prior decision. |
+| `soul journal init/append/query` shell-hook CLI | 0.5.0.dev0 (#189) | Wraps the org journal for non-Python runtimes and CI scripts. JSONL stdin batching; committed entries echoed to stdout for downstream causation. `--at <iso>` for point-in-time replay. |
+| `RetrievalTrace` receipt on every recall | 0.3.1 (#161) | `Soul.last_retrieval` exposes query, candidate set, rerank decisions, final selection. |
+| `MemoryEntry.scope` + `match_scope` bidirectional matcher | 0.3.1 (#162) + fix (#175) | DSP scope grammar (`org:sales:*`, `agent:<id>`, `session:<id>`). |
 
-  parsers/
-    markdown.py            # soul.md parser
-    yaml_parser.py         # soul.yaml parser
-    json_parser.py         # soul.json parser
+### 2.7 · CLI / MCP surface
 
-  state/
-    manager.py             # Single file (vision has 3 files)
+| Capability | Since | Notes |
+|---|---|---|
+| CLI commands (current count: ~50) | running total | `birth`, `awaken`, `inspect`, `status`, `list`, `delete`, `init`, `export`, `unpack`, `migrate`, `retire`, `remember`, `note`, `recall`, `layers`, `observe`, `reflect`, `dream`, `feel`, `prompt`, `forget`, `supersede`, `confirm`, `update`, `purge`, `reinstate`, `upgrade`, `edit-core`, `evolve`, `evaluate`, `learn`, `skills`, `bond`, `events`, `context`, `health`, `cleanup`, `repair`, `verify`, `audit`, `prune-chain`, `inject`, `eternal-status`, `template list/show/create`, `org init/status/destroy`, `import-soulspec`, `export-soulspec`, `import-tavernai`, `export-tavernai`, `export-a2a`, `import-a2a`, plus subcommand groups for `journal`, `diff`, `eval`, `optimize`, `graph`. |
+| MCP server | 0.2.3 → 0.5.0.dev0 | FastMCP-based, 28+ tools (per `docs/mcp-server.md`), 2 prompts. Added in 0.5.0.dev0: `soul_eval` (#160), `soul_optimize` (#142), `soul_prune_chain` (#203); 0.5.0.dev0 memory primitives: `soul_confirm`, `soul_update`, `soul_supersede`, `soul_purge`, `soul_reinstate`. |
+| Inject targets for IDE integration | 0.3.x | `soul inject --target {claude-code, cursor, vscode, windsurf, cline, continue}`. Marker-based idempotent replacement. |
+| Format importers / exporters | 0.2.5 | SoulSpec (SOUL.md / soul.json), TavernAI Character Card V2 (JSON + PNG tEXt chunks, no Pillow), Google A2A Agent Cards (`soul export-a2a` / `soul import-a2a`). |
+| Bundled role archetype templates | 0.3.1 (#163) | Arrow, Flash, Cyborg, Analyst. `load_template()` + `soul template` CLI. |
+| Safety net: dry-run by default on `soul forget` and `soul cleanup` | 0.3.3 (#181) | `.soul.bak` written before destructive saves. `--apply` required to execute. Closes #148. |
 
-  storage/
-    file.py                # FileStorage + save/load convenience functions
-    protocol.py            # Storage protocol definition
-    memory_store.py        # In-memory storage (testing)
-```
+### 2.8 · Documentation surface
 
-### 3.3 Key Structural Differences
-
-| Aspect | Vision | Actual | Assessment |
-|--------|--------|--------|------------|
-| Language | TypeScript/npm | Python/pip | Deliberate pivot |
-| Types organization | 5 separate files | 1 monolithic `types.py` | Works at current scale |
-| CLI structure | 6 command files | 1 `main.py` with Click | Simpler, works fine |
-| State management | 3 files (mood, energy, focus) | 1 `manager.py` | Appropriate consolidation |
-| Evolution | 3 files (mutations, approval, history) | 1 `manager.py` | Appropriate consolidation |
-| Identity | 3 files (did, keys, bond) | 1 `did.py` | Missing: keys, bond |
-| Memory modules | 7 files | 14 files | Implementation is richer |
-| Adapters | 3 adapter files | 0 adapters | Major gap |
-| Cognitive layer | Not in vision | 3 files | Beyond vision |
-| MCP server | Not in vision | 1 file (444 lines) | Beyond vision |
-| Storage backends | 4 backends | 3 backends | Missing: IndexedDB (browser) |
+| Doc | Status |
+|---|---|
+| `docs/SPEC.md` | Authoritative language-agnostic contract. Versioned at 0.4.0. |
+| `docs/architecture.md` | Reference implementation internals. |
+| `docs/api-reference.md` | Public Python API. 1,302 lines. |
+| `docs/cli-reference.md` | CLI command reference. 1,450 lines. |
+| `docs/memory-architecture.md` | Memory subsystem deep dive. Updated for 0.5.0.dev0 update primitives. |
+| `docs/trust-chain.md` | Threat model, key management, sharing souls safely. Touch-time pruning section added in 0.5.0.dev0. |
+| `docs/eval-format.md` | YAML eval spec + runner walkthrough. New in 0.5.0.dev0. |
+| `docs/soul-optimize.md` | Autoresearch loop, knob catalog, dry-run semantics. New in 0.5.0.dev0. |
+| `docs/rfc-memory-update-primitives.md` | Cog-sci grounding for the 0.5.0.dev0 memory verbs (Nader/LeDoux on reconsolidation, Sevenster/Beckers/Kindt on PE, Bjork/Wimber on forgetting). |
+| `docs/org-journal-spec.md` | Framework-agnostic journal wire format. |
+| `docs/mcp-server.md` | MCP setup, tool catalog, sampling engine. |
+| `docs/wiki/` | 328 auto-generated articles (rebuilt in 0.4.0 via #186). |
 
 ---
 
-## 4. What's Beyond Vision (Built but Not in Docs)
+## 3 · What is still missing
 
-These features exist in the implementation but were not described in any of the four vision documents.
+Honest gaps, verified against `src/soul_protocol/` and the CHANGELOG. Each row distinguishes "real gap" from "intentionally application-layer."
 
-### 4.1 Psychology-Informed Memory (v0.2.0)
+### 3.1 · Real gaps (likely candidates for issues)
 
-The memory system implements concepts from cognitive science papers:
+| Gap | Status | Notes |
+|---|---|---|
+| Real IPFS / Arweave / blockchain providers | Mock only | `runtime/eternal/providers/` ships `local.py` plus `mock_ipfs.py`, `mock_arweave.py`, `mock_blockchain.py`. The `EternalStorageProvider` protocol is real and stable; no provider talks to a live network. `soul archive` flow exists but resolves to mock CIDs / TXIDs. |
+| Cross-soul federation / handoff protocol | Spec draft only | Multi-soul coordination is described in the DSP v0.5.0 draft (Tuckman lifecycle, transitive trust decay, reputation scoring, handoff). No runtime implementation yet. |
+| Vector DB backends (Chroma, Pinecone, Qdrant, Weaviate) | Not implemented | `EmbeddingProvider` + `VectorSearchStrategy` exist and are stable. No store-side adapter ships — all vector search runs over in-memory tier files. |
+| Persistent graph backends (Neo4j, JanusGraph) | Not implemented | `Soul.graph` is in-memory dict + adjacency list. Production-scale graphs would need an external store. |
+| Conformance test suite (`tests/conformance/`) | Planned (0.4.x), not shipped | Without it, third-party impls can't self-certify "0.4.0 compliant" mechanically. |
+| Streaming wire protocol for real-time soul sync | Not addressed | No spec section, no runtime. Souls move as `.soul` archives only. |
+| Mobile / browser runtime | Not in scope of this repo | The Python reference impl is server-side / CLI / MCP. No JS/TS port, no IndexedDB backend, no React Native wrapper. A separate repo would carry this. |
+| Hardware wallet / HSM key custody | Not implemented | `Keystore` reads / writes Ed25519 keys from local files. No PKCS#11 / WebAuthn / Ledger / Trezor integration. |
+| Encrypted-at-rest `.soul` export by default | Functions exist, not wired | `runtime/crypto/encrypt.py` ships Fernet + PBKDF2; `Soul.export()` does not encrypt by default. Passphrase-encrypted export remains opt-in. |
+| `soul rotate-keys` CLI | Not shipped | Allow-list infrastructure landed in #204; the rotation command itself is intentionally not in 0.5.0.dev0. Callers can rotate manually by editing `Keystore.previous_public_keys`. |
+| Full trust-chain archive (`trust_chain/archive/` with checkpoints) | Deferred to 0.5.x | The 0.5.0.dev0 touch-time pruning (#203) is the stub. The full archival design with checkpoint entries is tracked but not implemented. |
+| Streak tracking on `SoulState` | Not implemented | Vision originally described `streak: <int>` for consecutive interaction days. Not in `types.py`. |
+| Mobile-format identity carriers (QR-encoded `.soul` summary, NFC export) | Not addressed | No spec, no runtime. |
+| Multi-language reference impls (Rust / Go / TS) | Not in this repo | The spec is now language-agnostic (0.3.3+) and a third-party can target it. None ship from us. |
 
-| Feature | Theory Source | Implementation |
-|---------|-------------|----------------|
-| Somatic markers | Damasio's Somatic Marker Hypothesis | `memory/sentiment.py` - valence/arousal/label on every memory |
-| Significance gating | LIDA architecture | `memory/attention.py` - novelty + emotional_intensity + goal_relevance |
-| ACT-R activation decay | Anderson's ACT-R | `memory/activation.py` - power-law decay over access timestamps |
-| Spreading activation | ACT-R spreading | `memory/activation.py` - query relevance as associative strength |
-| Emotional boost | Flashbulb memory effect | `memory/activation.py` - high-arousal memories recalled more easily |
+### 3.2 · Partial / shaped but not finished
 
-**Files:** `memory/sentiment.py` (295 lines), `memory/attention.py` (105 lines), `memory/activation.py` (172 lines)
-
-### 4.2 Cognitive Engine / Heuristic Engine (v0.2.1)
-
-A dual-mode processing architecture:
-
-- **`CognitiveEngine`** protocol: single `async think(prompt: str) -> str` method that consumers implement with any LLM
-- **`HeuristicEngine`**: zero-dependency fallback that routes task-tagged prompts to heuristic functions
-- **`CognitiveProcessor`**: internal orchestrator that delegates sentiment, significance, fact extraction, entity extraction, self-reflection, and consolidation to either engine
-
-**File:** `cognitive/engine.py` (480 lines)
-
-### 4.3 Self-Model Emergence (v0.2.0, enhanced v0.3.0)
-
-Based on Klein's self-concept theory, the soul builds a model of who it is from observation:
-
-- **Emergent domain discovery**: domains are not hardcoded but discovered from interaction content
-- **Seed domains**: 6 bootstrap domains (technical_helper, creative_writer, etc.) that can be replaced
-- **Dynamic keyword expansion**: domain vocabularies grow as the soul encounters related content
-- **Confidence curves**: diminishing returns formula approaching 0.95 as evidence accumulates
-- **Self-model in system prompt**: top 3 self-images injected into LLM context
-
-**File:** `memory/self_model.py` (547 lines)
-
-### 4.4 Pluggable Search Strategy (v0.2.2)
-
-The `SearchStrategy` protocol allows consumers to replace token-overlap search with embeddings, vector DB queries, or any custom scoring:
-
-```python
-class SearchStrategy(Protocol):
-    def score(self, query: str, content: str) -> float: ...
-```
-
-**File:** `memory/strategy.py` (42 lines)
-
-### 4.5 MCP Server (v0.3.2)
-
-A FastMCP server exposing the soul as an MCP service:
-
-- **10 tools**: soul_birth, soul_observe, soul_remember, soul_recall, soul_reflect, soul_state, soul_feel, soul_prompt, soul_save, soul_export
-- **3 resources**: soul://identity, soul://memory/core, soul://state
-- **2 prompts**: soul_system_prompt, soul_introduction
-- Single-client design with lifespan-based startup from `SOUL_PATH` env var
-
-**File:** `mcp/server.py` (444 lines)
-
-### 4.6 Two-Layer Architecture
-
-The codebase separates "engine-level" processing (requires LLM or heuristic) from "core-level" data models and storage. This manifests as:
-
-- **Core layer**: `types.py`, `identity/`, `memory/core.py`, `memory/episodic.py`, `memory/semantic.py`, `memory/procedural.py`, `memory/graph.py`, `export/`, `storage/` -- pure data, no intelligence
-- **Engine layer**: `cognitive/`, `memory/activation.py`, `memory/attention.py`, `memory/self_model.py`, `memory/sentiment.py`, `memory/strategy.py` -- intelligence and processing
-
-### 4.7 Context-for-Turn API (v0.3.0)
-
-`soul.context_for(user_input)` generates a per-turn context block with live state and relevant memories, designed for agentic systems that compress or truncate conversation history.
-
-### 4.8 General Events (Conway Hierarchy, v0.2.2)
-
-Episodes cluster into GeneralEvent themes following Conway's Self-Memory System. Created during reflection/consolidation, linking episodic memories to higher-level narrative themes.
-
-### 4.9 Fact Conflict Resolution (v0.2.2)
-
-When a new fact contradicts an existing one (same template prefix, different value), the old fact is marked `superseded_by` rather than deleted, preserving history.
-
-### 4.10 Custom Exception Hierarchy (v0.3.2)
-
-```
-SoulProtocolError
-  SoulFileNotFoundError
-  SoulCorruptError
-  SoulExportError
-  SoulRetireError
-```
-
-### 4.11 Sentiment-Driven Mood with EMA Inertia
-
-Mood changes are driven by detected sentiment but smoothed via exponential moving average (alpha=0.4). A single mild message cannot flip the mood -- accumulated signal is required.
+| Item | Current state | What's left |
+|---|---|---|
+| Memory compression / SimpleMem-style recursive consolidation | Dream cycle handles topic clustering + dedup; archival tier compresses old episodic. | Recursive multi-level summarisation (summary-of-summaries) not implemented. |
+| Working memory tier | Vision concept — runtime treats this as the caller's session buffer. | No `WorkingMemoryStore` exists. Probably stays the caller's responsibility. |
+| Automatic evolution triggers | `evolution/manager.py` runs supervised/autonomous approval flows; `check_triggers()` still a placeholder. | Threshold-based auto-proposals from accumulated `EvaluationHistory` are not wired. The signal exists (#160 evals, #142 optimize); a direct evolution loop on top is the next step. |
+| Skills decay + XP | `Skill.decay()` shipped 0.2.9; significance-weighted XP grants shipped 0.2.9. | Per-skill config (level-up gates, decay curves per skill) is hard-coded; not yet driven by a per-skill manifest. |
 
 ---
 
-## 5. Priority Roadmap
+## 4 · What is deferred (intentional)
 
-### P0: Critical for Launch
+These are not gaps — they're explicit "application-layer, not part of the standard" decisions documented in `docs/SPEC.md` or the relevant CHANGELOG entry.
 
-These items are required before soul-protocol can be considered "v1.0":
-
-| Item | Effort | Depends On |
-|------|--------|------------|
-| **Encrypted .soul export** -- wire crypto into pack/unpack | S | crypto/encrypt.py exists |
-| **Skills/XP system** -- basic skill tracking and levels | M | New module |
-| **Birth certificate** -- bornAt, birthplace, witnesses, genesisHash | S | types.py change |
-| **Bond model** -- bondStrength, bondedAt, bond evolution | S | types.py change |
-| **JSON Schema** -- generate from Pydantic models, publish | S | schemas/ dir exists |
-| **Lifecycle completeness** -- ESSENCE, REINCARNATED states | M | types.py + soul.py |
-| **`soul.age` / `soul.age_in_days`** -- computed properties | S | soul.py |
-| **Automatic evolution triggers** -- replace check_triggers no-op | M | evolution/manager.py |
-
-### P1: Important Differentiators
-
-These items would significantly strengthen the protocol's value proposition:
-
-| Item | Effort | Depends On |
-|------|--------|------------|
-| **Embedding-based recall** -- implement a SearchStrategy with sentence-transformers or OpenAI | M | memory/strategy.py exists |
-| **Memory consolidation pipeline** -- scheduled summarization + pruning | L | memory/manager.py |
-| **Memory compression** -- SimpleMem-style recursive consolidation | L | New module |
-| **Archival memory tier** -- conversation transcript storage with summaries | M | New store |
-| **Integration adapters** -- at least one reference adapter (e.g., for litellm or any-llm) | M | New module |
-| **Streak tracking** -- consecutive interaction day counting | S | state/manager.py |
-| **Working memory interface** -- session context buffer tracking | M | New module |
-
-### P2: Nice to Have
-
-| Item | Effort | Depends On |
-|------|--------|------------|
-| **IPFS archiving** -- web3.storage or Pinata integration | L | New module, optional dep |
-| **Temporal knowledge graph** -- time-aware relationships (Graphiti-style) | L | memory/graph.py |
-| **Dynamic preferences in dna.md** -- template variable injection | S | dna/prompt.py |
-| **Multi-format CLI export** -- `soul export --format` already exists but could expand | S | cli/main.py |
-| **soul archive CLI** -- archive to IPFS/Arweave | M | P2 deps |
-| **soul recover CLI** -- recovery from external storage | M | P2 deps |
-
-### P3: Future Vision
-
-| Item | Effort | Depends On |
-|------|--------|------------|
-| **Arweave permanent storage** -- pay-once archiving | L | arweave SDK |
-| **On-chain birth registration** -- Base L2 smart contract | XL | Solidity, ethers |
-| **Multi-device sync** -- cloud-based soul synchronization | XL | Backend infra |
-| **Soul transfer mechanism** -- ownership transfer | L | Blockchain |
-| **Hardware wallet support** -- HSM key storage | M | Crypto infra |
-| **IndexedDB backend** -- browser storage (only relevant if JS SDK exists) | M | JS port |
-| **Neo4j backend** -- production graph database | M | neo4j driver |
-| **Vector DB backends** -- Chroma, Pinecone, Qdrant | M per backend | embedding pipeline |
+| Item | Why it's deferred |
+|---|---|
+| Concrete `RetrievalRouter` orchestration | Removed from `soul_protocol.engine.retrieval` in 0.3.3 (#179). Now in pocketpaw at `pocketpaw.retrieval`. Spec only defines the `SourceAdapter` / `CredentialBroker` / `RetrievalRequest` / `RetrievalCandidate` vocabulary; orchestration belongs to the consuming runtime. |
+| `InMemoryCredentialBroker`, `ProjectionAdapter`, `MockAdapter` | Same move — application-layer / test helpers, not part of the standard. |
+| SaaS-specific source adapters (Drive, Slack, Salesforce, etc.) | Adapters are the consuming runtime's job. The spec defines the Protocol; pocketpaw ships the concrete adapters today, third-party runtimes would ship their own. |
+| LangChain / Vercel AI / "framework adapter" integrations | Soul Protocol is consumer-agnostic by design. Anything LangChain-specific lives downstream of the `CognitiveEngine` protocol and the `.soul` file. |
+| Reconsolidation-window persistence | The one-hour window in `Soul.update()` is in-memory only, capped at 1000 LRU entries. Modelled after cellular destabilisation; persisting it would distort the cog-sci grounding. |
 
 ---
 
-## 6. Metrics
+## 5 · Track-by-track summary
 
-### 6.1 Codebase Size
+A reader trying to map remaining work to milestones can read this as a roadmap snapshot.
 
-| Metric | Count |
-|--------|-------|
-| Python source files | 46 |
-| Source lines of code | 7,086 |
-| Test files | 34 |
-| Test lines of code | 7,216 |
-| Test functions | 453 |
-| Source-to-test ratio | 1:1.02 (excellent) |
-
-### 6.2 Module Size Breakdown
-
-| Module | Files | Lines | Notes |
-|--------|-------|-------|-------|
-| memory/ | 14 | 2,860 | Largest module -- core of the protocol |
-| cognitive/ | 3 | 590 | Engine + prompts |
-| cli/ | 2 | 488 | Rich TUI inspect/status |
-| mcp/ | 2 | 448 | FastMCP server |
-| state/ | 2 | 186 | Manager + init |
-| storage/ | 4 | 341 | File + protocol + memory |
-| evolution/ | 2 | 200 | Manager + init |
-| dna/ | 2 | 161 | Prompt generation |
-| export/ | 3 | 162 | Pack + unpack |
-| parsers/ | 4 | 217 | md, yaml, json |
-| identity/ | 2 | 36 | DID generation only |
-| crypto/ | 2 | 92 | Encrypt/decrypt |
-| types.py | 1 | 313 | All Pydantic models |
-| soul.py | 1 | 681 | Main Soul class |
-| exceptions.py | 1 | 45 | Error hierarchy |
-
-### 6.3 Vision Doc vs Implementation
-
-| Metric | Vision Docs | Implementation |
-|--------|-------------|----------------|
-| Total lines | 3,764 (5 docs) | 7,086 (source) + 7,216 (tests) = 14,302 |
-| Language | TypeScript | Python |
-| Package manager | npm | pip/uv |
-| Format spec coverage | 4/4 (md, yaml, json, .soul) | 4/4 |
-| Memory tiers coverage | 3/5 (core, recall, graph; missing working + archival) | 3/5 |
-| Storage tier coverage | 1/4 (local only) | 1/4 |
-| CLI command coverage | 5/8 (birth, inspect, status, export, migrate, retire; missing archive, recover, list) | 7/8 (adds init, list; missing archive, recover) |
-
-### 6.4 Test Coverage Areas
-
-| Area | Test Files | Test Count | Coverage Quality |
-|------|-----------|------------|------------------|
-| Memory system | 8 files | ~180 | Deep -- ACT-R, sentiment, self-model, strategy |
-| Models/types | 3 files | ~40 | Validation, serialization, enums |
-| Soul class | 1 file (in test_models/) | ~30 | Birth, observe, remember, recall, save |
-| CLI | 2 files | ~35 | All commands tested |
-| Cognitive | 2 files | ~50 | Both engine modes, all tasks |
-| Evolution | 1 file | ~25 | All modes, immutability, apply |
-| State | 2 files | ~30 | EMA, mood mapping, rest |
-| Storage | 2 files | ~20 | File persistence, atomic writes |
-| MCP | 2 files | ~30 | All tools, resources, prompts |
-| Export | included in storage | ~13 | Pack/unpack round-trip |
+| Track | Where it is | Next likely step |
+|---|---|---|
+| **Identity & access control** | Largely complete after 0.4.0. Multi-user, layers + domains, signed history all shipped. | Cross-soul federation (DSP v0.5.0 draft → runtime). |
+| **Memory** | Strongest area. Vector + heuristic + graph + dream + evals + optimize all shipped. | Recursive summarisation; persistent graph + vector backends. |
+| **Trust chain** | Verifiable, prunable, observable. | Full archival design (deferred 0.5.x); `soul rotate-keys` CLI; HSM custody. |
+| **Evals + optimize** | New in 0.5.0.dev0. Foundation for evolution-driven self-improvement. | Wire `OptimizeRunner` results into automatic evolution triggers. |
+| **Eternal storage** | Protocol stable; only mock providers ship. | Real IPFS provider; real Arweave provider; spec for content-addressed soul recovery. |
+| **Standard maturity** | Headless standard since 0.3.3; SPEC.md tracks 0.4.0. | Conformance test suite (`tests/conformance/`); first non-Python reference impl. |
+| **Distribution** | Python wheel + sdist on PyPI; MCP server for Claude Desktop / Cursor / etc. | Mobile / browser runtime out of scope here; would be a separate repo. |
 
 ---
 
-*Document generated from codebase analysis on 2026-03-06.*
+## 6 · How this doc stays honest
+
+- Refresh on each major release (next: when 0.5.0 tags). Section 2 grows; Section 3 shrinks or migrates rows into Section 2 with a `since` value.
+- Anything claimed as "shipped" must point at a CHANGELOG row or a file in `src/soul_protocol/`.
+- Anything claimed as "missing" must have been verified by reading the current code, not by reading an old version of this doc.
+- Previous editions of this file live in git history (`git log -- docs/GAP-ANALYSIS.md`). The March 2026 version with the original 0.2.2 vision-baseline scoring is at commit `eaaeebd` ± neighbouring commits.


### PR DESCRIPTION
## Summary

Both `docs/GAP-ANALYSIS.md` and `docs/COMPARISON.md` were March 2026 vintage and scored against the 0.2.2 baseline. Most of what they listed as missing has since shipped — the 0.3.x spec/runtime split, the 0.4.0 identity bundle (multi-user souls, open-string layers + domain isolation, trust chain), and the 0.5.0.dev0 wave (memory update primitives, soul-aware evals, autonomous optimize, graph traversal + typed ontology, dedup-aware writes, trust-chain hardening). The docs needed a rewrite to match.

### GAP-ANALYSIS.md

Restructured around what a reader actually wants to know today.

- Status header pins the doc to 0.5.0.dev0 and SPEC 0.4.0.
- Section 2 lists shipped capabilities with a `since` column. Identity / access control, trust chain (with all the 0.5.0.dev0 hardening — timestamp monotonicity, strict canonical JSON, key rotation allow-list, payload summaries, structured logging, touch-time pruning), memory primitives (`confirm` / `update` / `supersede` / `forget` / `purge` / `reinstate`, `note()`), graph traversal + typed ontology, evals / optimize / diff, journal + decision traces, CLI / MCP surface, doc surface.
- Section 3 names real gaps verified against current code: mock-only IPFS / Arweave / blockchain providers, no vector DB store adapters, no persistent graph backends, conformance suite still pending, no streaming wire protocol, no mobile / browser runtime, no HSM custody, no `soul rotate-keys` CLI yet, full trust-chain archive deferred to 0.5.x.
- Section 4 separates intentional deferrals (orchestration moved out to pocketpaw in 0.3.3; framework adapters explicitly out-of-scope).
- Track-by-track summary maps each lane to its next likely step.

### COMPARISON.md

Refreshed the head-to-head against Mem0, MemGPT / Letta, LangChain Memory, Cognee, OpenAI Memory.

- Status header pins the doc to 0.5.0.dev0; notes competitor claims reflect each project's latest stable release.
- Feature matrix gains rows for trust chain, multi-user attribution, domain isolation, memory update verbs, dedup-aware writes, typed graph ontology, soul-aware evals, autonomous optimization, structured diff, journal + decision traces, MCP server.
- Per-competitor sections refreshed: what soul-protocol adds since 0.4/0.5, and — honestly — what each competitor still does better. Mem0 keeps the mature vector store ecosystem and managed cloud. Letta owns context-window paging. LangChain wins on framework breadth. Cognee wins on persistent graph DB backends. OpenAI Memory wins on zero-config.
- Benchmark snapshot preserved but flagged as predating the 0.5 surface — re-run planned when 0.5.0 tags.

## Test plan

- [ ] Section 2 of GAP-ANALYSIS verified row-by-row against `CHANGELOG.md` `[Unreleased]` + `[0.4.0]` and `src/soul_protocol/{spec,runtime,cli,eval,optimize}/`.
- [ ] Section 3 gaps verified by reading current code (`runtime/eternal/providers/`, `runtime/embeddings/`, `runtime/memory/graph.py`, `runtime/trust/manager.py`, `runtime/crypto/keystore.py`) rather than copied from old doc.
- [ ] COMPARISON matrix rows for trust chain, layers + domains, evals, optimize, graph traversal, dedup writes cross-checked against the CHANGELOG PR numbers (#42, #41, #160, #142, #190, #231).
- [ ] Competitor "wins" rows stay honest (Mem0 vector ecosystem, Letta paging, LangChain breadth, Cognee graph DB, OpenAI zero-config).
- [ ] Previous versions of both docs remain in git history for the curious reader.

## Notes

- Targeting `dev` because the new content describes 0.5.0.dev0 features that only exist on `dev` (main is still at 0.4.0). Doc will land on `main` with the next release cut.