### PR TITLE
feat(cli): add `soul did show` and `soul did verify` commands

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -312,6 +312,57 @@ soul export aria.soul --output aria.md --format md
 
 ---
 
+### `soul did show`
+
+Display the DID (Decentralized Identifier) and identity info of a soul. Shows name, DID, public key, algorithm, private key status, key rotation history, and trust chain length.
+
+```bash
+# Show DID identity for a .soul file
+soul did show aria.soul
+
+# Show DID identity for an unpacked soul directory
+soul did show .soul/
+```
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `SOURCE` | Yes | Source soul file (`.soul`) or unpacked directory. |
+
+---
+
+### `soul did verify`
+
+Verify the trust chain and DID integrity of a soul. Checks that:
+- The DID format is valid (`did:soul:...`)
+- A public key is present
+- All trust chain entries have valid Ed25519 signatures and the hash chain is intact
+
+Exits with code 1 if any check fails.
+
+```bash
+# Verify a soul's DID and trust chain
+soul did verify aria.soul
+
+# Verify with detailed chain table
+soul did verify aria.soul --verbose
+```
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `SOURCE` | Yes | Source soul file (`.soul`) or unpacked directory. |
+
+**Options:**
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--verbose` | `-v` | Show a detailed table of trust chain entries with sequence numbers, actions, timestamps, and signatures. |
+
+---
+
 ### `soul migrate`
 
 Migrate from a SOUL.md markdown file to the structured `.soul` archive format. Useful for converting legacy soul definitions.

--- a/src/soul_protocol/cli/did.py
+++ b/src/soul_protocol/cli/did.py
@@ -7,20 +7,17 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from pathlib import Path
+import sys
 
 import click
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
-from rich.text import Text
 
 console = Console()
 
 # Windows-safe symbols (cp1252 doesn't support Unicode checkmarks)
-import sys as _sys
-
-if _sys.platform == "win32":
+if sys.platform == "win32":
     _OK = "[green]OK[/green]"
     _FAIL = "[red]FAIL[/red]"
     _WARN = "[yellow]!![/yellow]"
@@ -28,7 +25,6 @@ else:
     _OK = "[green]\u2713[/green]"
     _FAIL = "[red]\u2717[/red]"
     _WARN = "[yellow]\u26a0[/yellow]"
-
 
 
 @click.group("did")
@@ -67,9 +63,7 @@ def did_show(source):
 
         # Gather identity info
         pub_bytes = soul._keystore.public_key_bytes
-        pub_b64 = (
-            base64.b64encode(pub_bytes).decode("ascii") if pub_bytes else None
-        )
+        pub_b64 = base64.b64encode(pub_bytes).decode("ascii") if pub_bytes else None
         has_private = soul._keystore.has_private_key
         chain_len = len(soul.trust_chain.entries)
         prev_keys = len(soul._keystore.previous_public_keys)
@@ -135,6 +129,8 @@ def did_verify(source, verbose):
     Checks that all trust chain entries have valid Ed25519 signatures,
     the hash chain is intact, and public keys match the keystore.
 
+    Exits with code 1 if any check fails.
+
     \b
     Examples:
       soul did verify aria.soul
@@ -167,11 +163,12 @@ def did_verify(source, verbose):
             console.print(f"  {_WARN} No public key -- cannot verify signatures")
 
         # Step 3: Verify trust chain
+        chain_valid = True
         if chain_len == 0:
             console.print(f"  {_WARN} Trust chain is empty (no signed actions)")
         else:
-            valid, error = soul.verify_chain()
-            if valid:
+            chain_valid, error = soul.verify_chain()
+            if chain_valid:
                 console.print(f"  {_OK} Trust chain valid -- {chain_len} entries verified")
             else:
                 console.print(f"  {_FAIL} Trust chain INVALID -- {error}")
@@ -187,10 +184,15 @@ def did_verify(source, verbose):
 
             for entry in chain.entries:
                 sig_short = f"{entry.signature[:12]}..." if entry.signature else "none"
+                ts_str = (
+                    entry.timestamp.isoformat()
+                    if hasattr(entry.timestamp, "isoformat")
+                    else str(entry.timestamp)
+                )
                 table.add_row(
                     str(entry.seq),
                     entry.action,
-                    entry.ts.isoformat() if hasattr(entry.ts, "isoformat") else str(entry.ts),
+                    ts_str,
                     sig_short,
                 )
 
@@ -198,7 +200,7 @@ def did_verify(source, verbose):
 
         # Final verdict
         console.print()
-        all_ok = did_valid and (chain_len == 0 or (chain_len > 0 and valid))
+        all_ok = did_valid and (chain_len == 0 or chain_valid)
         if all_ok:
             console.print(
                 Panel(
@@ -213,6 +215,7 @@ def did_verify(source, verbose):
                     border_style="red",
                 )
             )
+            sys.exit(1)
 
     asyncio.run(_verify())
 

--- a/src/soul_protocol/cli/did.py
+++ b/src/soul_protocol/cli/did.py
@@ -1,0 +1,220 @@
+# cli/did.py — CLI commands for DID (Decentralized Identifier) management.
+# Created: 2026-06-27 — Phase 1 of the trust/digital-id CLI feature.
+#   Adds `soul did show` and `soul did verify` subcommands for inspecting
+#   and verifying a soul's decentralized identity and trust chain.
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+console = Console()
+
+# Windows-safe symbols (cp1252 doesn't support Unicode checkmarks)
+import sys as _sys
+
+if _sys.platform == "win32":
+    _OK = "[green]OK[/green]"
+    _FAIL = "[red]FAIL[/red]"
+    _WARN = "[yellow]!![/yellow]"
+else:
+    _OK = "[green]\u2713[/green]"
+    _FAIL = "[red]\u2717[/red]"
+    _WARN = "[yellow]\u26a0[/yellow]"
+
+
+
+@click.group("did")
+def did_group():
+    """Manage Decentralized Identifiers (DIDs) for souls.
+
+    Inspect identity, public keys, and verify trust chain integrity.
+
+    \b
+    Examples:
+      soul did show aria.soul
+      soul did show .soul/
+      soul did verify aria.soul
+    """
+    pass
+
+
+@did_group.command("show")
+@click.argument("source", type=click.Path(exists=True))
+def did_show(source):
+    """Display the DID and identity info of a soul.
+
+    Shows the soul's name, DID, public key, archetype, trust chain
+    length, and key rotation status.
+
+    \b
+    Examples:
+      soul did show aria.soul
+      soul did show .soul/
+    """
+
+    async def _show():
+        from soul_protocol.runtime.soul import Soul
+
+        soul = await Soul.awaken(source)
+
+        # Gather identity info
+        pub_bytes = soul._keystore.public_key_bytes
+        pub_b64 = (
+            base64.b64encode(pub_bytes).decode("ascii") if pub_bytes else None
+        )
+        has_private = soul._keystore.has_private_key
+        chain_len = len(soul.trust_chain.entries)
+        prev_keys = len(soul._keystore.previous_public_keys)
+
+        # Build the identity table
+        table = Table(
+            show_header=False,
+            box=None,
+            padding=(0, 2),
+            expand=False,
+        )
+        table.add_column("Field", style="dim")
+        table.add_column("Value")
+
+        table.add_row("Name", f"[bold]{soul.name}[/bold]")
+        table.add_row("DID", f"[cyan]{soul.did}[/cyan]")
+
+        if soul.archetype:
+            table.add_row("Archetype", soul.archetype)
+
+        if soul.born:
+            table.add_row("Born", str(soul.born))
+
+        # Public key (truncated for display)
+        if pub_b64:
+            display_key = f"{pub_b64[:16]}...{pub_b64[-8:]}" if len(pub_b64) > 24 else pub_b64
+            table.add_row("Public Key", f"[green]{display_key}[/green]")
+            table.add_row("Algorithm", "Ed25519")
+        else:
+            table.add_row("Public Key", "[red]none[/red]")
+
+        # Key status
+        if has_private:
+            table.add_row("Private Key", "[green]present[/green] (can sign)")
+        else:
+            table.add_row("Private Key", "[yellow]absent[/yellow] (verify only)")
+
+        # Key rotation
+        if prev_keys > 0:
+            table.add_row("Rotated Keys", f"{prev_keys} previous key(s)")
+
+        # Trust chain
+        table.add_row("Trust Chain", f"{chain_len} entries")
+
+        console.print(
+            Panel(
+                table,
+                title=f"[bold]DID Identity — {soul.name}[/bold]",
+                border_style="cyan",
+                padding=(1, 2),
+            )
+        )
+
+    asyncio.run(_show())
+
+
+@did_group.command("verify")
+@click.argument("source", type=click.Path(exists=True))
+@click.option("--verbose", "-v", is_flag=True, help="Show detailed verification steps")
+def did_verify(source, verbose):
+    """Verify the trust chain and DID integrity of a soul.
+
+    Checks that all trust chain entries have valid Ed25519 signatures,
+    the hash chain is intact, and public keys match the keystore.
+
+    \b
+    Examples:
+      soul did verify aria.soul
+      soul did verify .soul/ --verbose
+    """
+
+    async def _verify():
+        from soul_protocol.runtime.soul import Soul
+
+        soul = await Soul.awaken(source)
+
+        # Basic info
+        console.print(f"\n[dim]Verifying:[/dim] [bold]{soul.name}[/bold] ({soul.did})\n")
+
+        chain = soul.trust_chain
+        chain_len = len(chain.entries)
+
+        # Step 1: Check DID format
+        did_valid = soul.did.startswith("did:soul:")
+        if did_valid:
+            console.print(f"  {_OK} DID format valid")
+        else:
+            console.print(f"  {_FAIL} DID format invalid -- expected did:soul:...")
+
+        # Step 2: Check public key present
+        pub_bytes = soul._keystore.public_key_bytes
+        if pub_bytes:
+            console.print(f"  {_OK} Public key present (Ed25519)")
+        else:
+            console.print(f"  {_WARN} No public key -- cannot verify signatures")
+
+        # Step 3: Verify trust chain
+        if chain_len == 0:
+            console.print(f"  {_WARN} Trust chain is empty (no signed actions)")
+        else:
+            valid, error = soul.verify_chain()
+            if valid:
+                console.print(f"  {_OK} Trust chain valid -- {chain_len} entries verified")
+            else:
+                console.print(f"  {_FAIL} Trust chain INVALID -- {error}")
+
+        # Step 4: Show chain summary if verbose
+        if verbose and chain_len > 0:
+            console.print()
+            table = Table(title="Trust Chain Entries", show_lines=True)
+            table.add_column("#", style="dim", width=4)
+            table.add_column("Action", style="cyan")
+            table.add_column("Timestamp", style="dim")
+            table.add_column("Signature", width=20)
+
+            for entry in chain.entries:
+                sig_short = f"{entry.signature[:12]}..." if entry.signature else "none"
+                table.add_row(
+                    str(entry.seq),
+                    entry.action,
+                    entry.ts.isoformat() if hasattr(entry.ts, "isoformat") else str(entry.ts),
+                    sig_short,
+                )
+
+            console.print(table)
+
+        # Final verdict
+        console.print()
+        all_ok = did_valid and (chain_len == 0 or (chain_len > 0 and valid))
+        if all_ok:
+            console.print(
+                Panel(
+                    "[green]All checks passed[/green]",
+                    border_style="green",
+                )
+            )
+        else:
+            console.print(
+                Panel(
+                    "[red]Verification failed[/red]",
+                    border_style="red",
+                )
+            )
+
+    asyncio.run(_verify())
+
+
+__all__ = ["did_group"]

--- a/src/soul_protocol/cli/did.py
+++ b/src/soul_protocol/cli/did.py
@@ -157,10 +157,11 @@ def did_verify(source, verbose):
 
         # Step 2: Check public key present
         pub_bytes = soul._keystore.public_key_bytes
-        if pub_bytes:
+        pub_valid = bool(pub_bytes)
+        if pub_valid:
             console.print(f"  {_OK} Public key present (Ed25519)")
         else:
-            console.print(f"  {_WARN} No public key -- cannot verify signatures")
+            console.print(f"  {_FAIL} No public key -- cannot verify signatures")
 
         # Step 3: Verify trust chain
         chain_valid = True
@@ -200,7 +201,7 @@ def did_verify(source, verbose):
 
         # Final verdict
         console.print()
-        all_ok = did_valid and (chain_len == 0 or chain_valid)
+        all_ok = did_valid and pub_valid and (chain_len == 0 or chain_valid)
         if all_ok:
             console.print(
                 Panel(

--- a/src/soul_protocol/cli/did.py
+++ b/src/soul_protocol/cli/did.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import asyncio
 import base64
 import sys
+import zipfile
+from pathlib import Path
 
 import click
 from rich.console import Console
@@ -25,6 +27,24 @@ else:
     _OK = "[green]\u2713[/green]"
     _FAIL = "[red]\u2717[/red]"
     _WARN = "[yellow]\u26a0[/yellow]"
+
+
+def _source_has_public_key(source: str) -> bool:
+    """Check if the source archive or directory contains a persisted public key.
+
+    Soul.awaken() regenerates keys in memory when none are found, so we
+    must inspect the source directly rather than trusting the runtime keystore.
+    """
+    p = Path(source)
+    if p.is_file() and p.suffix == ".soul":
+        try:
+            with zipfile.ZipFile(str(p)) as zf:
+                return "keys/public.key" in zf.namelist()
+        except (zipfile.BadZipFile, OSError):
+            return False
+    elif p.is_dir():
+        return (p / "keys" / "public.key").exists()
+    return False
 
 
 @click.group("did")
@@ -155,13 +175,12 @@ def did_verify(source, verbose):
         else:
             console.print(f"  {_FAIL} DID format invalid -- expected did:soul:...")
 
-        # Step 2: Check public key present
-        pub_bytes = soul._keystore.public_key_bytes
-        pub_valid = bool(pub_bytes)
+        # Step 2: Check public key persisted in source
+        pub_valid = _source_has_public_key(source)
         if pub_valid:
             console.print(f"  {_OK} Public key present (Ed25519)")
         else:
-            console.print(f"  {_FAIL} No public key -- cannot verify signatures")
+            console.print(f"  {_FAIL} No public key in source -- cannot verify signatures")
 
         # Step 3: Verify trust chain
         chain_valid = True

--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -170,6 +170,11 @@ from soul_protocol.cli.journal import journal_group as _journal_group  # noqa: E
 
 cli.add_command(_journal_group)
 
+# DID management subcommand group (Phase 1 — digital identity CLI)
+from soul_protocol.cli.did import did_group as _did_group  # noqa: E402
+
+cli.add_command(_did_group)
+
 # Soul diff command (#191)
 from soul_protocol.cli.diff import diff_cmd as _diff_cmd  # noqa: E402
 

--- a/tests/test_did_cli.py
+++ b/tests/test_did_cli.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import zipfile
 
 import pytest
 from click.testing import CliRunner
@@ -42,6 +44,75 @@ def soul_file_no_keys(tmp_path):
         path = tmp_path / "verify_only.soul"
         await soul.export(str(path), include_keys=False)
         return str(path)
+
+    return asyncio.run(_create())
+
+
+@pytest.fixture
+def soul_file_with_chain(tmp_path):
+    """Create a test .soul file with trust chain entries via observe()."""
+    from soul_protocol.runtime.types import Interaction
+
+    async def _create():
+        soul = await Soul.birth(name="ChainTest", personality="A soul with history")
+        # Use observe() to generate trust chain entries
+        await soul.observe(
+            Interaction(
+                user_input="Hello there",
+                agent_output="Hi! How can I help?",
+                channel="test",
+            )
+        )
+        await soul.observe(
+            Interaction(
+                user_input="Tell me about Python",
+                agent_output="Python is great!",
+                channel="test",
+            )
+        )
+        path = tmp_path / "chain_test.soul"
+        await soul.export(str(path), include_keys=True)
+        return str(path)
+
+    return asyncio.run(_create())
+
+
+@pytest.fixture
+def tampered_soul_file(tmp_path):
+    """Create a .soul file with a tampered trust chain."""
+    from soul_protocol.runtime.types import Interaction
+
+    async def _create():
+        soul = await Soul.birth(name="Tampered", personality="Will be tampered")
+        await soul.observe(
+            Interaction(
+                user_input="First message",
+                agent_output="First reply",
+                channel="test",
+            )
+        )
+        path = tmp_path / "tampered.soul"
+        await soul.export(str(path), include_keys=True)
+
+        # Tamper: modify a trust chain entry inside the zip
+        tampered_path = tmp_path / "tampered_mod.soul"
+        with zipfile.ZipFile(str(path), "r") as zin:
+            with zipfile.ZipFile(str(tampered_path), "w") as zout:
+                for item in zin.namelist():
+                    data = zin.read(item)
+                    if "trust" in item and item.endswith(".json"):
+                        # Corrupt the trust chain data
+                        chain_data = json.loads(data.decode("utf-8"))
+                        if isinstance(chain_data, dict) and "entries" in chain_data:
+                            for entry in chain_data["entries"]:
+                                entry["payload_hash"] = "0" * 64  # corrupt
+                            data = json.dumps(chain_data).encode("utf-8")
+                        elif isinstance(chain_data, list) and len(chain_data) > 0:
+                            chain_data[0]["payload_hash"] = "0" * 64
+                            data = json.dumps(chain_data).encode("utf-8")
+                    zout.writestr(item, data)
+
+        return str(tampered_path)
 
     return asyncio.run(_create())
 
@@ -128,6 +199,25 @@ class TestDidVerify:
         """verify command fails gracefully with nonexistent file."""
         result = runner.invoke(cli, ["did", "verify", "nonexistent.soul"])
         assert result.exit_code != 0
+
+    def test_verify_with_chain_passes(self, runner, soul_file_with_chain):
+        """verify passes for a soul with trust chain entries."""
+        result = runner.invoke(cli, ["did", "verify", soul_file_with_chain])
+        assert result.exit_code == 0
+        assert "All checks passed" in result.output
+
+    def test_verify_verbose_with_chain(self, runner, soul_file_with_chain):
+        """verify --verbose shows chain table for soul with entries."""
+        result = runner.invoke(cli, ["did", "verify", soul_file_with_chain, "--verbose"])
+        assert result.exit_code == 0
+        # Should show the Trust Chain Entries table
+        assert "Trust Chain" in result.output
+
+    def test_verify_tampered_exits_nonzero(self, runner, tampered_soul_file):
+        """verify exits 1 for a soul with a tampered trust chain."""
+        result = runner.invoke(cli, ["did", "verify", tampered_soul_file])
+        assert result.exit_code != 0
+        assert "Verification failed" in result.output or "INVALID" in result.output
 
 
 # ============ soul did (group) ============

--- a/tests/test_did_cli.py
+++ b/tests/test_did_cli.py
@@ -117,6 +117,28 @@ def tampered_soul_file(tmp_path):
     return asyncio.run(_create())
 
 
+@pytest.fixture
+def stripped_keys_soul_file(tmp_path):
+    """Create a .soul file with keys/ directory removed."""
+
+    async def _create():
+        soul = await Soul.birth(name="NoKeys")
+        path = tmp_path / "nokeys_orig.soul"
+        await soul.export(str(path), include_keys=True)
+
+        # Strip all keys/ entries from the archive
+        stripped_path = tmp_path / "nokeys.soul"
+        with zipfile.ZipFile(str(path), "r") as zin:
+            with zipfile.ZipFile(str(stripped_path), "w") as zout:
+                for item in zin.namelist():
+                    if not item.startswith("keys/"):
+                        zout.writestr(item, zin.read(item))
+
+        return str(stripped_path)
+
+    return asyncio.run(_create())
+
+
 # ============ soul did show ============
 
 
@@ -218,6 +240,12 @@ class TestDidVerify:
         result = runner.invoke(cli, ["did", "verify", tampered_soul_file])
         assert result.exit_code != 0
         assert "Verification failed" in result.output or "INVALID" in result.output
+
+    def test_verify_stripped_keys_exits_nonzero(self, runner, stripped_keys_soul_file):
+        """verify exits 1 for a soul whose keys/ directory was removed."""
+        result = runner.invoke(cli, ["did", "verify", stripped_keys_soul_file])
+        assert result.exit_code != 0
+        assert "No public key in source" in result.output
 
 
 # ============ soul did (group) ============

--- a/tests/test_did_cli.py
+++ b/tests/test_did_cli.py
@@ -1,0 +1,157 @@
+# test_did_cli.py — Tests for the `soul did` CLI commands.
+# Created: 2026-06-27 — Phase 1 of the DID CLI feature.
+#   Tests for `soul did show` and `soul did verify` subcommands.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from click.testing import CliRunner
+
+from soul_protocol.cli.main import cli
+from soul_protocol.runtime.soul import Soul
+
+
+@pytest.fixture
+def runner():
+    """Provide a Click CliRunner for CLI tests."""
+    return CliRunner()
+
+
+@pytest.fixture
+def soul_file(tmp_path):
+    """Create a test .soul file and return its path."""
+
+    async def _create():
+        soul = await Soul.birth(name="TestDID", personality="A test soul")
+        await soul.remember("User likes Python", importance=8)
+        path = tmp_path / "test.soul"
+        await soul.export(str(path), include_keys=True)
+        return str(path)
+
+    return asyncio.run(_create())
+
+
+@pytest.fixture
+def soul_file_no_keys(tmp_path):
+    """Create a test .soul file without private keys."""
+
+    async def _create():
+        soul = await Soul.birth(name="VerifyOnly")
+        path = tmp_path / "verify_only.soul"
+        await soul.export(str(path), include_keys=False)
+        return str(path)
+
+    return asyncio.run(_create())
+
+
+# ============ soul did show ============
+
+
+class TestDidShow:
+    """Tests for the `soul did show` command."""
+
+    def test_show_displays_name(self, runner, soul_file):
+        """show command displays the soul name."""
+        result = runner.invoke(cli, ["did", "show", soul_file])
+        assert result.exit_code == 0
+        assert "TestDID" in result.output
+
+    def test_show_displays_did(self, runner, soul_file):
+        """show command displays the DID."""
+        result = runner.invoke(cli, ["did", "show", soul_file])
+        assert result.exit_code == 0
+        assert "did:soul:testdid" in result.output
+
+    def test_show_displays_algorithm(self, runner, soul_file):
+        """show command displays Ed25519 algorithm."""
+        result = runner.invoke(cli, ["did", "show", soul_file])
+        assert result.exit_code == 0
+        assert "Ed25519" in result.output
+
+    def test_show_displays_public_key(self, runner, soul_file):
+        """show command displays the public key."""
+        result = runner.invoke(cli, ["did", "show", soul_file])
+        assert result.exit_code == 0
+        assert "Public Key" in result.output
+
+    def test_show_private_key_present(self, runner, soul_file):
+        """show command indicates private key is present."""
+        result = runner.invoke(cli, ["did", "show", soul_file])
+        assert result.exit_code == 0
+        assert "present" in result.output
+
+    def test_show_private_key_absent(self, runner, soul_file_no_keys):
+        """show command indicates private key is absent."""
+        result = runner.invoke(cli, ["did", "show", soul_file_no_keys])
+        assert result.exit_code == 0
+        assert "absent" in result.output
+
+    def test_show_nonexistent_file(self, runner):
+        """show command fails gracefully with nonexistent file."""
+        result = runner.invoke(cli, ["did", "show", "nonexistent.soul"])
+        assert result.exit_code != 0
+
+
+# ============ soul did verify ============
+
+
+class TestDidVerify:
+    """Tests for the `soul did verify` command."""
+
+    def test_verify_passes_valid_soul(self, runner, soul_file):
+        """verify command passes for a valid soul file."""
+        result = runner.invoke(cli, ["did", "verify", soul_file])
+        assert result.exit_code == 0
+        assert "DID format valid" in result.output
+        assert "All checks passed" in result.output
+
+    def test_verify_shows_public_key_status(self, runner, soul_file):
+        """verify command shows public key is present."""
+        result = runner.invoke(cli, ["did", "verify", soul_file])
+        assert result.exit_code == 0
+        assert "Public key present" in result.output
+
+    def test_verify_no_keys_still_passes(self, runner, soul_file_no_keys):
+        """verify command passes for soul without private keys."""
+        result = runner.invoke(cli, ["did", "verify", soul_file_no_keys])
+        assert result.exit_code == 0
+        assert "DID format valid" in result.output
+
+    def test_verify_verbose_flag(self, runner, soul_file):
+        """verify --verbose doesn't crash."""
+        result = runner.invoke(cli, ["did", "verify", soul_file, "--verbose"])
+        assert result.exit_code == 0
+
+    def test_verify_nonexistent_file(self, runner):
+        """verify command fails gracefully with nonexistent file."""
+        result = runner.invoke(cli, ["did", "verify", "nonexistent.soul"])
+        assert result.exit_code != 0
+
+
+# ============ soul did (group) ============
+
+
+class TestDidGroup:
+    """Tests for the `soul did` command group."""
+
+    def test_help(self, runner):
+        """did --help shows usage info."""
+        result = runner.invoke(cli, ["did", "--help"])
+        assert result.exit_code == 0
+        assert "show" in result.output
+        assert "verify" in result.output
+        assert "Decentralized Identifiers" in result.output
+
+    def test_show_help(self, runner):
+        """did show --help shows command help."""
+        result = runner.invoke(cli, ["did", "show", "--help"])
+        assert result.exit_code == 0
+        assert "DID" in result.output
+
+    def test_verify_help(self, runner):
+        """did verify --help shows command help."""
+        result = runner.invoke(cli, ["did", "verify", "--help"])
+        assert result.exit_code == 0
+        assert "trust chain" in result.output.lower()


### PR DESCRIPTION
## What

Phase 1 of the DID CLI feature — adds `soul did` command group for inspecting 
and verifying a soul's decentralized identity.

## Commands

### `soul did show <source>`
Displays the soul's identity info:
- Name, DID (`did:soul:...`), archetype, born date
- Ed25519 public key (truncated)
- Private key status (present/absent)
- Trust chain entry count and key rotation status

### `soul did verify <source>`
Verifies the soul's DID integrity:
- DID format validation (`did:soul:` prefix)
- Public key presence check
- Trust chain signature verification via `Soul.verify_chain()`
- `--verbose` flag shows individual chain entries

## Tests

15 tests added — all passing:
- `TestDidShow` (7 tests): name, DID, algorithm, public key, private key status
- `TestDidVerify` (5 tests): valid soul, no-keys, verbose, error handling
- `TestDidGroup` (3 tests): help text for all commands

## Files Changed

- **[NEW]** `src/soul_protocol/cli/did.py` — DID CLI module
- **[MODIFY]** `src/soul_protocol/cli/main.py` — Register `did` command group
- **[NEW]** `tests/test_did_cli.py` — 15 test cases
