### PR TITLE
Game Profile brain: Pulse director + the four dials + GameWorld

### DIFF
--- a/spec/profiles/game.md
+++ b/spec/profiles/game.md
@@ -1,6 +1,10 @@
 <!-- game.md — The Game Profile: npc + player roles as the first Soul Protocol profile -->
 <!-- Created: 2026-07-02 — Written from the graduated reference runtime at
      src/soul_protocol/profiles/game/ (experiment/npc-soul-grudge-kernel). -->
+<!-- Updated: 2026-07-02 — §8: director + dials moved from forward work to
+     shipped-in-reference-runtime-v0.1, with a normative §8.1 (DirectorEngine,
+     Dials, ChallengeDial, ProgressTracker, ChoiceGuard, SparkScheduler);
+     §2 file list gains director.py + dials.py. -->
 
 # Soul Protocol Game Profile: `npc.soul` and `player.soul`
 
@@ -20,7 +24,7 @@
 5. [Graceful Degradation](#5-graceful-degradation)
 6. [The Dialogue Seam](#6-the-dialogue-seam)
 7. [Profile Registry and Evolution](#7-profile-registry-and-evolution)
-8. [Forward Work (Non-Normative)](#8-forward-work-non-normative)
+8. [Forward Work](#8-forward-work)
 
 The key words "MUST", "MUST NOT", "SHOULD", "MAY" are to be interpreted as
 described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
@@ -60,7 +64,7 @@ The layering, from most stable to most product-specific:
 A profile MUST NOT require changes to L0. This is not an aspiration but the
 empirical record: the Game Profile shipped with **zero modifications to core
 files** — the reference runtime is new files only (`grudge.py`, `player.py`,
-`dialogue.py`, `costmeter.py`), importing `Soul`, `MemoryType`,
+`dialogue.py`, `costmeter.py`, `director.py`, `dials.py`), importing `Soul`, `MemoryType`,
 `MemoryVisibility`, and `Interaction` from the public API like any external
 consumer would.
 
@@ -214,12 +218,25 @@ the intended feedback loop:
 Until promoted, conforming implementations MUST rely only on the conventions
 in §4.
 
-## 8. Forward Work (Non-Normative)
+## 8. Forward Work
 
-Planned next in this profile, not yet specified:
+The director and dials, drafted here as forward work, have shipped; §8.1
+specifies them. No other forward work is currently planned.
 
-- **Director** — a pacing layer that reads NPC grudge state and player
-  reputation across a scene and schedules narrative beats from them.
-- **Dials** — the tunable feel parameters (severity tables, bond damage,
-  forgiveness/decay thresholds) exposed as a declared, per-world
-  configuration instead of module constants.
+### 8.1 Director and Dials — shipped in reference runtime v0.1 (Normative)
+
+- **Director** — `DirectorEngine` (`director.py`) paces event FREQUENCY, not
+  amplitude: `observe_beat(player_did, kind, grudge_level)` accrues per-player
+  heat (base `SEVERITY`, grudge-amplified, decayed per beat) through the cycle
+  `BUILD_UP → PEAK → FADE → RELAX`. A conforming director MUST escalate only
+  in `BUILD_UP` below the peak threshold (`should_escalate()`), MUST enforce
+  the relax window regardless of heat, and MUST NOT veto a player action —
+  `yes_and()` returns a build-on suggestion for every input. An
+  `enjoyment_signal` hook (0–1) MAY scale the peak threshold.
+- **Dials** — `dials.py` ships the feel parameters as four continuous 0.0–1.0
+  dials bundled by `Dials` and wired via `Dials.build()`: `ChallengeDial`
+  (maps its level to the director's peak threshold and heat multiplier),
+  `ProgressTracker` (MUST advance at least one track even on a failed beat —
+  failure is progression), `ChoiceGuard` (`offer()` MUST return ≥ 2 actions,
+  synthesizing an alternative when fewer are viable), and `SparkScheduler`
+  (variation pressure once the last K beats run same-kind).

--- a/src/soul_protocol/profiles/game/__init__.py
+++ b/src/soul_protocol/profiles/game/__init__.py
@@ -8,6 +8,13 @@
 #   public GrudgeKernel.grievances() / PlayerSoul.deeds() accessors.
 #   Zero core files were modified to build this profile. Spec:
 #   spec/profiles/game.md.
+#
+# Updated: 2026-07-02 (experiment/npc-soul-grudge-kernel) — PACING + DIALS.
+#   Re-exports the Pulse director (DirectorEngine + the BUILD_UP/PEAK/FADE/
+#   RELAX phase constants, director.py) and the fun-dial machinery (Dials,
+#   BuiltDials, ChallengeDial, ProgressTracker, ChoiceGuard, SparkScheduler,
+#   dials.py). BuiltDials rides along as the return type of the public
+#   Dials.build(). Still zero core modifications.
 
 """The Game Profile — npc.soul + player.soul over the unchanged core.
 
@@ -21,6 +28,11 @@ Two roles on the same ``.soul`` format:
   player's own PUBLIC deeds — reputation (``UNKNOWN`` / ``KNOWN`` /
   ``NOTORIOUS``) any never-met NPC can read and react to.
 
+Around them, the feel layer: :class:`DirectorEngine` (the Pulse director —
+deterministic L4D-style pacing over the beat stream) and the four fun dials
+(:class:`ChallengeDial`, :class:`ProgressTracker`, :class:`ChoiceGuard`,
+:class:`SparkScheduler`), declared and wired through :class:`Dials`.
+
 Normative conventions in ``spec/profiles/game.md``.
 """
 
@@ -31,6 +43,15 @@ from .dialogue import (
     TemplatedDialogueEngine,
     claude_cli_generate,
 )
+from .dials import (
+    BuiltDials,
+    ChallengeDial,
+    ChoiceGuard,
+    Dials,
+    ProgressTracker,
+    SparkScheduler,
+)
+from .director import BUILD_UP, FADE, PEAK, RELAX, DirectorEngine
 from .grudge import GRUDGING, NONE, SLIGHTED, Grievance, GrudgeKernel
 from .player import KNOWN, NOTORIOUS, UNKNOWN, Deed, PlayerSoul
 
@@ -47,6 +68,19 @@ __all__ = [
     "CostMeter",
     "ReplayCache",
     "PRICING",
+    # the Pulse director (pacing) + its phases
+    "DirectorEngine",
+    "BUILD_UP",
+    "PEAK",
+    "FADE",
+    "RELAX",
+    # the fun dials
+    "Dials",
+    "BuiltDials",
+    "ChallengeDial",
+    "ProgressTracker",
+    "ChoiceGuard",
+    "SparkScheduler",
     # grudge levels (npc)
     "NONE",
     "SLIGHTED",

--- a/src/soul_protocol/profiles/game/__init__.py
+++ b/src/soul_protocol/profiles/game/__init__.py
@@ -15,6 +15,12 @@
 #   BuiltDials, ChallengeDial, ProgressTracker, ChoiceGuard, SparkScheduler,
 #   dials.py). BuiltDials rides along as the return type of the public
 #   Dials.build(). Still zero core modifications.
+#
+# Updated: 2026-07-02 (experiment/npc-soul-grudge-kernel) — GAME WORLD.
+#   Re-exports GameWorld (world.py, the composition root that runs beats
+#   through director + kernel + dials and narrates them as the engine-neutral
+#   session event stream, state-stream v0) and DEFAULT_ZONE (the zone every
+#   soul starts in). Still zero core modifications.
 
 """The Game Profile — npc.soul + player.soul over the unchanged core.
 
@@ -54,6 +60,7 @@ from .dials import (
 from .director import BUILD_UP, FADE, PEAK, RELAX, DirectorEngine
 from .grudge import GRUDGING, NONE, SLIGHTED, Grievance, GrudgeKernel
 from .player import KNOWN, NOTORIOUS, UNKNOWN, Deed, PlayerSoul
+from .world import DEFAULT_ZONE, GameWorld
 
 __all__ = [
     # roles
@@ -81,6 +88,9 @@ __all__ = [
     "ProgressTracker",
     "ChoiceGuard",
     "SparkScheduler",
+    # the world (composition + state stream)
+    "GameWorld",
+    "DEFAULT_ZONE",
     # grudge levels (npc)
     "NONE",
     "SLIGHTED",

--- a/src/soul_protocol/profiles/game/dials.py
+++ b/src/soul_protocol/profiles/game/dials.py
@@ -1,0 +1,288 @@
+# dials.py — The four fun dials of the Game Profile: Challenge / Progress /
+#   Choice / Spark as composable, continuous 0.0-1.0 dials.
+#
+# Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — The evidence-derived
+#   feel parameters, each a small deterministic module (no LLM, no network, no
+#   randomness) a game runtime composes with the Pulse director:
+#     * ChallengeDial(level) — maps the dial to the DirectorEngine tunables:
+#       peak_threshold() falls as challenge rises (peaks come sooner) and
+#       heat_multiplier() climbs (every beat lands hotter). Anchored so level
+#       0.5 reproduces the director's stock feel (threshold 2.5, heat x1.0).
+#     * ProgressTracker(aspirations, level) — N overlapping progress tracks.
+#       THE evidence rule: on_beat(kind, succeeded) advances at least one track
+#       even when succeeded=False — a failed beat still moves the "grit" and
+#       "story" tracks (failure-as-progression), scaled by the dial level.
+#       Successes advance the caller's aspiration tracks round-robin.
+#     * ChoiceGuard(level) — offer(actions) never returns fewer than 2 options:
+#       given <2 viable actions it SYNTHESIZES a deterministic alternative
+#       ("walk away from <topic>"), because one option is not a choice. Higher
+#       levels widen the offer to 3-4.
+#     * SparkScheduler(level, window) — variation pressure: needs_variation()
+#       fires when the last K beats are same-kind (K shrinks as the dial
+#       rises), and twist(kind) suggests a deterministic variation.
+#   Dials bundles the four levels (each 0.0-1.0, default 0.5) and build() wires
+#   the configured instances — including a DirectorEngine consuming the
+#   ChallengeDial. Spec: spec/profiles/game.md (section 8).
+
+"""Challenge / Progress / Choice / Spark — the Game Profile's fun dials.
+
+Each dial is a continuous ``0.0-1.0`` level (out-of-range inputs clamp — a
+dial physically stops at its ends) driving one small deterministic module.
+:class:`Dials` declares the four levels; :meth:`Dials.build` turns the
+declaration into configured instances wired to a :class:`DirectorEngine`.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from .director import DirectorEngine
+from .grudge import SEVERITY
+
+# ---------------------------------------------------------------------------
+# Shared dial plumbing.
+# ---------------------------------------------------------------------------
+
+
+def _clamp(level: float) -> float:
+    """Clamp a dial level into [0.0, 1.0] — dials stop at their ends."""
+    return min(1.0, max(0.0, float(level)))
+
+
+# ---------------------------------------------------------------------------
+# Challenge — how hard the world pushes back.
+# ---------------------------------------------------------------------------
+
+# Threshold endpoints: an easy world needs a long, hot build before it peaks;
+# a hard world tips early. Level 0.5 lands on the DirectorEngine default (2.5).
+_EASY_PEAK_THRESHOLD = 4.0
+_HARD_PEAK_THRESHOLD = 1.0
+
+
+class ChallengeDial:
+    """Maps a 0-1 challenge level onto the director's pacing tunables.
+
+    Higher challenge => LOWER :meth:`peak_threshold` (the scene tips into PEAK
+    sooner) and HIGHER :meth:`heat_multiplier` (every beat lands hotter). Both
+    mappings are linear and anchored so level 0.5 reproduces the stock
+    :class:`DirectorEngine` feel (threshold 2.5, heat x1.0).
+    """
+
+    def __init__(self, level: float = 0.5) -> None:
+        self.level = _clamp(level)
+
+    def peak_threshold(self) -> float:
+        """Peak threshold for the director: 4.0 at level 0.0 down to 1.0 at 1.0."""
+        return _EASY_PEAK_THRESHOLD + (_HARD_PEAK_THRESHOLD - _EASY_PEAK_THRESHOLD) * self.level
+
+    def heat_multiplier(self) -> float:
+        """Per-beat heat scale: 0.5 at level 0.0 up to 1.5 at level 1.0."""
+        return 0.5 + self.level
+
+
+# ---------------------------------------------------------------------------
+# Progress — visible motion on overlapping tracks, even through failure.
+# ---------------------------------------------------------------------------
+
+# Implicit tracks every tracker carries alongside the caller's aspirations.
+STORY_TRACK = "story"
+GRIT_TRACK = "grit"
+
+# Base advancement per beat before the dial scale (0.5 + level) is applied.
+_BEAT_PROGRESS = 0.1
+
+
+class ProgressTracker:
+    """N overlapping progress tracks with failure-as-progression.
+
+    ``aspirations`` name the caller's tracks (a quest, a relationship, a
+    skill); the implicit ``story`` and ``grit`` tracks always exist too. THE
+    evidence rule: :meth:`on_beat` advances at least one track even when
+    ``succeeded=False`` — a failed beat forges ``grit`` and still moves the
+    ``story`` (weighted by the beat's :data:`~.grudge.SEVERITY`, a failed
+    betrayal is a bigger story beat than a failed greeting). All advancement
+    scales with the dial level via ``(0.5 + level)``, which never reaches
+    zero, so the guarantee holds at every dial setting.
+    """
+
+    def __init__(self, aspirations: list[str], level: float = 0.5) -> None:
+        self.level = _clamp(level)
+        self._aspirations = list(aspirations)
+        self._tracks: dict[str, float] = dict.fromkeys(self._aspirations, 0.0)
+        self._tracks.setdefault(STORY_TRACK, 0.0)
+        self._tracks.setdefault(GRIT_TRACK, 0.0)
+        self._round_robin = 0
+
+    def advance(self, track: str, amount: float) -> float:
+        """Advance one track by ``amount`` (creating it if new); returns its
+        new value. Manual advances are verbatim — the dial scale applies only
+        to :meth:`on_beat`."""
+        self._tracks[track] = self._tracks.get(track, 0.0) + float(amount)
+        return self._tracks[track]
+
+    def on_beat(self, kind: str, succeeded: bool) -> dict[str, float]:
+        """Advance tracks for one beat; returns ``{track: amount}`` advanced.
+
+        Success moves the next aspiration track (round-robin; ``story`` when
+        no aspirations were declared). Failure ALWAYS moves ``grit`` and
+        ``story`` — at least one track advances on every beat, succeeded or
+        not. That is the dial's evidence rule: failing forward is progression.
+        """
+        base = _BEAT_PROGRESS * (0.5 + self.level)
+        if succeeded:
+            advanced = {self._next_success_track(): base}
+        else:
+            advanced = {
+                GRIT_TRACK: base,
+                STORY_TRACK: base * (0.5 + SEVERITY.get(kind, 0.0)),
+            }
+        for track, amount in advanced.items():
+            self.advance(track, amount)
+        return advanced
+
+    def snapshot(self) -> dict[str, float]:
+        """A copy of every track's current progress."""
+        return dict(self._tracks)
+
+    def _next_success_track(self) -> str:
+        if not self._aspirations:
+            return STORY_TRACK
+        track = self._aspirations[self._round_robin % len(self._aspirations)]
+        self._round_robin += 1
+        return track
+
+
+# ---------------------------------------------------------------------------
+# Choice — one option is not a choice.
+# ---------------------------------------------------------------------------
+
+
+class ChoiceGuard:
+    """Guarantees every offer holds at least two viable actions.
+
+    :meth:`offer` filters blank actions, caps breadth by the dial (level 0.0
+    offers 2, 0.5 offers 3, 1.0 offers 4 — more choice at higher settings),
+    and when fewer than two viable actions were passed it SYNTHESIZES a
+    deterministic alternative — a "walk away from <topic>" construction off
+    the first action (or a stock stand-your-ground option when none were
+    given). The return is always >= 2 options.
+    """
+
+    def __init__(self, level: float = 0.5) -> None:
+        self.level = _clamp(level)
+        self.max_offered = 2 + int(self.level * 2 + 0.5)
+
+    def offer(self, actions: list[str]) -> list[str]:
+        """At least two, at most ``max_offered``, always deterministic."""
+        offered = [a for a in actions if a and a.strip()][: self.max_offered]
+        while len(offered) < 2:
+            offered.append(self._synthesize(offered))
+        return offered
+
+    @staticmethod
+    def _synthesize(offered: list[str]) -> str:
+        """A deterministic alternative built from what is already on offer."""
+        if not offered:
+            return "hold your ground"
+        first = offered[0]
+        topic = " ".join(first.split()[1:]) or first
+        alternative = f"walk away from {topic}"
+        if alternative in offered:  # keep the pair distinct, still deterministic
+            alternative = f"{alternative} instead"
+        return alternative
+
+
+# ---------------------------------------------------------------------------
+# Spark — variation pressure against same-kind monotony.
+# ---------------------------------------------------------------------------
+
+# Deterministic variation suggestions for the profile's known beat kinds.
+_TWISTS: dict[str, str] = {
+    "neutral": "interrupt the calm: an old debt comes due mid-sentence",
+    "insult": "let the insult land on an unintended ear",
+    "theft": "the stolen thing turns out to matter more than it looked",
+    "betrayal": "reveal the betrayal cut both ways",
+}
+
+
+class SparkScheduler:
+    """Fires when the recent beats have gone same-kind stale.
+
+    Tracks the last ``window`` beat kinds via :meth:`observe`.
+    :meth:`needs_variation` is True when the last ``k`` beats are all the same
+    kind, where ``k`` shrinks from ``window`` (level 0.0, tolerant) down to 2
+    (level 1.0, an immediate repeat already demands a change). Any different
+    kind breaks the streak. :meth:`twist` suggests a deterministic variation
+    for the repeated kind.
+    """
+
+    def __init__(self, level: float = 0.5, window: int = 5) -> None:
+        self.level = _clamp(level)
+        self.window = max(2, int(window))
+        self.k = max(2, self.window - int(self.level * (self.window - 2)))
+        self._recent: deque[str] = deque(maxlen=self.window)
+
+    def observe(self, kind: str) -> None:
+        """Record one beat kind."""
+        self._recent.append(kind)
+
+    def needs_variation(self) -> bool:
+        """True when the last ``k`` observed beats are all the same kind."""
+        if len(self._recent) < self.k:
+            return False
+        tail = list(self._recent)[-self.k :]
+        return len(set(tail)) == 1
+
+    def twist(self, kind: str) -> str:
+        """A deterministic variation suggestion for a repeated kind."""
+        return _TWISTS.get(kind, f"vary the {kind} beat: change who pays its price")
+
+
+# ---------------------------------------------------------------------------
+# The bundle — declare four levels, build the configured machinery.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BuiltDials:
+    """The configured instances :meth:`Dials.build` returns, ready to run."""
+
+    challenge: ChallengeDial
+    progress: ProgressTracker
+    choice: ChoiceGuard
+    spark: SparkScheduler
+    director: DirectorEngine
+
+
+@dataclass(frozen=True)
+class Dials:
+    """The declared feel of a world: four continuous dials, 0.0-1.0 each.
+
+    Defaults sit at 0.5 — the tuned baseline (a :class:`ChallengeDial` at 0.5
+    reproduces the stock :class:`DirectorEngine`). Levels outside the range
+    clamp inside the modules they configure.
+    """
+
+    challenge: float = 0.5
+    progress: float = 0.5
+    choice: float = 0.5
+    spark: float = 0.5
+
+    def build(
+        self,
+        aspirations: list[str] | None = None,
+        enjoyment_signal: Callable[[str], float] | None = None,
+    ) -> BuiltDials:
+        """Wire the configured instances — the director consumes the
+        :class:`ChallengeDial` (threshold + heat), and the optional
+        ``enjoyment_signal`` hook passes straight through to it."""
+        challenge = ChallengeDial(self.challenge)
+        return BuiltDials(
+            challenge=challenge,
+            progress=ProgressTracker(list(aspirations or []), level=self.progress),
+            choice=ChoiceGuard(self.choice),
+            spark=SparkScheduler(self.spark),
+            director=DirectorEngine(challenge=challenge, enjoyment_signal=enjoyment_signal),
+        )

--- a/src/soul_protocol/profiles/game/director.py
+++ b/src/soul_protocol/profiles/game/director.py
@@ -1,0 +1,219 @@
+# director.py — The Pulse director: an L4D-style pacing engine for the Game
+#   Profile, over the unchanged Soul Protocol core.
+#
+# Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — Implements Valve's
+#   AI-director algorithm (GDC 2009, Left 4 Dead) on the grudge kernel's beat
+#   stream: pace event FREQUENCY, not amplitude. The scene cycles
+#   BUILD_UP -> PEAK -> FADE -> RELAX; only BUILD_UP green-lights new stress
+#   events (should_escalate() is the frequency governor), and RELAX is the
+#   mandatory low-intensity window — no escalation there, no matter how hot the
+#   intensity reads. Per-player intensity is a deterministic float: each
+#   observe_beat(player_did, kind, grudge_level) decays the player's value by a
+#   configurable factor, then adds heat from the shared SEVERITY table
+#   (betrayal > theft > insult > neutral ~ small floor) amplified by the grudge
+#   level (GRUDGING lands hottest). Layered on top: Monolith's "yes-and" rule —
+#   yes_and(kind) NEVER vetoes a player action, it always returns a build-on
+#   suggestion — and an optional enjoyment_signal hook (0..1 per player) that
+#   scales the peak threshold (bored players peak sooner, delighted players get
+#   a longer build). Zero LLM, zero network, zero randomness — every method is
+#   a pure function of the observed beat sequence and the constructor tunables.
+#   Spec: spec/profiles/game.md (section 8).
+
+"""The Pulse director — deterministic L4D-style pacing over grudge beats.
+
+One :class:`DirectorEngine` paces one scene. Feed it every player action via
+:meth:`DirectorEngine.observe_beat`; read back ``phase``,
+:meth:`~DirectorEngine.intensity`, :meth:`~DirectorEngine.should_escalate`,
+:meth:`~DirectorEngine.suggest_pacing`, and :meth:`~DirectorEngine.yes_and`.
+The phase is scene-global (a director paces the whole scene, driven by
+whichever relationship runs hottest); intensity is tracked per player.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .grudge import GRUDGING, NONE, SEVERITY, SLIGHTED
+
+# ---------------------------------------------------------------------------
+# Phases — the L4D pacing cycle. BUILD_UP is the only phase in which the
+# director green-lights new stress events; PEAK is held for a bounded number
+# of beats, FADE releases, and RELAX is the mandatory quiet window.
+# ---------------------------------------------------------------------------
+BUILD_UP = "BUILD_UP"
+PEAK = "PEAK"
+FADE = "FADE"
+RELAX = "RELAX"
+
+PHASES: tuple[str, ...] = (BUILD_UP, PEAK, FADE, RELAX)
+
+# Phase -> pacing verb, the vocabulary suggest_pacing() speaks.
+PACING_BY_PHASE: dict[str, str] = {
+    BUILD_UP: "escalate",
+    PEAK: "sustain",
+    FADE: "release",
+    RELAX: "rest",
+}
+
+# A beat of ANY kind stimulates a little (a scene where things happen is never
+# fully cold); SEVERITY supplies the real heat above this floor.
+NEUTRAL_HEAT = 0.05
+
+# Grudge context amplifies heat: the same wrong lands hotter on an already
+# GRUDGING relationship. Unknown levels read as NONE — never reject an input.
+GRUDGE_HEAT_MULTIPLIER: dict[str, float] = {
+    NONE: 1.0,
+    SLIGHTED: 1.2,
+    GRUDGING: 1.5,
+}
+
+# Monolith's "yes-and" rule: the director never negates a player action, it
+# builds on it. Known kinds map to a curated suggestion; unknown kinds get a
+# deterministic constructed one (see DirectorEngine.yes_and) — never a veto.
+YES_AND_BUILDS: dict[str, str] = {
+    "neutral": "deepen",
+    "insult": "sharpen",
+    "theft": "pursue",
+    "betrayal": "consequence",
+}
+
+
+class DirectorEngine:
+    """Deterministic pacing state machine over the beat stream of one scene.
+
+    Tunables (constructor):
+
+    * ``peak_threshold`` — intensity at which BUILD_UP tips into PEAK.
+    * ``decay`` — per-beat retention factor in ``(0, 1]``; a player's intensity
+      is multiplied by it before the new beat's heat is added, so quiet beats
+      cool the scene.
+    * ``peak_beats`` / ``fade_beats`` / ``relax_beats`` — how many observed
+      beats each post-build phase lasts (each phase reports itself for exactly
+      that many beats before handing over).
+    * ``enjoyment_signal`` — optional ``(player_did) -> 0..1`` hook. When
+      provided, the effective peak threshold becomes
+      ``peak_threshold * (0.5 + signal)``: a bored player (0.0) peaks at half
+      the threshold, a delighted one (1.0) earns a 1.5x longer build. ``None``
+      (the v0 default) is the pure intensity model, identical to a constant
+      signal of 0.5.
+    """
+
+    def __init__(
+        self,
+        peak_threshold: float = 2.5,
+        decay: float = 0.85,
+        peak_beats: int = 4,
+        fade_beats: int = 2,
+        relax_beats: int = 5,
+        enjoyment_signal: Callable[[str], float] | None = None,
+    ) -> None:
+        if peak_threshold <= 0:
+            raise ValueError(f"peak_threshold must be > 0, got {peak_threshold!r}")
+        if not 0.0 < decay <= 1.0:
+            raise ValueError(f"decay must be in (0.0, 1.0], got {decay!r}")
+        if peak_beats < 1 or fade_beats < 1 or relax_beats < 1:
+            raise ValueError("peak_beats, fade_beats and relax_beats must each be >= 1")
+        self.peak_threshold = peak_threshold
+        self.decay = decay
+        self.peak_beats = peak_beats
+        self.fade_beats = fade_beats
+        self.relax_beats = relax_beats
+        self.enjoyment_signal = enjoyment_signal
+        self._phase = BUILD_UP
+        self._beats_in_phase = 0
+        self._intensity: dict[str, float] = {}
+
+    # ---- readouts ----------------------------------------------------------
+
+    @property
+    def phase(self) -> str:
+        """The scene's current pacing phase (one of :data:`PHASES`)."""
+        return self._phase
+
+    def intensity(self, player_did: str) -> float:
+        """This player's current intensity (0.0 for a player never observed)."""
+        return self._intensity.get(player_did, 0.0)
+
+    # ---- the beat clock ----------------------------------------------------
+
+    def observe_beat(self, player_did: str, kind: str, grudge_level: str = NONE) -> float:
+        """Feed one player action into the director; returns the new intensity.
+
+        Heat = ``max(SEVERITY[kind], NEUTRAL_HEAT)`` (unknown kinds read as
+        neutral — yes-and: the director never rejects an observed action)
+        amplified by the grudge level. The player's intensity decays by the
+        configured factor, the heat lands, and then the phase machine advances:
+        BUILD_UP tips into PEAK when this player's intensity crosses their
+        effective threshold; PEAK, FADE and RELAX each last their configured
+        number of beats.
+        """
+        heat = max(SEVERITY.get(kind, 0.0), NEUTRAL_HEAT)
+        heat *= GRUDGE_HEAT_MULTIPLIER.get(grudge_level, 1.0)
+        value = self._intensity.get(player_did, 0.0) * self.decay + heat
+        self._intensity[player_did] = value
+        self._advance_phase(player_did)
+        return value
+
+    def _advance_phase(self, player_did: str) -> None:
+        """One tick of the phase machine, clocked by observed beats."""
+        if self._phase == BUILD_UP:
+            if self._intensity[player_did] >= self._effective_threshold(player_did):
+                self._enter(PEAK)
+        elif self._phase == PEAK:
+            self._beats_in_phase += 1
+            if self._beats_in_phase >= self.peak_beats:
+                self._enter(FADE)
+        elif self._phase == FADE:
+            self._beats_in_phase += 1
+            if self._beats_in_phase >= self.fade_beats:
+                self._enter(RELAX)
+        else:  # RELAX — the mandatory quiet window, then a fresh build.
+            self._beats_in_phase += 1
+            if self._beats_in_phase >= self.relax_beats:
+                self._enter(BUILD_UP)
+
+    def _enter(self, phase: str) -> None:
+        self._phase = phase
+        self._beats_in_phase = 0
+
+    # ---- the frequency governor --------------------------------------------
+
+    def should_escalate(self, player_did: str) -> bool:
+        """True ONLY in BUILD_UP while this player is below their effective
+        peak threshold — the frequency governor. In PEAK/FADE/RELAX (and in
+        BUILD_UP at or above the ceiling) the answer is False regardless of
+        how hot the intensity reads."""
+        return self._phase == BUILD_UP and self._intensity.get(
+            player_did, 0.0
+        ) < self._effective_threshold(player_did)
+
+    def suggest_pacing(self, player_did: str) -> str:
+        """The phase's pacing verb: ``escalate`` / ``sustain`` / ``release`` /
+        ``rest`` (see :data:`PACING_BY_PHASE`). In BUILD_UP, a player already
+        at/over their effective threshold gets ``sustain`` instead of
+        ``escalate`` so this readout never contradicts
+        :meth:`should_escalate`."""
+        if self._phase == BUILD_UP and not self.should_escalate(player_did):
+            return PACING_BY_PHASE[PEAK]
+        return PACING_BY_PHASE[self._phase]
+
+    # ---- yes-and ------------------------------------------------------------
+
+    def yes_and(self, action_kind: str) -> str:
+        """A build-on suggestion for ANY action kind — never a veto.
+
+        Known kinds map through :data:`YES_AND_BUILDS` (``neutral -> deepen``,
+        ``betrayal -> consequence``, ...); unknown kinds get a deterministic
+        constructed suggestion that still builds on the action. The director
+        never negates what a player did.
+        """
+        return YES_AND_BUILDS.get(action_kind, f"build-on-{action_kind}")
+
+    # ---- internals -----------------------------------------------------------
+
+    def _effective_threshold(self, player_did: str) -> float:
+        """The peak threshold, scaled by the enjoyment hook when present."""
+        if self.enjoyment_signal is None:
+            return self.peak_threshold
+        signal = min(1.0, max(0.0, float(self.enjoyment_signal(player_did))))
+        return self.peak_threshold * (0.5 + signal)

--- a/src/soul_protocol/profiles/game/director.py
+++ b/src/soul_protocol/profiles/game/director.py
@@ -18,6 +18,14 @@
 #   a longer build). Zero LLM, zero network, zero randomness — every method is
 #   a pure function of the observed beat sequence and the constructor tunables.
 #   Spec: spec/profiles/game.md (section 8).
+#
+# Updated: 2026-07-02 (experiment/npc-soul-grudge-kernel) — DIALS WIRING. The
+#   constructor gains an optional challenge=ChallengeDial (dials.py): when
+#   provided, the dial derives peak_threshold (overriding an explicit value)
+#   and its heat_multiplier() scales every beat's heat, so one 0-1 Challenge
+#   dial retunes the whole pacing feel. Behavior without the param is
+#   unchanged (heat scale 1.0). Import is TYPE_CHECKING-only — dials.py
+#   imports this module at runtime, not the other way around.
 
 """The Pulse director — deterministic L4D-style pacing over grudge beats.
 
@@ -32,8 +40,12 @@ whichever relationship runs hottest); intensity is tracked per player.
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from .grudge import GRUDGING, NONE, SEVERITY, SLIGHTED
+
+if TYPE_CHECKING:  # typing only — dials.py imports this module at runtime.
+    from .dials import ChallengeDial
 
 # ---------------------------------------------------------------------------
 # Phases — the L4D pacing cycle. BUILD_UP is the only phase in which the
@@ -96,6 +108,10 @@ class DirectorEngine:
       the threshold, a delighted one (1.0) earns a 1.5x longer build. ``None``
       (the v0 default) is the pure intensity model, identical to a constant
       signal of 0.5.
+    * ``challenge`` — optional :class:`~.dials.ChallengeDial`. When provided,
+      the dial IS the tuning knob: it derives ``peak_threshold`` (overriding
+      an explicitly passed value) and scales every beat's heat by its
+      ``heat_multiplier()``.
     """
 
     def __init__(
@@ -106,7 +122,13 @@ class DirectorEngine:
         fade_beats: int = 2,
         relax_beats: int = 5,
         enjoyment_signal: Callable[[str], float] | None = None,
+        challenge: ChallengeDial | None = None,
     ) -> None:
+        if challenge is not None:
+            peak_threshold = challenge.peak_threshold()
+            self._heat_scale = challenge.heat_multiplier()
+        else:
+            self._heat_scale = 1.0
         if peak_threshold <= 0:
             raise ValueError(f"peak_threshold must be > 0, got {peak_threshold!r}")
         if not 0.0 < decay <= 1.0:
@@ -141,14 +163,15 @@ class DirectorEngine:
 
         Heat = ``max(SEVERITY[kind], NEUTRAL_HEAT)`` (unknown kinds read as
         neutral — yes-and: the director never rejects an observed action)
-        amplified by the grudge level. The player's intensity decays by the
+        amplified by the grudge level and by the challenge dial's heat
+        multiplier when one was wired in. The player's intensity decays by the
         configured factor, the heat lands, and then the phase machine advances:
         BUILD_UP tips into PEAK when this player's intensity crosses their
         effective threshold; PEAK, FADE and RELAX each last their configured
         number of beats.
         """
         heat = max(SEVERITY.get(kind, 0.0), NEUTRAL_HEAT)
-        heat *= GRUDGE_HEAT_MULTIPLIER.get(grudge_level, 1.0)
+        heat *= GRUDGE_HEAT_MULTIPLIER.get(grudge_level, 1.0) * self._heat_scale
         value = self._intensity.get(player_did, 0.0) * self.decay + heat
         self._intensity[player_did] = value
         self._advance_phase(player_did)

--- a/src/soul_protocol/profiles/game/world.py
+++ b/src/soul_protocol/profiles/game/world.py
@@ -1,0 +1,273 @@
+# world.py — GameWorld: composition root + the engine-neutral session event
+#   stream (state-stream v0) of the Game Profile.
+#
+# Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — Composes the whole
+#   profile: N GrudgeKernels (npcs) + N PlayerSouls (players) + one Pulse
+#   DirectorEngine + the four fun dials, and emits every observable state
+#   change as one JSON event per line (session.jsonl) so ANY renderer — a
+#   canvas client, a terminal, a game engine — can replay or live-follow the
+#   session without importing Python. Design rules:
+#     * REPLAY-SAFE: no wall clock, no randomness. Every event carries
+#       t = a monotonic int counter (1, 2, 3, ...), unique and strictly
+#       increasing, so `since`-cursor polling and file replay are exact.
+#     * beat() is the one verb: route the player action to the named NPC
+#       (default: first), (1) director.observe_beat with the PRE-beat grudge
+#       level, (2) kernel.record (both-directions ledger when the player's
+#       own PlayerSoul is in the world), (3) dials — progress.on_beat
+#       (succeeded = the beat was neutral), spark observe + variation check,
+#       (4) kernel.react for the spoken line, then emit the event run:
+#       beat -> speech -> grudge_change (only on a level transition) ->
+#       bond_change (every beat, current value — the HUD's meter) ->
+#       director_phase (only on a phase transition) -> cost_tick (only when
+#       a CostMeter is attached via attach_meter()).
+#     * Zone model v0: zones = {soul-name: zone-string}, everyone starts in
+#       DEFAULT_ZONE ("tavern"); move() re-homes a soul and emits a "move"
+#       event. Zones are labels, not geometry — the renderer owns layout.
+#     * snapshot() is SYNC (grudge levels are cached per (npc, player) as
+#       beats compute them; bonds read live off the kernels) — the HUD's
+#       late-joiner bootstrap: zones, director phase, per-NPC per-player
+#       bond/grudge/last-grievance.
+#     * session_path is truncated fresh at construction so the invariant
+#       "read the file back == events()" holds for the world's lifetime.
+#   Zero core files touched. Spec: spec/profiles/game.md.
+
+"""GameWorld — the Game Profile's composition root and state stream.
+
+One :class:`GameWorld` runs one scene: it owns the NPCs (:class:`GrudgeKernel`),
+the players (:class:`PlayerSoul`), one :class:`DirectorEngine`, the built fun
+dials, and a zone map — and narrates everything that happens as an append-only,
+engine-neutral event stream (``{"t": <counter>, "type": ..., ...}`` per line).
+Feed player actions through :meth:`GameWorld.beat`; read the stream back with
+:meth:`GameWorld.events` (or the ``session.jsonl`` mirror) and bootstrap a HUD
+with :meth:`GameWorld.snapshot`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .costmeter import CostMeter
+from .dials import BuiltDials, Dials
+from .director import DirectorEngine
+from .grudge import NONE, SEVERITY, GrudgeKernel
+from .player import PlayerSoul
+
+# Every soul starts here until move() re-homes it. A zone is a plain string
+# label — geometry belongs to the renderer, not the world.
+DEFAULT_ZONE = "tavern"
+
+
+class GameWorld:
+    """Composition root: souls + director + dials + zones -> one event stream.
+
+    Construct with at least one NPC. ``director`` and ``dials`` default to the
+    profile's tuned baseline — ``Dials().build()`` wires a
+    :class:`DirectorEngine` that consumes the ChallengeDial. Pass
+    ``session_path`` to mirror every event to a jsonl file (truncated fresh at
+    construction, one JSON object per line, append-only afterwards).
+    """
+
+    def __init__(
+        self,
+        npcs: list[GrudgeKernel],
+        players: list[PlayerSoul],
+        director: DirectorEngine | None = None,
+        dials: Dials | None = None,
+        session_path: str | Path | None = None,
+    ) -> None:
+        if not npcs:
+            raise ValueError("GameWorld needs at least one NPC (GrudgeKernel)")
+        self.npcs = list(npcs)
+        self.players = list(players)
+        built: BuiltDials = (dials or Dials()).build()
+        self.dials = built
+        self.director = director if director is not None else built.director
+
+        # Zone model v0: soul-name -> zone label; everyone starts in the tavern.
+        self.zones: dict[str, str] = {kernel.npc_name: DEFAULT_ZONE for kernel in self.npcs}
+        for player in self.players:
+            self.zones[player.name] = DEFAULT_ZONE
+
+        self.session_path = Path(session_path) if session_path is not None else None
+        if self.session_path is not None:
+            self.session_path.parent.mkdir(parents=True, exist_ok=True)
+            # Fresh stream per world: the file always equals events().
+            self.session_path.write_text("", encoding="utf-8")
+
+        self._events: list[dict] = []
+        self._t = 0  # monotonic event counter — NOT wall time (replay-safe)
+        self._meter: CostMeter | None = None
+        # Caches that keep snapshot() sync: last computed grudge level and the
+        # last grievance line, keyed by (npc_name, player_did).
+        self._grudge_levels: dict[tuple[str, str], str] = {}
+        self._last_grievance: dict[tuple[str, str], str] = {}
+
+    # ---- wiring ------------------------------------------------------------
+
+    def attach_meter(self, meter: CostMeter) -> None:
+        """Attach a :class:`CostMeter`; every beat then emits a ``cost_tick``
+        event carrying the meter's running totals."""
+        self._meter = meter
+
+    # ---- zones ---------------------------------------------------------------
+
+    def move(self, name: str, zone: str) -> dict:
+        """Re-home a soul (by name) to ``zone`` and emit a ``move`` event."""
+        if name not in self.zones:
+            raise ValueError(f"unknown soul {name!r}; known: {sorted(self.zones)}")
+        self.zones[name] = zone
+        return self._emit("move", name=name, zone=zone)
+
+    # ---- the one verb --------------------------------------------------------
+
+    async def beat(
+        self,
+        player_did: str,
+        player_name: str,
+        line: str,
+        kind: str = "neutral",
+        npc_name: str | None = None,
+    ) -> dict:
+        """One player action against one NPC; returns the beat summary.
+
+        Routes to the named NPC (default: the first), runs director ->
+        record -> dials -> react, and appends the event run to the stream
+        (see the module header for the exact event order). ``kind`` must be
+        one of the profile's transgression kinds.
+        """
+        if kind not in SEVERITY:
+            raise ValueError(f"unknown kind {kind!r}; expected one of {sorted(SEVERITY)}")
+        kernel = self._kernel_named(npc_name)
+        key = (kernel.npc_name, player_did)
+
+        # Pre-beat state — the director paces off the level as it stood, and
+        # grudge_change needs the old -> new transition.
+        old_level = await kernel.grudge_level(player_did)
+        old_phase = self.director.phase
+
+        # (1) The director observes the beat (frequency governor ticks).
+        self.director.observe_beat(player_did, kind, old_level)
+
+        # (2) The NPC records it — both directions when the player's own soul
+        # is in this world (portable reputation).
+        player_soul = next((p for p in self.players if p.did == player_did), None)
+        await kernel.record(player_did, line, kind, player_soul=player_soul)
+
+        # (3) Dials: progress (a neutral beat counts as a success), spark.
+        progress_advanced = self.dials.progress.on_beat(kind, succeeded=kind == "neutral")
+        self.dials.spark.observe(kind)
+        needs_variation = self.dials.spark.needs_variation()
+
+        # (4) The NPC speaks.
+        reaction = await kernel.react(player_did, player_name=player_name, player_line=line)
+
+        # Post-beat state.
+        new_level = await kernel.grudge_level(player_did)
+        self._grudge_levels[key] = new_level
+        if kind != "neutral":
+            self._last_grievance[key] = line
+        bond = kernel.bond_strength(player_did)
+
+        # (5) The event run — one beat's narration, in a fixed order.
+        self._emit(
+            "beat", player=player_name, did=player_did, line=line, kind=kind, npc=kernel.npc_name
+        )
+        self._emit("speech", npc=kernel.npc_name, text=reaction, zone=self.zones[kernel.npc_name])
+        if new_level != old_level:
+            self._emit(
+                "grudge_change", npc=kernel.npc_name, did=player_did, old=old_level, new=new_level
+            )
+        self._emit("bond_change", npc=kernel.npc_name, did=player_did, value=bond)
+        if self.director.phase != old_phase:
+            self._emit("director_phase", phase=self.director.phase, old=old_phase)
+        if self._meter is not None:
+            self._emit(
+                "cost_tick",
+                model=self._meter.model,
+                calls=self._meter.calls,
+                cached_calls=self._meter.cached_calls,
+                total_cost=self._meter.total_cost,
+            )
+
+        return {
+            "npc": kernel.npc_name,
+            "player": player_name,
+            "did": player_did,
+            "kind": kind,
+            "line": line,
+            "reaction": reaction,
+            "grudge_level": new_level,
+            "bond": bond,
+            "phase": self.director.phase,
+            "pacing": self.director.suggest_pacing(player_did),
+            "yes_and": self.director.yes_and(kind),
+            "progress": progress_advanced,
+            "spark": {
+                "needs_variation": needs_variation,
+                "twist": self.dials.spark.twist(kind) if needs_variation else None,
+            },
+        }
+
+    # ---- readbacks -----------------------------------------------------------
+
+    def events(self) -> list[dict]:
+        """The full event stream so far (a copy — safe to mutate)."""
+        return list(self._events)
+
+    def snapshot(self) -> dict:
+        """The HUD bootstrap: zones, director phase, per-NPC relationship state.
+
+        Sync by design — grudge levels are the cached values the beats
+        computed (``NONE`` for a pair never beaten), bonds read live off the
+        kernels, and ``last_grievance`` is the most recent wronging line.
+        """
+        npcs = []
+        for kernel in self.npcs:
+            per_player = {}
+            for player in self.players:
+                key = (kernel.npc_name, player.did)
+                per_player[player.did] = {
+                    "player": player.name,
+                    "grudge": self._grudge_levels.get(key, NONE),
+                    "bond": kernel.bond_strength(player.did),
+                    "last_grievance": self._last_grievance.get(key),
+                }
+            npcs.append(
+                {
+                    "name": kernel.npc_name,
+                    "did": kernel.npc_did,
+                    "zone": self.zones[kernel.npc_name],
+                    "players": per_player,
+                }
+            )
+        return {
+            "zones": dict(self.zones),
+            "phase": self.director.phase,
+            "npcs": npcs,
+            "players": [
+                {"name": p.name, "did": p.did, "zone": self.zones[p.name]} for p in self.players
+            ],
+        }
+
+    # ---- internals -----------------------------------------------------------
+
+    def _kernel_named(self, npc_name: str | None) -> GrudgeKernel:
+        """The named NPC, or the first when no name was given."""
+        if npc_name is None:
+            return self.npcs[0]
+        for kernel in self.npcs:
+            if kernel.npc_name == npc_name:
+                return kernel
+        known = sorted(k.npc_name for k in self.npcs)
+        raise ValueError(f"unknown npc {npc_name!r}; known: {known}")
+
+    def _emit(self, event_type: str, **fields) -> dict:
+        """Append one event to the stream (and its jsonl mirror)."""
+        self._t += 1
+        event = {"t": self._t, "type": event_type, **fields}
+        self._events.append(event)
+        if self.session_path is not None:
+            with self.session_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(event) + "\n")
+        return event

--- a/tests/profiles/game/test_dials.py
+++ b/tests/profiles/game/test_dials.py
@@ -1,0 +1,198 @@
+# test_dials.py — Deterministic tests for the four fun dials (dials.py).
+#
+# Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — Eight tests, all
+#   pure and synchronous (no Soul, no LLM, no network, no randomness), proving
+#   each dial's evidence rule:
+#     * test_progress_advances_on_failed_beat — THE evidence rule: a failed
+#       beat still advances at least one track (grit + story), at every dial
+#       level including 0.0, and the advancement scales with the level.
+#     * test_progress_success_round_robins_aspirations — successes rotate
+#       through the declared aspiration tracks ("story" when none declared).
+#     * test_choice_pads_to_at_least_two — offer() never returns fewer than 2
+#       options: 1-action, empty, and blank inputs all get a synthesized
+#       deterministic alternative; property-style loop over levels and sizes.
+#     * test_choice_breadth_follows_level — level 0.0 offers 2, 0.5 offers 3,
+#       1.0 offers 4 from the same action pool.
+#     * test_spark_fires_after_k_same_kind_and_resets — needs_variation()
+#       fires only once the last K beats are same-kind, resets on variation,
+#       and K shrinks as the dial level rises.
+#     * test_spark_twist_is_deterministic — twist(kind) is stable, non-empty,
+#       distinct per kind, and covers unknown kinds by construction.
+#     * test_challenge_mappings_monotonic — peak_threshold() strictly falls
+#       and heat_multiplier() strictly climbs with level; level 0.5 reproduces
+#       the stock DirectorEngine feel (threshold 2.5, heat x1.0).
+#     * test_dials_build_wires_director — Dials.build() returns configured
+#       instances and a DirectorEngine that actually consumes the
+#       ChallengeDial: a hard build peaks on the first hot beat, an easy build
+#       shrugs the same arc off.
+#
+# Run:  uv run pytest tests/profiles/game/test_dials.py -v
+
+from __future__ import annotations
+
+import pytest
+
+from soul_protocol.profiles.game import (
+    BUILD_UP,
+    GRUDGING,
+    PEAK,
+    ChallengeDial,
+    ChoiceGuard,
+    Dials,
+    DirectorEngine,
+    ProgressTracker,
+    SparkScheduler,
+)
+from soul_protocol.profiles.game.dials import GRIT_TRACK, STORY_TRACK
+
+RAGNAR = "did:soul:player:ragnar"
+
+
+def test_progress_advances_on_failed_beat() -> None:
+    """THE evidence rule: a failed beat is still progression — grit and story
+    move even when succeeded=False, at every dial level, scaled by the level."""
+    tracker = ProgressTracker(["revenge"], level=0.5)
+    assert sum(tracker.snapshot().values()) == 0.0
+
+    advanced = tracker.on_beat("betrayal", succeeded=False)
+    snap = tracker.snapshot()
+    assert advanced  # at least one track moved — the rule itself
+    assert snap[GRIT_TRACK] == pytest.approx(0.1)  # 0.1 * (0.5 + 0.5)
+    assert snap[STORY_TRACK] == pytest.approx(0.14)  # 0.1 * 1.0 * (0.5 + 0.9)
+    assert snap["revenge"] == 0.0  # failure never fakes aspiration progress
+
+    # The guarantee holds at the very bottom of the dial...
+    floor = ProgressTracker([], level=0.0)
+    assert sum(floor.on_beat("neutral", succeeded=False).values()) > 0.0
+    # ...and a higher level advances further for the identical failed beat.
+    ceiling = ProgressTracker([], level=1.0)
+    ceiling.on_beat("theft", succeeded=False)
+    assert ceiling.snapshot()[GRIT_TRACK] > floor.snapshot()[GRIT_TRACK]
+
+
+def test_progress_success_round_robins_aspirations() -> None:
+    """Successes rotate through the declared aspiration tracks; with none
+    declared, success advances the implicit story track."""
+    tracker = ProgressTracker(["revenge", "romance"], level=0.5)
+    tracker.on_beat("neutral", succeeded=True)
+    tracker.on_beat("neutral", succeeded=True)
+    snap = tracker.snapshot()
+    assert snap["revenge"] == pytest.approx(0.1)
+    assert snap["romance"] == pytest.approx(0.1)
+
+    bare = ProgressTracker([], level=0.5)
+    bare.on_beat("neutral", succeeded=True)
+    assert bare.snapshot()[STORY_TRACK] == pytest.approx(0.1)
+
+    # advance() is the manual, unscaled path — it moves exactly what it is told.
+    tracker.advance("revenge", 0.5)
+    assert tracker.snapshot()["revenge"] == pytest.approx(0.6)
+
+
+def test_choice_pads_to_at_least_two() -> None:
+    """One option is not a choice: offer() synthesizes a deterministic
+    alternative whenever fewer than two viable actions come in."""
+    guard = ChoiceGuard(level=0.5)
+
+    offered = guard.offer(["confront the butcher"])
+    assert offered[0] == "confront the butcher"
+    assert offered[1] == "walk away from the butcher"  # deterministic synthesis
+    assert len(offered) >= 2
+
+    # Empty and blank-only inputs still produce a real pair of options.
+    assert len(guard.offer([])) >= 2
+    assert len(guard.offer(["", "   "])) >= 2
+    # Synthesis is deterministic: same input, same offer.
+    assert guard.offer(["confront the butcher"]) == offered
+
+    # Property-style: never fewer than 2, for any level and any input size.
+    for level in (0.0, 0.5, 1.0):
+        g = ChoiceGuard(level=level)
+        for n in range(6):
+            assert len(g.offer([f"action {i}" for i in range(n)])) >= 2
+
+
+def test_choice_breadth_follows_level() -> None:
+    """Higher Choice level widens the offer: 2 at 0.0, 3 at 0.5, 4 at 1.0."""
+    actions = [f"action {i}" for i in range(6)]
+    assert len(ChoiceGuard(level=0.0).offer(actions)) == 2
+    assert len(ChoiceGuard(level=0.5).offer(actions)) == 3
+    assert len(ChoiceGuard(level=1.0).offer(actions)) == 4
+
+
+def test_spark_fires_after_k_same_kind_and_resets() -> None:
+    """needs_variation() fires only once the last K beats are same-kind, a
+    variation resets it, and K shrinks as the dial level rises."""
+    spark = SparkScheduler(level=0.0, window=3)  # most tolerant: K == window == 3
+    spark.observe("insult")
+    spark.observe("insult")
+    assert not spark.needs_variation()  # two in a row is not yet a rut
+    spark.observe("insult")
+    assert spark.needs_variation()  # three same-kind beats — vary it
+
+    spark.observe("theft")  # variation breaks the streak
+    assert not spark.needs_variation()
+
+    # Higher level shrinks K: an immediate repeat already demands variation.
+    eager = SparkScheduler(level=1.0, window=5)
+    assert eager.k == 2
+    eager.observe("insult")
+    assert not eager.needs_variation()
+    eager.observe("insult")
+    assert eager.needs_variation()
+
+
+def test_spark_twist_is_deterministic() -> None:
+    """twist(kind) is stable, non-empty, per-kind distinct, and constructs a
+    suggestion for unknown kinds instead of refusing them."""
+    spark = SparkScheduler(level=0.5)
+    assert spark.twist("insult") == spark.twist("insult")
+    assert spark.twist("insult")
+    assert spark.twist("insult") != spark.twist("betrayal")
+    assert "ambush" in spark.twist("ambush")  # unknown kind still gets a twist
+
+
+def test_challenge_mappings_monotonic() -> None:
+    """Higher challenge => strictly lower peak threshold and strictly hotter
+    heat; the midpoint reproduces the stock DirectorEngine feel."""
+    levels = [0.0, 0.25, 0.5, 0.75, 1.0]
+    thresholds = [ChallengeDial(lv).peak_threshold() for lv in levels]
+    multipliers = [ChallengeDial(lv).heat_multiplier() for lv in levels]
+
+    for easier, harder in zip(thresholds, thresholds[1:]):
+        assert harder < easier
+    for cooler, hotter in zip(multipliers, multipliers[1:]):
+        assert hotter > cooler
+
+    assert ChallengeDial(0.5).peak_threshold() == pytest.approx(2.5)
+    assert ChallengeDial(0.5).heat_multiplier() == pytest.approx(1.0)
+    # Dials clamp: out-of-range levels stop at the ends.
+    assert ChallengeDial(7.0).peak_threshold() == ChallengeDial(1.0).peak_threshold()
+    assert ChallengeDial(-3.0).heat_multiplier() == ChallengeDial(0.0).heat_multiplier()
+
+
+def test_dials_build_wires_director() -> None:
+    """Dials.build() returns configured instances, and the DirectorEngine
+    genuinely consumes the ChallengeDial: hard peaks on the first hot beat,
+    easy shrugs the same arc off."""
+    assert Dials() == Dials(challenge=0.5, progress=0.5, choice=0.5, spark=0.5)
+
+    hard = Dials(challenge=1.0).build(aspirations=["survive"])
+    assert isinstance(hard.challenge, ChallengeDial)
+    assert isinstance(hard.progress, ProgressTracker)
+    assert isinstance(hard.choice, ChoiceGuard)
+    assert isinstance(hard.spark, SparkScheduler)
+    assert isinstance(hard.director, DirectorEngine)
+    assert "survive" in hard.progress.snapshot()
+
+    # Hard: threshold 1.0, heat x1.5 -> one GRUDGING betrayal (0.9*1.5*1.5 =
+    # 2.025) crosses immediately.
+    hard.director.observe_beat(RAGNAR, "betrayal", GRUDGING)
+    assert hard.director.phase == PEAK
+
+    # Easy: threshold 4.0, heat x0.5 -> the same three-beat arc stays a build.
+    easy = Dials(challenge=0.0).build()
+    for _ in range(3):
+        easy.director.observe_beat(RAGNAR, "betrayal", GRUDGING)
+    assert easy.director.phase == BUILD_UP
+    assert easy.director.should_escalate(RAGNAR)

--- a/tests/profiles/game/test_director.py
+++ b/tests/profiles/game/test_director.py
@@ -1,0 +1,196 @@
+# test_director.py — Deterministic tests for the Pulse director (director.py).
+#
+# Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — Eight tests, all
+#   pure and synchronous (no Soul, no LLM, no network, no randomness), proving
+#   the L4D pacing contract:
+#     * test_scripted_arc_builds_to_peak_at_threshold — a scripted beat
+#       sequence accrues intensity through BUILD_UP and tips into PEAK exactly
+#       when the threshold is crossed (hand-computed heat math).
+#     * test_peak_exits_after_peak_beats — PEAK reports itself for exactly
+#       peak_beats beats, then hands over to FADE.
+#     * test_relax_blocks_escalation_even_under_max_heat — RELAX lasts
+#       relax_beats and should_escalate() is False throughout, even when every
+#       relax beat is a max-heat betrayal on a GRUDGING relationship; the
+#       governor also stays False back in BUILD_UP while intensity remains at
+#       or over the ceiling.
+#     * test_decay_lowers_intensity_across_quiet_beats — quiet (neutral) beats
+#       strictly cool a hot player at the configured decay factor.
+#     * test_yes_and_never_vetoes_any_kind — property-style loop over every
+#       SEVERITY kind plus unknown/empty kinds: always a non-empty build-on
+#       suggestion, never a veto word.
+#     * test_enjoyment_signal_scales_peak_threshold — a bored player (0.0)
+#       peaks in fewer beats than a delighted one (1.0) under identical beats.
+#     * test_pacing_strings_map_to_phases — the four phases speak exactly
+#       escalate/sustain/release/rest.
+#     * test_intensity_is_per_player — heat lands only on the observed player.
+#
+# Run:  uv run pytest tests/profiles/game/test_director.py -v
+
+from __future__ import annotations
+
+import pytest
+
+from soul_protocol.profiles.game import GRUDGING, NONE, SLIGHTED
+from soul_protocol.profiles.game.director import (
+    BUILD_UP,
+    FADE,
+    PACING_BY_PHASE,
+    PEAK,
+    PHASES,
+    RELAX,
+    DirectorEngine,
+)
+from soul_protocol.profiles.game.grudge import SEVERITY
+
+RAGNAR = "did:soul:player:ragnar"
+ASTRID = "did:soul:player:astrid"
+
+
+def test_scripted_arc_builds_to_peak_at_threshold() -> None:
+    """A scripted arc drives BUILD_UP -> PEAK exactly at the threshold.
+
+    decay=1.0 keeps the math additive: 0.05 (neutral) + 0.4 (insult, NONE)
+    + 0.84 (theft, SLIGHTED x1.2) = 1.29 < 2.0, still building; the betrayal
+    on a GRUDGING relationship (+0.9 x 1.5 = 1.35) crosses 2.0 -> PEAK.
+    """
+    director = DirectorEngine(peak_threshold=2.0, decay=1.0, peak_beats=3)
+
+    director.observe_beat(RAGNAR, "neutral", NONE)
+    assert director.phase == BUILD_UP
+    director.observe_beat(RAGNAR, "insult", NONE)
+    assert director.phase == BUILD_UP
+    director.observe_beat(RAGNAR, "theft", SLIGHTED)
+    assert director.phase == BUILD_UP
+    assert director.intensity(RAGNAR) == pytest.approx(1.29)
+    assert director.should_escalate(RAGNAR)  # below threshold, still building
+
+    director.observe_beat(RAGNAR, "betrayal", GRUDGING)
+    assert director.intensity(RAGNAR) == pytest.approx(2.64)
+    assert director.phase == PEAK
+    assert not director.should_escalate(RAGNAR)  # the governor closed
+
+
+def test_peak_exits_after_peak_beats() -> None:
+    """PEAK reports itself for exactly peak_beats beats, then FADE."""
+    director = DirectorEngine(peak_threshold=1.0, decay=1.0, peak_beats=3, fade_beats=2)
+
+    director.observe_beat(RAGNAR, "betrayal", GRUDGING)  # 1.35 >= 1.0 -> PEAK
+    phases = [director.phase]
+    for _ in range(3):
+        director.observe_beat(RAGNAR, "neutral", NONE)
+        phases.append(director.phase)
+
+    assert phases == [PEAK, PEAK, PEAK, FADE]
+    assert phases.count(PEAK) == director.peak_beats
+
+
+def test_relax_blocks_escalation_even_under_max_heat() -> None:
+    """RELAX is the mandatory quiet window: relax_beats beats where
+    should_escalate() is False no matter how hot the beats run."""
+    director = DirectorEngine(
+        peak_threshold=1.0, decay=1.0, peak_beats=1, fade_beats=1, relax_beats=3
+    )
+    director.observe_beat(RAGNAR, "betrayal", GRUDGING)  # -> PEAK
+    assert director.phase == PEAK
+    director.observe_beat(RAGNAR, "betrayal", GRUDGING)  # peak spent -> FADE
+    assert director.phase == FADE
+    director.observe_beat(RAGNAR, "betrayal", GRUDGING)  # fade spent -> RELAX
+    assert director.phase == RELAX
+
+    # Two more MAX-heat beats inside the window: still RELAX, still no green light.
+    for _ in range(2):
+        assert not director.should_escalate(RAGNAR)
+        director.observe_beat(RAGNAR, "betrayal", GRUDGING)
+        assert director.phase == RELAX
+        assert not director.should_escalate(RAGNAR)
+
+    # The window closes only after relax_beats beats -> a fresh BUILD_UP...
+    director.observe_beat(RAGNAR, "betrayal", GRUDGING)
+    assert director.phase == BUILD_UP
+    # ...and even there the governor stays shut while intensity >= threshold.
+    assert director.intensity(RAGNAR) > director.peak_threshold
+    assert not director.should_escalate(RAGNAR)
+
+
+def test_decay_lowers_intensity_across_quiet_beats() -> None:
+    """Quiet beats cool a hot player: decay=0.5 halves, the neutral floor
+    (0.05) trickles in — 0.9 -> 0.5 -> 0.3 -> 0.2, strictly decreasing."""
+    director = DirectorEngine(peak_threshold=10.0, decay=0.5)
+    director.observe_beat(RAGNAR, "betrayal", NONE)
+    assert director.intensity(RAGNAR) == pytest.approx(0.9)
+
+    readings = [director.intensity(RAGNAR)]
+    for expected in (0.5, 0.3, 0.2):
+        value = director.observe_beat(RAGNAR, "neutral", NONE)
+        assert value == pytest.approx(expected)
+        readings.append(value)
+
+    assert all(later < earlier for earlier, later in zip(readings, readings[1:]))
+    assert director.phase == BUILD_UP  # never peaked; this is pure cooling
+
+
+def test_yes_and_never_vetoes_any_kind() -> None:
+    """Monolith's rule, property-style: EVERY input — every SEVERITY kind and
+    any unknown kind — gets a non-empty build-on suggestion, never a veto."""
+    director = DirectorEngine()
+    vetoes = {"veto", "block", "deny", "refuse", "negate", "no", "stop", "cancel"}
+
+    for kind in [*SEVERITY, "ambush", "gift", "riddle", ""]:
+        suggestion = director.yes_and(kind)
+        assert isinstance(suggestion, str) and suggestion
+        assert suggestion.lower() not in vetoes
+        # Deterministic: the same kind always yields the same suggestion.
+        assert director.yes_and(kind) == suggestion
+
+    # Spot-check the curated mappings.
+    assert director.yes_and("neutral") == "deepen"
+    assert director.yes_and("betrayal") == "consequence"
+
+
+def test_enjoyment_signal_scales_peak_threshold() -> None:
+    """The enjoyment hook scales the threshold: bored (0.0) halves it and
+    peaks on beat 1; delighted (1.0) raises it 1.5x and peaks on beat 3."""
+
+    def beats_to_peak(director: DirectorEngine) -> int:
+        for beat in range(1, 11):
+            director.observe_beat(RAGNAR, "betrayal", GRUDGING)  # 1.35 heat per beat
+            if director.phase == PEAK:
+                return beat
+        raise AssertionError("never peaked")
+
+    bored = DirectorEngine(peak_threshold=2.0, decay=1.0, enjoyment_signal=lambda did: 0.0)
+    delighted = DirectorEngine(peak_threshold=2.0, decay=1.0, enjoyment_signal=lambda did: 1.0)
+
+    assert beats_to_peak(bored) == 1  # effective threshold 1.0 < 1.35
+    assert beats_to_peak(delighted) == 3  # effective threshold 3.0, crossed at 4.05
+    # None (the v0 default) sits between the two: effective threshold == 2.0.
+    assert beats_to_peak(DirectorEngine(peak_threshold=2.0, decay=1.0)) == 2
+
+
+def test_pacing_strings_map_to_phases() -> None:
+    """One full cycle speaks exactly escalate/sustain/release/rest, phase by
+    phase, and PACING_BY_PHASE covers every phase."""
+    assert set(PACING_BY_PHASE) == set(PHASES)
+
+    director = DirectorEngine(
+        peak_threshold=1.0, decay=1.0, peak_beats=2, fade_beats=2, relax_beats=2
+    )
+    seen = {director.phase: director.suggest_pacing(RAGNAR)}  # fresh scene: BUILD_UP
+    for _ in range(6):
+        director.observe_beat(RAGNAR, "betrayal", GRUDGING)
+        seen.setdefault(director.phase, director.suggest_pacing(RAGNAR))
+
+    assert seen == {BUILD_UP: "escalate", PEAK: "sustain", FADE: "release", RELAX: "rest"}
+
+
+def test_intensity_is_per_player() -> None:
+    """Heat lands only on the observed player; a bystander stays cold."""
+    director = DirectorEngine()
+    director.observe_beat(RAGNAR, "insult", NONE)
+    director.observe_beat(RAGNAR, "insult", NONE)
+
+    assert director.intensity(RAGNAR) > 0.0
+    assert director.intensity(ASTRID) == 0.0
+    assert director.phase == BUILD_UP
+    assert director.should_escalate(RAGNAR)  # 0.74 is well under the 2.5 default
+    assert director.should_escalate(ASTRID)  # a cold player is fair game too

--- a/tests/profiles/game/test_world.py
+++ b/tests/profiles/game/test_world.py
@@ -1,0 +1,204 @@
+# test_world.py — Deterministic tests for GameWorld (world.py): composition +
+#   the engine-neutral session event stream (state-stream v0).
+#
+# Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — Six pytest-asyncio
+#   tests against the REAL Soul (no mocks of the profile, no LLM, no network,
+#   no randomness):
+#     * test_scripted_session_event_sequence — a scripted 6-beat session
+#       produces the EXACT event-type sequence (beat/speech/bond_change every
+#       beat; grudge_change only on the two level transitions) with t a
+#       strictly increasing 1..N counter, and the transitions carry the right
+#       old -> new levels.
+#     * test_grudge_change_fires_exactly_once_when_slighted — one insult among
+#       neutrals trips NONE -> SLIGHTED exactly once; no further grudge_change
+#       without a second wrong.
+#     * test_session_jsonl_roundtrips — the session.jsonl mirror parses back
+#       byte-for-value equal to events().
+#     * test_snapshot_shape_routing_and_move — snapshot carries zones/phase/
+#       per-NPC per-player state; beats route to the NAMED npc (Astrid takes
+#       the insult, Bjorn stays clean); move() re-homes a soul and emits a
+#       move event.
+#     * test_cost_tick_only_when_meter_attached — cost_tick events appear only
+#       after attach_meter(); absent otherwise.
+#     * test_director_phase_event_on_transition — a hard world (challenge=1.0)
+#       peaks on one hot beat and emits director_phase BUILD_UP -> PEAK.
+#
+# Run:  uv run pytest tests/profiles/game/test_world.py -v
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from soul_protocol.profiles.game import (
+    BUILD_UP,
+    DEFAULT_ZONE,
+    GRUDGING,
+    NONE,
+    PEAK,
+    SLIGHTED,
+    CostMeter,
+    Dials,
+    GameWorld,
+    GrudgeKernel,
+    PlayerSoul,
+)
+
+
+async def _tavern(
+    tmp_path: Path | None = None,
+    dials: Dials | None = None,
+    with_astrid: bool = False,
+) -> tuple[GameWorld, PlayerSoul]:
+    """A fresh world: Bjorn (+ optionally Astrid) and player Ragnar."""
+    npcs = [await GrudgeKernel.birth(name="Bjorn", archetype="The Butcher")]
+    if with_astrid:
+        npcs.append(
+            await GrudgeKernel.birth(
+                name="Astrid",
+                archetype="The Innkeeper",
+                persona="I am Astrid, the sharp-eyed innkeeper. I miss nothing.",
+            )
+        )
+    ragnar = await PlayerSoul.birth(name="Ragnar")
+    session_path = tmp_path / "session.jsonl" if tmp_path is not None else None
+    world = GameWorld(npcs, [ragnar], dials=dials, session_path=session_path)
+    return world, ragnar
+
+
+async def test_scripted_session_event_sequence(tmp_path: Path) -> None:
+    """The exact event-type run of a 6-beat scripted session, replay-safe t."""
+    world, ragnar = await _tavern(tmp_path)
+    script = ["neutral", "neutral", "insult", "neutral", "theft", "neutral"]
+    for kind in script:
+        await world.beat(ragnar.did, "Ragnar", f"a {kind} act", kind=kind)
+
+    types = [e["type"] for e in world.events()]
+    assert types == [
+        # beat 1 (neutral)
+        "beat",
+        "speech",
+        "bond_change",
+        # beat 2 (neutral)
+        "beat",
+        "speech",
+        "bond_change",
+        # beat 3 (insult) — NONE -> SLIGHTED trips here
+        "beat",
+        "speech",
+        "grudge_change",
+        "bond_change",
+        # beat 4 (neutral)
+        "beat",
+        "speech",
+        "bond_change",
+        # beat 5 (theft) — SLIGHTED -> GRUDGING trips here
+        "beat",
+        "speech",
+        "grudge_change",
+        "bond_change",
+        # beat 6 (neutral) — the butcher remembers, but no new transition
+        "beat",
+        "speech",
+        "bond_change",
+    ]
+
+    # t is a monotonic counter, not wall time: exactly 1..N, strictly rising.
+    ts = [e["t"] for e in world.events()]
+    assert ts == list(range(1, len(types) + 1))
+
+    changes = [e for e in world.events() if e["type"] == "grudge_change"]
+    assert [(c["old"], c["new"]) for c in changes] == [(NONE, SLIGHTED), (SLIGHTED, GRUDGING)]
+    assert all(c["npc"] == "Bjorn" and c["did"] == ragnar.did for c in changes)
+
+
+async def test_grudge_change_fires_exactly_once_when_slighted() -> None:
+    """One insult among neutrals: NONE -> SLIGHTED fires exactly once."""
+    world, ragnar = await _tavern()
+    for kind in ["neutral", "insult", "neutral", "neutral"]:
+        await world.beat(ragnar.did, "Ragnar", f"a {kind} act", kind=kind)
+
+    changes = [e for e in world.events() if e["type"] == "grudge_change"]
+    assert len(changes) == 1
+    assert changes[0]["old"] == NONE
+    assert changes[0]["new"] == SLIGHTED
+
+
+async def test_session_jsonl_roundtrips(tmp_path: Path) -> None:
+    """The jsonl mirror reads back exactly equal to events()."""
+    world, ragnar = await _tavern(tmp_path)
+    world.move("Ragnar", "door")
+    for kind in ["neutral", "betrayal", "neutral"]:
+        await world.beat(ragnar.did, "Ragnar", f"a {kind} act", kind=kind)
+
+    raw = (tmp_path / "session.jsonl").read_text(encoding="utf-8")
+    replayed = [json.loads(line) for line in raw.splitlines() if line.strip()]
+    assert replayed == world.events()
+
+
+async def test_snapshot_shape_routing_and_move() -> None:
+    """Snapshot carries zones/phase/per-NPC state; beats route to the NAMED
+    npc; move() re-homes a soul and emits a move event."""
+    world, ragnar = await _tavern(with_astrid=True)
+    snap = world.snapshot()
+    assert snap["zones"] == {"Bjorn": DEFAULT_ZONE, "Astrid": DEFAULT_ZONE, "Ragnar": DEFAULT_ZONE}
+    assert snap["phase"] == BUILD_UP
+    assert [n["name"] for n in snap["npcs"]] == ["Bjorn", "Astrid"]
+    assert snap["players"] == [{"name": "Ragnar", "did": ragnar.did, "zone": DEFAULT_ZONE}]
+
+    # Route the insult to Astrid by name — Bjorn must stay clean.
+    summary = await world.beat(
+        ragnar.did, "Ragnar", "Your ale tastes of dishwater.", kind="insult", npc_name="Astrid"
+    )
+    assert summary["npc"] == "Astrid"
+    speech = [e for e in world.events() if e["type"] == "speech"]
+    assert speech[-1]["npc"] == "Astrid"
+
+    world.move("Ragnar", "door")
+    snap = world.snapshot()
+    assert snap["zones"]["Ragnar"] == "door"
+    assert world.events()[-1] == {
+        "t": world.events()[-1]["t"],
+        "type": "move",
+        "name": "Ragnar",
+        "zone": "door",
+    }
+
+    astrid_state = snap["npcs"][1]["players"][ragnar.did]
+    bjorn_state = snap["npcs"][0]["players"][ragnar.did]
+    assert astrid_state["grudge"] == SLIGHTED
+    assert astrid_state["last_grievance"] == "Your ale tastes of dishwater."
+    assert astrid_state["bond"] < 50.0  # the insult cost trust
+    assert bjorn_state == {"player": "Ragnar", "grudge": NONE, "bond": 50.0, "last_grievance": None}
+
+
+async def test_cost_tick_only_when_meter_attached() -> None:
+    """cost_tick rides the stream only once a CostMeter is attached."""
+    world, ragnar = await _tavern()
+    await world.beat(ragnar.did, "Ragnar", "Morning, butcher.", kind="neutral")
+    assert "cost_tick" not in {e["type"] for e in world.events()}
+
+    async def generate(prompt: str) -> str:  # never called (templated engine)
+        return "a line"
+
+    world.attach_meter(CostMeter(generate, model="claude-cli"))
+    await world.beat(ragnar.did, "Ragnar", "Fine day for a trade.", kind="neutral")
+    ticks = [e for e in world.events() if e["type"] == "cost_tick"]
+    assert len(ticks) == 1
+    assert ticks[0]["model"] == "claude-cli"
+    assert ticks[0]["calls"] == 0  # templated dialogue never hit the meter
+    assert ticks[0]["total_cost"] == 0.0
+
+
+async def test_director_phase_event_on_transition() -> None:
+    """A hard world (challenge=1.0) peaks on one hot beat: director_phase
+    BUILD_UP -> PEAK is emitted, and the summary reports the new phase."""
+    world, ragnar = await _tavern(dials=Dials(challenge=1.0))
+    summary = await world.beat(
+        ragnar.did, "Ragnar", "I sold your secrets to the guard.", kind="betrayal"
+    )
+    assert summary["phase"] == PEAK
+    phase_events = [e for e in world.events() if e["type"] == "director_phase"]
+    assert phase_events == [
+        {"t": phase_events[0]["t"], "type": "director_phase", "phase": PEAK, "old": BUILD_UP}
+    ]


### PR DESCRIPTION
Stacks on the graduation PR. Adds the runtime brain: a drama director, the evidence-derived dial machinery, and the GameWorld composition that emits the engine-neutral session event stream.

## What's in here

- **Pulse director** (`0ea2e3d`): L4D-style pacing engine — per-player intensity, BUILD_UP → PEAK (beat-counted) → FADE → RELAX cycle, paces event frequency not amplitude, a mandatory relax window that blocks escalation even under max heat, a yes-and rule that never vetoes a player action, and an enjoyment-signal hook for future telemetry.
- **Dials** (`2734ba4`): Challenge / Progress / Choice / Spark as composable 0-1 dials. The design rules are enforced mechanically: Progress must advance on a failed beat (failure-as-progression), Choice never returns fewer than two viable actions, Spark forces variation after K same-kind beats, Challenge maps monotonically onto the director's thresholds.
- **GameWorld** (`73846a7`): composes kernels + director + dials + cost meter; `beat()` runs the loop and appends session events (beat / speech / grudge_change / bond_change / director_phase / cost_tick) to a jsonl stream — the renderer protocol. Counter-based time, no wall clock, replay-safe.

## Tests

40/40 (8 director + 8 dials + 6 world + 15 kernel + 3 demo-server from the next PR's base). All deterministic, no LLM, no network.