### PR TITLE
fix(memory): episodic remember/note stores content verbatim

### DIFF
--- a/src/soul_protocol/runtime/memory/episodic.py
+++ b/src/soul_protocol/runtime/memory/episodic.py
@@ -1,4 +1,8 @@
 # memory/episodic.py — EpisodicStore for timestamped interaction memories.
+# Updated: 2026-05-29 — Added add_entry() to store a pre-built MemoryEntry
+#   VERBATIM (fixes #234 + sibling importance-drop bug). The Interaction-based
+#   add()/add_with_psychology() builders that wrap content in the
+#   "User: ...\nAgent: ..." envelope are left untouched — observe relies on them.
 # Updated: 2026-03-29 — Filter archived entries from search() results (F2).
 # Updated: 2026-03-13 — Added update_entry() public method for updating fields
 #   on stored entries (replaces direct _memories dict access from manager.py).
@@ -108,6 +112,37 @@ class EpisodicStore:
 
         self._memories[memory_id] = entry
         return memory_id
+
+    async def add_entry(self, entry: MemoryEntry) -> str:
+        """Store a pre-built :class:`MemoryEntry` VERBATIM.
+
+        Unlike :meth:`add` and :meth:`add_with_psychology` — which build a
+        ``"User: ...\\nAgent: ..."`` envelope from an :class:`Interaction` and
+        hardcode importance — this stores the entry exactly as the caller
+        constructed it. Used by the blunt ``Soul.remember(type=EPISODIC)`` /
+        ``Soul.note(...)`` path so content, importance, emotion, entities,
+        somatic, significance, visibility, scope, domain, and user_id all
+        survive the write (fixes #234 and the sibling importance-drop bug).
+
+        Generates an id when ``entry.id`` is empty, forces
+        ``type = MemoryType.EPISODIC``, seeds ``access_timestamps`` from
+        ``created_at`` when empty, and runs the same capacity/eviction logic
+        as :meth:`add`.
+
+        Returns the stored memory ID.
+        """
+        entry.type = MemoryType.EPISODIC
+        if not entry.id:
+            entry.id = uuid.uuid4().hex[:12]
+        if not entry.access_timestamps:
+            entry.access_timestamps = [entry.created_at]
+
+        # Evict if at capacity (mirrors add()).
+        if len(self._memories) >= self._max_entries:
+            self._evict_least_significant()
+
+        self._memories[entry.id] = entry
+        return entry.id
 
     def update_entry(self, memory_id: str, **kwargs) -> bool:
         """Update fields on an existing episodic entry.

--- a/src/soul_protocol/runtime/memory/manager.py
+++ b/src/soul_protocol/runtime/memory/manager.py
@@ -1,4 +1,10 @@
 # memory/manager.py — MemoryManager facade orchestrating all memory subsystems.
+# Updated: 2026-05-29 — add() now routes episodic entries through
+#   EpisodicStore.add_entry() (stores the MemoryEntry verbatim) instead of
+#   rebuilding an Interaction. Fixes #234 (content no longer wrapped in a
+#   "User: ...\nAgent: " envelope) and the sibling bug that reset importance
+#   to 5 and dropped emotion/entities/visibility/scope/user_id. observe() and
+#   add_episodic() still use the envelope-building add()/add_with_psychology().
 # Updated: 2026-04-29 (#192) — Brain-aligned memory update primitives.
 #   recall() now filters out entries with retrieval_weight < min_weight
 #   (default 0.1). Callers can opt-in to the older "see everything"
@@ -915,17 +921,11 @@ class MemoryManager:
         if entry.ingested_at is None:
             entry.ingested_at = datetime.now()
         if entry.type == MemoryType.EPISODIC:
-            interaction = Interaction(
-                user_input=entry.content,
-                agent_output="",
-                timestamp=entry.created_at,
-            )
-            new_id = await self._episodic.add(interaction)
-            # Episodic store creates its own MemoryEntry — propagate domain.
-            stored = await self._episodic.get(new_id)
-            if stored is not None and entry.domain:
-                stored.domain = entry.domain
-            return new_id
+            # Store the pre-built entry verbatim — content, importance, emotion,
+            # entities, visibility, scope, domain, and user_id all survive.
+            # (#234 + sibling fix; was rebuilding an Interaction that wrapped
+            # content in a "User: ...\nAgent: " envelope and reset importance.)
+            return await self._episodic.add_entry(entry)
         elif entry.type == MemoryType.SEMANTIC:
             return await self._semantic.add(entry)
         elif entry.type == MemoryType.PROCEDURAL:

--- a/tests/test_memory/test_episodic_verbatim.py
+++ b/tests/test_memory/test_episodic_verbatim.py
@@ -1,0 +1,145 @@
+# test_episodic_verbatim.py — Regression tests for issue #234 and its sibling.
+# Created: 2026-05-29 — Asserts that episodic writes via Soul.remember/Soul.note
+#   store content VERBATIM (no "User: ...\nAgent: " envelope), preserve the
+#   caller's importance (not hardcoded to 5), and keep emotion/entities/user_id.
+#   Includes regression guards proving semantic stays verbatim and that the
+#   observe pipeline STILL produces the intentional "User: ...\nAgent: ..."
+#   envelope from a real user/agent interaction.
+
+from __future__ import annotations
+
+import pytest
+
+from soul_protocol.runtime.memory.manager import MemoryManager
+from soul_protocol.runtime.soul import Soul
+from soul_protocol.runtime.types import (
+    CoreMemory,
+    Interaction,
+    MemorySettings,
+    MemoryType,
+)
+
+
+@pytest.fixture
+async def soul() -> Soul:
+    """A freshly birthed soul for exercising the public memory API."""
+    return await Soul.birth("Aria", archetype="The Compassionate Creator")
+
+
+def _episodic_entries(soul: Soul) -> list:
+    """Return all stored episodic MemoryEntry objects from the soul."""
+    return soul._memory._episodic.entries()
+
+
+# ---------------------------------------------------------------------------
+# Bug #234 — episodic remember must store content VERBATIM (no envelope)
+# ---------------------------------------------------------------------------
+
+
+async def test_episodic_remember_stores_content_verbatim(soul: Soul):
+    """An episodic remember stores the input string exactly, with no
+    "User: " prefix and no trailing "\\nAgent: " suffix (#234)."""
+    text = "Shipped the verbatim-episodic fix today"
+    mem_id = await soul.remember(text, type=MemoryType.EPISODIC, importance=8)
+
+    entry = await soul._memory._episodic.get(mem_id)
+    assert entry is not None
+    assert entry.content == text
+    assert "User: " not in entry.content
+    assert "\nAgent: " not in entry.content
+
+
+async def test_episodic_remember_preserves_importance(soul: Soul):
+    """An episodic remember with importance=8 stores importance == 8,
+    not the hardcoded 5 from EpisodicStore.add() (sibling bug)."""
+    mem_id = await soul.remember("A high-importance event", type=MemoryType.EPISODIC, importance=8)
+
+    entry = await soul._memory._episodic.get(mem_id)
+    assert entry is not None
+    assert entry.importance == 8
+
+
+async def test_episodic_remember_preserves_emotion_entities_user_id(soul: Soul):
+    """An episodic remember preserves emotion, entities, and user_id —
+    all silently dropped by the Interaction round-trip today."""
+    mem_id = await soul.remember(
+        "Met Alice at the conference",
+        type=MemoryType.EPISODIC,
+        importance=7,
+        emotion="joy",
+        entities=["Alice", "conference"],
+        user_id="user-42",
+    )
+
+    entry = await soul._memory._episodic.get(mem_id)
+    assert entry is not None
+    assert entry.emotion == "joy"
+    assert entry.entities == ["Alice", "conference"]
+    assert entry.user_id == "user-42"
+
+
+async def test_episodic_note_stores_content_verbatim(soul: Soul):
+    """Soul.note() for episodic shares the remember() path, so it must
+    also store content verbatim with no envelope and the right importance."""
+    text = "Logged a unique timestamped event"
+    result = await soul.note(text, type=MemoryType.EPISODIC, importance=9)
+    mem_id = result["id"]
+
+    entry = await soul._memory._episodic.get(mem_id)
+    assert entry is not None
+    assert entry.content == text
+    assert "User: " not in entry.content
+    assert "\nAgent: " not in entry.content
+    assert entry.importance == 9
+
+
+# ---------------------------------------------------------------------------
+# Regression guards — must stay green before AND after the fix
+# ---------------------------------------------------------------------------
+
+
+async def test_semantic_remember_stays_verbatim(soul: Soul):
+    """Semantic remember already stores verbatim — guard against the fix
+    accidentally regressing the non-episodic branches."""
+    text = "User prefers Python over JavaScript"
+    mem_id = await soul.remember(text, type=MemoryType.SEMANTIC, importance=8)
+
+    entry = await soul._memory._semantic.get(mem_id)
+    assert entry is not None
+    assert entry.content == text
+    assert entry.importance == 8
+
+
+async def test_observe_still_builds_user_agent_envelope():
+    """observe() intentionally wraps a real user/agent pair into the
+    "User: ...\\nAgent: ..." envelope. The fix must NOT break this — only
+    the blunt episodic remember() path should change.
+
+    This drives the episodic store directly through add_with_psychology
+    (the path observe uses) to assert the envelope is produced, with no
+    LLM calls involved.
+    """
+    mgr = MemoryManager(core=CoreMemory(), settings=MemorySettings())
+    interaction = Interaction(
+        user_input="What is the weather?",
+        agent_output="It's sunny today!",
+    )
+    mem_id = await mgr._episodic.add_with_psychology(interaction)
+
+    entry = await mgr._episodic.get(mem_id)
+    assert entry is not None
+    assert entry.content == "User: What is the weather?\nAgent: It's sunny today!"
+    assert entry.content.startswith("User: ")
+    assert "\nAgent: " in entry.content
+
+
+async def test_episodic_store_add_interaction_keeps_envelope():
+    """EpisodicStore.add(interaction) is the legacy envelope builder used by
+    add_episodic/observe. It must remain unchanged by the fix."""
+    mgr = MemoryManager(core=CoreMemory(), settings=MemorySettings())
+    mem_id = await mgr.add_episodic(
+        Interaction(user_input="I need coffee", agent_output="Let me help!")
+    )
+    entry = await mgr._episodic.get(mem_id)
+    assert entry is not None
+    assert entry.content == "User: I need coffee\nAgent: Let me help!"


### PR DESCRIPTION
Fixes #234.

## The bug

Episodic writes through `Soul.remember(type=EPISODIC)` and `Soul.note(...)` came out corrupted in two ways that share one root cause:

1. Content was wrapped in a `User: <text>\nAgent: ` envelope (the #234 report).
2. The caller's `importance` was discarded and saved as 5.

`Soul.remember` builds a clean `MemoryEntry` (verbatim content, the importance you passed, plus emotion/entities/visibility/scope/user_id) and hands it to `MemoryManager.add()`. The episodic branch there rebuilt an `Interaction` from the entry and called `EpisodicStore.add()`, which formats `"User: ...\nAgent: ..."` and hardcodes `importance=5`. Only `domain` was copied back, so emotion, entities, visibility, scope, and user_id were silently dropped too. Semantic, procedural, and social writes store the entry directly, which is why only episodic was affected.

## The fix

- New `EpisodicStore.add_entry(entry)` stores a pre-built `MemoryEntry` as-is: generates an id when blank, seeds `access_timestamps`, runs the same eviction logic, and keeps every field the caller set.
- `MemoryManager.add()` routes episodic entries through `add_entry()` instead of round-tripping an `Interaction`.
- `EpisodicStore.add()` and `add_with_psychology()` are untouched, so `observe()` still builds the `User: ...\nAgent: ...` envelope from a real user/agent pair. That behavior is covered by a regression test.

## Tests

`tests/test_memory/test_episodic_verbatim.py` (7 tests). Verified RED before the fix: the verbatim-content, importance, field-preservation, and note tests fail against the old code with the exact `User:`/`Agent:` envelope and importance=5. All 7 pass after the fix. The wider `episodic/observe/note/remember/manager` suite stays green (197 passed).

## Follow-up

The paw-workspace `session-prime.sh` hook added a regex strip to work around this. That workaround can be removed once this lands.