### PR TITLE
feat(memory): agent-created procedural provenance + curator

### DIFF
--- a/src/soul_protocol/runtime/memory/manager.py
+++ b/src/soul_protocol/runtime/memory/manager.py
@@ -1,4 +1,11 @@
 # memory/manager.py — MemoryManager facade orchestrating all memory subsystems.
+# Updated: 2026-06-16 (feat/soul-skills-procedural) — adds
+#   consolidate_agent_procedures(): a curator pass over PROCEDURAL memories that
+#   only ever considers AGENT-authored entries (provenance == AGENT). It finds
+#   overlapping agent procedures via the same Jaccard/containment scoring used by
+#   reconcile_fact and marks the weaker of each near-duplicate pair as
+#   superseded (soft, never a hard delete). HUMAN-authored procedures are never
+#   inspected or modified. Returns a small report dict.
 # Updated: 2026-05-29 — add() now routes episodic entries through
 #   EpisodicStore.add_entry() (stores the MemoryEntry verbatim) instead of
 #   rebuilding an Interaction. Fixes #234 (content no longer wrapped in a
@@ -127,7 +134,7 @@ from soul_protocol.runtime.memory.attention import (
 )
 from soul_protocol.runtime.memory.contradiction import ContradictionDetector
 from soul_protocol.runtime.memory.core import CoreMemoryManager
-from soul_protocol.runtime.memory.dedup import reconcile_fact
+from soul_protocol.runtime.memory.dedup import _jaccard_similarity, reconcile_fact
 from soul_protocol.runtime.memory.episodic import EpisodicStore
 from soul_protocol.runtime.memory.graph import KnowledgeGraph
 from soul_protocol.runtime.memory.procedural import ProceduralStore
@@ -141,6 +148,7 @@ from soul_protocol.runtime.types import (
     GeneralEvent,
     Interaction,
     MemoryEntry,
+    MemoryProvenance,
     MemorySettings,
     MemoryType,
     Personality,
@@ -1390,6 +1398,92 @@ class MemoryManager:
             archive.id,
         )
         return archive
+
+    async def consolidate_agent_procedures(self, *, similarity_threshold: float = 0.6) -> dict:
+        """Curator pass: consolidate overlapping AGENT-authored procedures.
+
+        Walks the PROCEDURAL store, considering ONLY entries whose
+        ``provenance`` is :attr:`MemoryProvenance.AGENT` and that are not
+        already superseded. For each near-duplicate pair (similarity above
+        ``similarity_threshold``, the same band ``reconcile_fact`` calls
+        MERGE/SKIP), the weaker entry is marked ``superseded=True`` and its
+        ``superseded_by`` back-edge is pointed at the survivor. "Weaker" is the
+        lower-importance entry, breaking ties toward the older one so the most
+        recent agent learning survives.
+
+        This is a SOFT consolidation: superseded entries stay in the store
+        (recall already filters them), so nothing is ever hard-deleted.
+        HUMAN-authored procedures are never inspected or touched — this is the
+        guard that keeps the self-improving loop from rewriting human knowledge.
+
+        Interim-window caveat: PocketPaw's skills loop only sends the native
+        ``provenance=AGENT`` kwarg once its soul-protocol dependency is bumped to
+        this release. Before that bump, procedures it writes land with the
+        default ``provenance=HUMAN`` (it tags them on the ``entities`` list
+        instead). Those interim procedures therefore ESCAPE this curator until
+        the dep lands — a one-time re-tag pass (entities-tag → provenance=AGENT)
+        may be desired after the bump to sweep them in.
+
+        Args:
+            similarity_threshold: Minimum Jaccard/containment similarity for
+                two procedures to count as overlapping. Defaults to 0.6, the
+                lower bound of ``reconcile_fact``'s MERGE band.
+
+        Returns:
+            ``{"considered": int, "consolidated": int, "superseded_ids": list[str]}``
+            where ``considered`` counts the live agent procedures inspected and
+            ``consolidated`` counts the entries newly marked superseded.
+        """
+        # NOTE: ``entries()`` hands back LIVE MemoryEntry references from the
+        # store, not copies. The in-place ``superseded`` / ``superseded_by``
+        # writes below are INTENTIONAL — they mutate the stored entries directly
+        # (the same soft-supersede contract supersede() uses). Do not "fix" this
+        # into a copy-then-mutate; that would silently drop the consolidation.
+        agent_entries = [
+            e
+            for e in self._procedural.entries()
+            if e.provenance == MemoryProvenance.AGENT and not e.superseded
+        ]
+
+        superseded_ids: list[str] = []
+        # Survivors we've already kept — used so a single survivor can absorb
+        # several near-duplicates without itself being demoted.
+        for i, entry in enumerate(agent_entries):
+            if entry.superseded:
+                continue
+            for other in agent_entries[i + 1 :]:
+                if other.superseded:
+                    continue
+                sim = _jaccard_similarity(entry.content, other.content)
+                if sim < similarity_threshold:
+                    continue
+                # Pick the survivor: higher importance wins; tie → keep the
+                # newer entry (later created_at) as the canonical learning.
+                if (other.importance, other.created_at) >= (
+                    entry.importance,
+                    entry.created_at,
+                ):
+                    loser, survivor = entry, other
+                else:
+                    loser, survivor = other, entry
+                loser.superseded = True
+                loser.superseded_by = survivor.id
+                superseded_ids.append(loser.id)
+                if loser is entry:
+                    # The outer entry got superseded — stop pairing it further.
+                    break
+
+        if superseded_ids:
+            logger.info(
+                "consolidate_agent_procedures: superseded %d agent procedures",
+                len(superseded_ids),
+            )
+
+        return {
+            "considered": len(agent_entries),
+            "consolidated": len(superseded_ids),
+            "superseded_ids": superseded_ids,
+        }
 
     # ---- GDPR-compliant deletion (v0.3.0) ----
 

--- a/src/soul_protocol/runtime/skills.py
+++ b/src/soul_protocol/runtime/skills.py
@@ -4,6 +4,11 @@
 # Updated: 2026-03-22 — Added grant_xp_from_learning().
 # Updated: 2026-03-29 — Added Skill.decay() and SkillRegistry.decay_all() for
 #   significance-weighted XP and time-based XP decay (F3: Skills XP).
+# Updated: 2026-06-16 (feat/soul-skills-procedural) — Added
+#   grant_xp_for_procedure_use(): grants XP to the skill tracking a learned
+#   procedure each time that procedure is used, auto-creating the skill on
+#   first use. Returns True when the grant crosses a level boundary (the
+#   graduation signal PocketPaw's skills loop uses to materialize a SKILL.md).
 
 from __future__ import annotations
 
@@ -76,6 +81,28 @@ class SkillRegistry(BaseModel):
                 if skill.xp < before:
                     decayed += 1
         return decayed
+
+    def grant_xp_for_procedure_use(self, skill_id: str, amount: int = 10) -> bool:
+        """Grant XP to the skill that tracks a learned procedure's usage.
+
+        Called by the self-improving skills loop whenever an agent-learned
+        procedure is used. Auto-creates the skill (named after ``skill_id``)
+        on first use so callers never have to pre-register it.
+
+        Args:
+            skill_id: Stable id tying a procedure to its progression skill —
+                e.g. ``"proc:<memory_id>"``.
+            amount: XP to grant per use (default 10).
+
+        Returns:
+            True if the grant crossed a level boundary — the graduation signal
+            the loop uses to materialize a SKILL.md.
+        """
+        skill = self.get(skill_id)
+        if not skill:
+            skill = Skill(id=skill_id, name=skill_id)
+            self.add(skill)
+        return skill.add_xp(amount)
 
     def grant_xp_from_learning(self, event: LearningEvent) -> bool:
         """Grant XP to a skill based on a LearningEvent."""

--- a/src/soul_protocol/runtime/soul.py
+++ b/src/soul_protocol/runtime/soul.py
@@ -1,4 +1,11 @@
 # soul.py — The main Soul class: birth, awaken, observe, dream, save, export
+# Updated: 2026-06-16 (feat/soul-skills-procedural) — remember() and note() now
+#   accept a ``provenance: MemoryProvenance`` kwarg (default HUMAN) so an
+#   autonomous loop (PocketPaw's self-improving skills reviewer) can stamp the
+#   procedures it learns as AGENT-authored. Adds Soul.curate_agent_procedures():
+#   a curator pass that consolidates overlapping AGENT-created procedures
+#   (marking the weaker one superseded) and never touches HUMAN procedures or
+#   hard-deletes anything. Delegates to MemoryManager.consolidate_agent_procedures().
 # Updated: 2026-05-05 (#231) — Adds Soul.note() — a fact-shaped writer that
 #   routes through reconcile_fact() (Jaccard + containment dedup) before
 #   storing. Mirrors remember() but applies SKIP/MERGE/CREATE so callers
@@ -225,6 +232,7 @@ from .types import (
     Interaction,
     LifecycleState,
     MemoryEntry,
+    MemoryProvenance,
     MemoryType,
     MemoryVisibility,
     Mutation,
@@ -1400,6 +1408,7 @@ class Soul:
         scope: list[str] | None = None,
         domain: str = "default",
         user_id: str | None = None,
+        provenance: MemoryProvenance = MemoryProvenance.HUMAN,
     ) -> str:
         """Soul remembers something. Returns memory ID.
 
@@ -1426,6 +1435,7 @@ class Soul:
                 scope=scope or [],
                 domain=domain,
                 user_id=user_id,
+                provenance=provenance,
             )
         )
 
@@ -1443,6 +1453,7 @@ class Soul:
         user_id: str | None = None,
         dedup: bool = True,
         detect_contradictions: bool | None = None,
+        provenance: MemoryProvenance = MemoryProvenance.HUMAN,
     ) -> dict:
         """Note a fact, routing through the dedup pipeline before storing.
 
@@ -1479,6 +1490,10 @@ class Soul:
             detect_contradictions: When True, run contradiction detection
                 on stored facts (currently a TODO — see #231).
                 Defaults to True for semantic, False otherwise.
+            provenance: Authorship tag (default HUMAN). Pass
+                ``MemoryProvenance.AGENT`` when an autonomous loop is writing
+                the fact so the curator can consolidate it without touching
+                human-authored memories.
 
         Returns:
             ``{"action": str, "id": str | None, "existing_id": str | None,
@@ -1509,6 +1524,7 @@ class Soul:
                 scope=scope,
                 domain=domain,
                 user_id=user_id,
+                provenance=provenance,
             )
             return {
                 "action": "CREATE",
@@ -1537,6 +1553,7 @@ class Soul:
                 scope=scope,
                 domain=domain,
                 user_id=user_id,
+                provenance=provenance,
             )
             return {
                 "action": "CREATE",
@@ -1578,6 +1595,7 @@ class Soul:
                 scope=scope,
                 domain=domain,
                 user_id=user_id,
+                provenance=provenance,
             )
             similarity = None
             if target_id is not None:
@@ -1604,6 +1622,7 @@ class Soul:
             scope=scope,
             domain=domain,
             user_id=user_id,
+            provenance=provenance,
         )
         return {
             "action": "CREATE",
@@ -1611,6 +1630,27 @@ class Soul:
             "existing_id": None,
             "similarity": None,
         }
+
+    async def curate_agent_procedures(self, *, similarity_threshold: float = 0.6) -> dict:
+        """Curate AGENT-authored procedural memories.
+
+        Idle/scheduled pass for the self-improving skills loop: consolidates
+        overlapping procedures that an autonomous reviewer wrote (provenance
+        AGENT), marking the weaker of each near-duplicate pair superseded. It
+        never inspects or modifies HUMAN-authored procedures and never
+        hard-deletes — superseded entries stay in the store and simply stop
+        surfacing in recall.
+
+        Args:
+            similarity_threshold: Overlap floor for two agent procedures to be
+                treated as near-duplicates. Defaults to 0.6.
+
+        Returns:
+            ``{"considered": int, "consolidated": int, "superseded_ids": list[str]}``.
+        """
+        return await self._memory.consolidate_agent_procedures(
+            similarity_threshold=similarity_threshold
+        )
 
     async def recall(
         self,

--- a/src/soul_protocol/runtime/types.py
+++ b/src/soul_protocol/runtime/types.py
@@ -310,6 +310,21 @@ class MemoryVisibility(StrEnum):
     PRIVATE = "private"
 
 
+class MemoryProvenance(StrEnum):
+    """Who authored a memory entry.
+
+    Distinguishes human-authored memories from those written autonomously
+    by an agent (e.g. PocketPaw's self-improving skills loop, where a forked
+    write-only reviewer learns a procedure from a session transcript). The
+    curator only ever consolidates / archives ``AGENT`` entries — human-authored
+    procedures are never touched. Defaults to ``HUMAN`` so pre-provenance souls
+    round-trip without migration.
+    """
+
+    HUMAN = "human"
+    AGENT = "agent"
+
+
 class MemoryType(StrEnum):
     """Built-in memory tiers. v0.4.0 (#41) treats these as ergonomic
     constants for layer names — runtimes can use any string layer they
@@ -431,6 +446,13 @@ class MemoryEntry(BaseModel):
     # prior trace to predict against. Captured in the trust chain payload too,
     # so verifiers can re-derive how confident the runtime was in the change.
     prediction_error: float | None = Field(default=None, ge=0.0, le=1.0)
+    # feat/soul-skills-procedural — authorship tag. HUMAN for every memory the
+    # human or the standard observe/remember path writes; AGENT for memories an
+    # autonomous loop authors (PocketPaw's self-improving skills reviewer). The
+    # procedural curator only consolidates / archives AGENT entries; it never
+    # touches HUMAN-authored procedures and never hard-deletes. Defaults to
+    # HUMAN so pre-provenance souls round-trip with no migration.
+    provenance: MemoryProvenance = MemoryProvenance.HUMAN
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/test_agent_provenance.py
+++ b/tests/test_agent_provenance.py
@@ -1,0 +1,137 @@
+# test_agent_provenance.py — Agent-created procedural provenance + curator.
+# Created: 2026-06-16 (feat/soul-skills-procedural) — covers the substrate for
+#   PocketPaw's self-improving skills loop: a MemoryProvenance tag distinguishing
+#   agent-authored procedures from human-authored ones, threaded through
+#   Soul.remember / Soul.note, plus a curator that consolidates and archives
+#   AGENT-CREATED procedures only and never hard-deletes.
+
+from __future__ import annotations
+
+import pytest
+
+from soul_protocol import Soul
+from soul_protocol.runtime.skills import Skill, SkillRegistry
+from soul_protocol.runtime.types import MemoryProvenance, MemoryType
+
+
+@pytest.mark.asyncio
+class TestProvenanceTagging:
+    async def test_remember_defaults_to_human_provenance(self):
+        soul = await Soul.birth("TestSoul")
+        mid = await soul.remember("Deploy by running make ship", type=MemoryType.PROCEDURAL)
+        entry = await soul._memory._procedural.get(mid)
+        assert entry.provenance == MemoryProvenance.HUMAN
+
+    async def test_remember_can_tag_agent_provenance(self):
+        soul = await Soul.birth("TestSoul")
+        mid = await soul.remember(
+            "To regenerate C4, run make c4-pp from /docs",
+            type=MemoryType.PROCEDURAL,
+            provenance=MemoryProvenance.AGENT,
+        )
+        entry = await soul._memory._procedural.get(mid)
+        assert entry.provenance == MemoryProvenance.AGENT
+
+    async def test_note_threads_agent_provenance(self):
+        soul = await Soul.birth("TestSoul")
+        result = await soul.note(
+            "When tests hang, check for an unawaited asyncio task",
+            type=MemoryType.PROCEDURAL,
+            provenance=MemoryProvenance.AGENT,
+        )
+        assert result["action"] == "CREATE"
+        entry = await soul._memory._procedural.get(result["id"])
+        assert entry.provenance == MemoryProvenance.AGENT
+
+    async def test_agent_and_human_entries_are_distinguishable(self):
+        soul = await Soul.birth("TestSoul")
+        await soul.remember("Human wrote this one", type=MemoryType.PROCEDURAL)
+        await soul.remember(
+            "Agent learned this one",
+            type=MemoryType.PROCEDURAL,
+            provenance=MemoryProvenance.AGENT,
+        )
+        agent_entries = [
+            e for e in soul._memory._procedural.entries() if e.provenance == MemoryProvenance.AGENT
+        ]
+        human_entries = [
+            e for e in soul._memory._procedural.entries() if e.provenance == MemoryProvenance.HUMAN
+        ]
+        assert len(agent_entries) == 1
+        assert len(human_entries) == 1
+        assert agent_entries[0].content == "Agent learned this one"
+
+
+@pytest.mark.asyncio
+class TestCurator:
+    async def test_consolidate_supersedes_overlapping_agent_procedures(self):
+        soul = await Soul.birth("TestSoul")
+        # Two near-duplicate agent procedures (dedup is bypassed by remember()).
+        await soul.remember(
+            "To run the e2e suite use uv run pytest tests e2e directory",
+            type=MemoryType.PROCEDURAL,
+            provenance=MemoryProvenance.AGENT,
+        )
+        await soul.remember(
+            "To run the e2e suite use uv run pytest tests e2e directory always",
+            type=MemoryType.PROCEDURAL,
+            provenance=MemoryProvenance.AGENT,
+        )
+        report = await soul.curate_agent_procedures()
+        # One of the overlapping pair is superseded (never hard-deleted).
+        assert report["consolidated"] >= 1
+        superseded = [e for e in soul._memory._procedural.entries() if e.superseded]
+        assert len(superseded) >= 1
+        # The superseded entry still exists in the store (no hard delete).
+        assert all(s.id for s in superseded)
+
+    async def test_curator_never_touches_human_procedures(self):
+        soul = await Soul.birth("TestSoul")
+        # Two overlapping HUMAN procedures must be left untouched.
+        h1 = await soul.remember(
+            "To run the e2e suite use uv run pytest tests e2e directory",
+            type=MemoryType.PROCEDURAL,
+        )
+        h2 = await soul.remember(
+            "To run the e2e suite use uv run pytest tests e2e directory always",
+            type=MemoryType.PROCEDURAL,
+        )
+        await soul.curate_agent_procedures()
+        e1 = await soul._memory._procedural.get(h1)
+        e2 = await soul._memory._procedural.get(h2)
+        assert not e1.superseded
+        assert not e2.superseded
+
+    async def test_curator_never_hard_deletes(self):
+        soul = await Soul.birth("TestSoul")
+        ids = []
+        for i in range(3):
+            ids.append(
+                await soul.remember(
+                    f"Agent procedure number {i} for running the deploy pipeline cleanly",
+                    type=MemoryType.PROCEDURAL,
+                    provenance=MemoryProvenance.AGENT,
+                )
+            )
+        count_before = len(soul._memory._procedural.entries())
+        await soul.curate_agent_procedures()
+        count_after = len(soul._memory._procedural.entries())
+        # Curator marks, never removes — store size is unchanged.
+        assert count_after == count_before
+
+
+class TestGraduationXP:
+    def test_grant_xp_for_procedure_use_crosses_threshold(self):
+        registry = SkillRegistry()
+        registry.add(Skill(id="proc:deploy", name="deploy", xp=95, xp_to_next=100))
+        graduated = registry.grant_xp_for_procedure_use("proc:deploy", amount=10)
+        assert graduated is True
+        skill = registry.get("proc:deploy")
+        assert skill.level == 2
+
+    def test_grant_xp_creates_skill_when_absent(self):
+        registry = SkillRegistry()
+        registry.grant_xp_for_procedure_use("proc:newproc", amount=5)
+        skill = registry.get("proc:newproc")
+        assert skill is not None
+        assert skill.xp == 5


### PR DESCRIPTION
First half of the self-improving skills loop — the soul-side substrate. Merge this before the pocketpaw side (pocketpaw bumps its soul-protocol dep to pick this up).

## What

- `MemoryProvenance` (HUMAN default / AGENT) on `MemoryEntry`, threaded through `Soul.remember` and `Soul.note`. Lets us tell agent-written memories apart from human-authored ones — the basis for safely auto-curating only what the agent created.
- `Soul.curate_agent_procedures` → `MemoryManager.consolidate_agent_procedures`: consolidates overlapping AGENT procedures by soft-superseding the weaker one. Never touches human procedures, never hard-deletes.
- `SkillRegistry.grant_xp_for_procedure_use`: the XP hook that lets a proven procedure earn graduation later.

## Why

The skills loop (pocketpaw side, separate PR) writes learned procedures into the workspace agent's soul. For that to be safe, the soul has to (a) mark what the agent wrote and (b) consolidate it without ever disturbing human-authored memory. This adds exactly those two capabilities and nothing more.

## Honest scope note

There's a documented interim window: until pocketpaw bumps its dependency to this version, the pocketpaw writer tags provenance on the entities list (works on the old version) but can't send the native `provenance=` kwarg — so interim procedures carry `provenance=HUMAN` and escape the curator until the bump. A comment at `consolidate_agent_procedures` flags this; a one-time re-tag pass may be worth running after the dep lands. This is why this PR merges first.

## Tests

`uv run --extra dev pytest tests/test_agent_provenance.py -q` → 9 passed. Regression across provenance + auto_consolidation + archival → 32 passed. The new provenance field defaults to HUMAN so existing serialization/export/awaken is unaffected.

Captain reviews; not merging.