### PR TITLE
Ignore local lfd/ working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ research/results/
 # Internal docs (not for public repo)
 idocs/
 .claude/worktrees/
+lfd/


### PR DESCRIPTION
The `lfd/` directory holds local-only working files that shouldn't be in version control. An earlier local change tried to ignore it but used the wrong name (`lfdt/`), so the directory was still tracked.

This adds the correct `.gitignore` entry. No code changes.