### PR TITLE
The Butcher Remembers — playable demo (2D client, .soul export, reputation, cost overlay)

### DIFF
--- a/examples/butcher_remembers/README.md
+++ b/examples/butcher_remembers/README.md
@@ -1,64 +1,117 @@
+<!-- README.md — "The Butcher Remembers" 90-second demo.
+     Updated: 2026-07-02 (BD-2) — full rewrite: run one-liners per engine
+     (templated / claude / deepseek), the demo script beats mapped to UI
+     actions, the 7-beat video shot list, the Gemini Nano note, and
+     troubleshooting. -->
+
 # The Butcher Remembers
 
-The Game Profile's scripted grudge arc, rendered live in a browser. Two
-`npc.soul` minds (Bjorn the butcher, Astrid the innkeeper), one `player.soul`
-(Ragnar), one `GameWorld` narrating everything as an engine-neutral event
-stream — and a 2D canvas tavern drawing that stream as it happens.
+The Soul Protocol Game Profile's 90-second demo: two `npc.soul` minds (Bjorn
+the butcher, Astrid the innkeeper), one `player.soul` (Ragnar), one `GameWorld`
+narrating every state change as an engine-neutral event stream — and a 2D
+canvas tavern drawing it live. Wrong the butcher, export him as a **file**,
+wrong him some more, import the file back — he forgets what happened after the
+export, because *he is the file*. Then ask the innkeeper about yourself: she
+has never been wronged by you, but your `player.soul` carries your reputation,
+and she reads it.
 
-Python stdlib + vanilla JS only. No frameworks, no build step, no npm, no API
-key: dialogue is the deterministic `TemplatedDialogueEngine`.
+Python stdlib + vanilla JS. No frameworks, no build step, no npm, no account.
 
 ## Run it
 
 ```bash
+# Free + deterministic (TemplatedDialogueEngine) — the default:
 uv run python examples/butcher_remembers/server.py --scripted
+
+# Real LLM lines via the local claude CLI (no API key; ~20-40s per line):
+uv run python examples/butcher_remembers/server.py --engine claude
+
+# Real LLM lines via the DeepSeek API (fast + ~$0.0001/line):
+DEEPSEEK_API_KEY=sk-... uv run python examples/butcher_remembers/server.py --engine deepseek
 ```
 
-Then open **http://localhost:8777**.
+Then open **http://localhost:8777**. `--scripted` auto-plays the canonical
+six-beat arc (greet → trade → betrayal → theft → Astrid control beat → "old
+friend?" → the butcher remembers), one beat every ~1.4s.
 
-`--scripted` auto-plays the canonical arc, one beat every ~1.4s:
+## The 90-second demo script (beats → UI actions)
 
-1. Ragnar greets Bjorn (neutral) — warm welcome, bond healthy.
-2. Ragnar trades fairly (neutral) — still friendly.
-3. Ragnar lies to the town guard about him (**betrayal**) — Bjorn tips to
-   `SLIGHTED`, bond drops hard.
-4. Ragnar pockets sausages (**theft**) — `GRUDGING`. The ledger card goes red.
-5. Ragnar chats with Astrid (neutral) — the control: she holds no grudge and
-   stays warm while Bjorn seethes two zones away.
-6. Ragnar tries "old friend?" on Bjorn (neutral) — the butcher remembers, and
-   says so, citing the actual wrongs.
+| # | Beat | Time | Do this in the UI |
+|---|------|------|-------------------|
+| 1 | **Create** | 0:00 | Start the server (or click **Reset world**) — three Souls are born with real DIDs, zoned on the canvas. |
+| 2 | **Befriend** | 0:15 | Bottom bar: type friendly lines ("Good morning, Bjorn! Fine sausages.") and **Send**. No kind dropdown — the server classifies. Bjorn stays warm, bond ~50+. |
+| 3 | **Betray** | 0:25 | Type "While you argued with the guard, I pocketed a string of sausages." — classified `theft` (echoed under the bar). Bond drops, ledger chip flips `SLIGHTED` → `GRUDGING`. |
+| 4 | **THE FILE** | 0:40 | Click **⬇ Export bjorn.soul**. A real `.soul` (zip) lands in your downloads. *He's a file. ~16 KB. And he remembers.* |
+| 5 | **Return** | 0:50 | Keep wronging him, then **⬆ Import soul** and pick the earlier `bjorn.soul` — his grudge state reverts to the moment of export. Or import into a *fresh* world after Reset: still hostile, names the theft. |
+| 6 | **Gut-punch** | 1:05 | Click **🏨 Ask the innkeeper about me**. Astrid has no grievance of her own — she reads Ragnar's `player.soul` reputation: *"Word travels… move along."* Amber bubble + notoriety chip. |
+| 7 | **Tag** | 1:20 | Cost overlay (top-right, LLM engines only): claude = **$0.00**, plus "would cost on DeepSeek: $0.000xx". *Worlds that remember you. Your reputation is a file YOU own.* |
+
+**⬇ Export ragnar.player.soul** downloads the reputation file itself — the
+artifact the player carries between games.
+
+## Engines
+
+| `--engine` | Backend | Cost | Latency | Notes |
+|---|---|---|---|---|
+| `templated` (default) | Deterministic templates | $0 | instant | What the tests run. Cost overlay hidden. |
+| `claude` | Local `claude` CLI | $0 (no API key) | **~20-40s per line** — narrate over it or pre-bake takes | Metered as `claude-cli`; token counts still feed the DeepSeek projection. |
+| `deepseek` | `https://api.deepseek.com/chat/completions`, model `deepseek-chat` | ~$0.0001/line | ~2-5s | Needs `DEEPSEEK_API_KEY`. Missing key → prints a warning and falls back to templated (never crashes). |
+
+**Gemini Nano (browser-native, not wired):** the endgame for the "$0, ran in
+YOUR browser" kicker is Chrome's built-in Prompt API (Gemini Nano on-device).
+It needs a Chrome Origin Trial token + `chrome://flags` today, so this demo
+documents it rather than wiring it. The seam is ready: any
+`async (prompt) -> str` dropped into `LLMDialogueEngine` works — a client-side
+Nano bridge would POST generated lines back through the same `/line` loop.
 
 ## What you'll see
 
-- **Canvas tavern** — labeled zones (Bjorn's stall / tables / door), each soul
-  a colored circle (Ragnar wears the light ring), speech bubbles that fade
-  after a few seconds. Player lines get the slate bubble, NPC lines the
-  parchment one.
-- **Grudge ledger (right panel)** — one card per NPC: grudge level chip
-  (`NONE` green / `SLIGHTED` amber / `GRUDGING` red), live bond number, and
-  the last remembered grievance line.
-- **Top bar** — the Pulse director's phase (`BUILD_UP` / `PEAK` / `FADE` /
-  `RELAX`) plus a dialogue-cost readout (always $0 here; `cost_tick` events
-  light it up when a metered LLM engine is wired in).
-
-## Controls
-
-After (or instead of) the script, keep playing from the panel: pick the NPC
-and the act kind (`neutral` / `insult` / `theft` / `betrayal`), type a line,
-**Say it**. **Reset world** births fresh souls and starts the ledger clean.
+- **Canvas tavern** — labeled zones (Bjorn's stall / tables / door), souls as
+  colored circles (Ragnar wears the light ring), fading speech bubbles.
+  Reputation lines glow amber and linger.
+- **Grudge ledger (right panel)** — per-NPC: grudge chip (`NONE` green /
+  `SLIGHTED` amber / `GRUDGING` red), live bond, last remembered grievance.
+- **Top bar** — Pulse director phase (`BUILD_UP` / `PEAK` / `FADE` / `RELAX`)
+  and the running cost readout.
+- **Bottom bar** — free-play input (kind auto-classified), the soul
+  export/import buttons, the innkeeper button, the notoriety chip.
 
 ## Flags
 
 | Flag | Default | What it does |
 | --- | --- | --- |
 | `--port` | `8777` | HTTP port |
-| `--scripted` | off | auto-play the six-beat arc above |
+| `--scripted` | off | auto-play the six-beat arc |
 | `--delay` | `1.4` | seconds between scripted beats |
 | `--session-log PATH` | off | mirror the event stream to a `session.jsonl` |
+| `--engine` | `templated` | `templated` \| `claude` \| `deepseek` |
 
-## Endpoints (for the curious)
+## Endpoints
 
-- `GET /snapshot` — zones, director phase, per-NPC bond/grudge (HUD bootstrap)
+- `GET /snapshot` — zones, phase, per-NPC bond/grudge, active `engine`
 - `GET /events?since=N` — world events with `t > N` (the client polls this)
-- `POST /line` — `{"player": "Ragnar", "text": "...", "kind": "insult", "npc": "Bjorn"}`
+- `GET /cost` — meter summary + `projected_deepseek` + `cost_per_player_hour`
+  (zeros on templated)
+- `GET /reputation?npc=Astrid&player=Ragnar` — `{line, notoriety}`
+- `POST /line` — `{"player","text","kind"?,"npc"?}`; omit `kind` and the
+  keyword classifier picks `theft` / `betrayal` / `insult` / `neutral`
 - `POST /reset` — rebuild the world fresh
+- `POST /export_soul` — `{"npc"?}` → the `.soul` bytes as a download
+- `POST /export_player` — `{"player"?}` → the `.player.soul` download
+- `POST /import_soul` — raw `.soul` bytes → awaken + swap the same-named NPC
+
+## Troubleshooting
+
+- **Port already in use** — another demo is running: `--port 8778`, or kill it
+  (`lsof -ti :8777 | xargs kill`).
+- **`claude` lines are slow** — expected: the local CLI takes ~20-40s per
+  line. The world loop serializes beats, so queued lines land in order. For a
+  smooth video, use `deepseek`, or record templated and voice-over.
+- **DeepSeek silently templated?** — the server printed
+  `DEEPSEEK_API_KEY is not set` at startup and fell back. Export the key and
+  restart.
+- **Import does nothing** — the file must be a `.soul` exported from this
+  demo whose NPC name matches one in the world (`Bjorn` or `Astrid`); anything
+  else returns a 400 with the reason (shown under the bottom bar).
+- **Stale UI after hacking on app.js** — hard-reload; there's no cache
+  busting.

--- a/examples/butcher_remembers/README.md
+++ b/examples/butcher_remembers/README.md
@@ -1,0 +1,64 @@
+# The Butcher Remembers
+
+The Game Profile's scripted grudge arc, rendered live in a browser. Two
+`npc.soul` minds (Bjorn the butcher, Astrid the innkeeper), one `player.soul`
+(Ragnar), one `GameWorld` narrating everything as an engine-neutral event
+stream — and a 2D canvas tavern drawing that stream as it happens.
+
+Python stdlib + vanilla JS only. No frameworks, no build step, no npm, no API
+key: dialogue is the deterministic `TemplatedDialogueEngine`.
+
+## Run it
+
+```bash
+uv run python examples/butcher_remembers/server.py --scripted
+```
+
+Then open **http://localhost:8777**.
+
+`--scripted` auto-plays the canonical arc, one beat every ~1.4s:
+
+1. Ragnar greets Bjorn (neutral) — warm welcome, bond healthy.
+2. Ragnar trades fairly (neutral) — still friendly.
+3. Ragnar lies to the town guard about him (**betrayal**) — Bjorn tips to
+   `SLIGHTED`, bond drops hard.
+4. Ragnar pockets sausages (**theft**) — `GRUDGING`. The ledger card goes red.
+5. Ragnar chats with Astrid (neutral) — the control: she holds no grudge and
+   stays warm while Bjorn seethes two zones away.
+6. Ragnar tries "old friend?" on Bjorn (neutral) — the butcher remembers, and
+   says so, citing the actual wrongs.
+
+## What you'll see
+
+- **Canvas tavern** — labeled zones (Bjorn's stall / tables / door), each soul
+  a colored circle (Ragnar wears the light ring), speech bubbles that fade
+  after a few seconds. Player lines get the slate bubble, NPC lines the
+  parchment one.
+- **Grudge ledger (right panel)** — one card per NPC: grudge level chip
+  (`NONE` green / `SLIGHTED` amber / `GRUDGING` red), live bond number, and
+  the last remembered grievance line.
+- **Top bar** — the Pulse director's phase (`BUILD_UP` / `PEAK` / `FADE` /
+  `RELAX`) plus a dialogue-cost readout (always $0 here; `cost_tick` events
+  light it up when a metered LLM engine is wired in).
+
+## Controls
+
+After (or instead of) the script, keep playing from the panel: pick the NPC
+and the act kind (`neutral` / `insult` / `theft` / `betrayal`), type a line,
+**Say it**. **Reset world** births fresh souls and starts the ledger clean.
+
+## Flags
+
+| Flag | Default | What it does |
+| --- | --- | --- |
+| `--port` | `8777` | HTTP port |
+| `--scripted` | off | auto-play the six-beat arc above |
+| `--delay` | `1.4` | seconds between scripted beats |
+| `--session-log PATH` | off | mirror the event stream to a `session.jsonl` |
+
+## Endpoints (for the curious)
+
+- `GET /snapshot` — zones, director phase, per-NPC bond/grudge (HUD bootstrap)
+- `GET /events?since=N` — world events with `t > N` (the client polls this)
+- `POST /line` — `{"player": "Ragnar", "text": "...", "kind": "insult", "npc": "Bjorn"}`
+- `POST /reset` — rebuild the world fresh

--- a/examples/butcher_remembers/app.js
+++ b/examples/butcher_remembers/app.js
@@ -1,0 +1,338 @@
+// app.js — "The Butcher Remembers" canvas client.
+// Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — vanilla JS renderer
+// over the GameWorld event stream: polls /events?since=N every ~700ms, draws
+// the tavern zones (stall / tables / door) with souls as labeled circles,
+// floats fading speech bubbles on speech/beat events, and keeps the grudge
+// HUD (level chip, bond, last grievance) + director phase chip in sync.
+// No frameworks, no assets, no build step.
+
+"use strict";
+
+const canvas = document.getElementById("tavern");
+const ctx = canvas.getContext("2d");
+
+// Zone geometry is CLIENT-side; the world only speaks zone labels.
+const ZONES = {
+  stall: { x: 28, y: 64, w: 200, h: 168, label: "Bjorn's stall" },
+  tables: { x: 258, y: 168, w: 214, h: 180, label: "tables" },
+  door: { x: 498, y: 296, w: 118, h: 126, label: "door" },
+  tavern: { x: 258, y: 64, w: 214, h: 76, label: "tavern" }, // fallback / lobby
+};
+
+const SOUL_COLORS = { Bjorn: "#c1653f", Astrid: "#5f9e8f", Ragnar: "#7292c4" };
+const FALLBACK_COLORS = ["#a07ac0", "#b3a24c", "#c47292"];
+const BUBBLE_MS = 4200; // how long a speech bubble lives
+
+const state = {
+  souls: new Map(), // name -> {kind:'npc'|'player', zone, color}
+  cards: new Map(), // npc name -> {level, bond, lastGrievance, flashUntil}
+  bubbles: [], // {name, text, born, fromPlayer}
+  phase: "BUILD_UP",
+  cost: null,
+  cursor: 0,
+};
+
+// ---------------------------------------------------------------------------
+// Bootstrap + polling
+// ---------------------------------------------------------------------------
+
+async function boot() {
+  await seedFromSnapshot();
+  setInterval(poll, 700);
+  requestAnimationFrame(draw);
+}
+
+async function seedFromSnapshot() {
+  const snap = await fetch("/snapshot").then((r) => r.json());
+  state.souls.clear();
+  state.cards.clear();
+  snap.npcs.forEach((npc) => {
+    ensureSoul(npc.name, "npc", npc.zone);
+    const first = Object.values(npc.players)[0] || {};
+    state.cards.set(npc.name, {
+      level: first.grudge || "NONE",
+      bond: typeof first.bond === "number" ? first.bond : 50,
+      lastGrievance: first.last_grievance || null,
+      flashUntil: 0,
+    });
+  });
+  snap.players.forEach((p) => ensureSoul(p.name, "player", p.zone));
+  state.phase = snap.phase;
+  renderCards();
+  renderPhase();
+}
+
+function ensureSoul(name, kind, zone) {
+  const color =
+    SOUL_COLORS[name] || FALLBACK_COLORS[state.souls.size % FALLBACK_COLORS.length];
+  state.souls.set(name, { kind, zone: zone || "tavern", color });
+}
+
+async function poll() {
+  try {
+    const events = await fetch(`/events?since=${state.cursor}`).then((r) => r.json());
+    if (!Array.isArray(events) || events.length === 0) return;
+    events.forEach(apply);
+    renderCards();
+    renderPhase();
+  } catch (err) {
+    setStatus("server unreachable...");
+  }
+}
+
+function apply(e) {
+  state.cursor = Math.max(state.cursor, e.t);
+  const card = e.npc ? state.cards.get(e.npc) : null;
+  switch (e.type) {
+    case "move": {
+      const soul = state.souls.get(e.name);
+      if (soul) soul.zone = e.zone;
+      else ensureSoul(e.name, "npc", e.zone);
+      break;
+    }
+    case "beat":
+      addBubble(e.player, e.line, true);
+      if (card && e.kind !== "neutral") card.lastGrievance = e.line;
+      break;
+    case "speech":
+      addBubble(e.npc, e.text, false);
+      break;
+    case "grudge_change":
+      if (card) {
+        card.level = e.new;
+        card.flashUntil = performance.now() + 1200;
+      }
+      break;
+    case "bond_change":
+      if (card) card.bond = e.value;
+      break;
+    case "director_phase":
+      state.phase = e.phase;
+      break;
+    case "cost_tick":
+      state.cost = e;
+      break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Canvas rendering
+// ---------------------------------------------------------------------------
+
+function draw(now) {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawFloor();
+  Object.values(ZONES).forEach(drawZone);
+  for (const name of state.souls.keys()) drawSoul(name);
+  state.bubbles = state.bubbles.filter((b) => now - b.born < BUBBLE_MS);
+  state.bubbles.forEach((b) => drawBubble(b, now));
+  requestAnimationFrame(draw);
+}
+
+function drawFloor() {
+  ctx.fillStyle = "#241c12";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.strokeStyle = "rgba(0,0,0,0.25)"; // plank seams
+  ctx.lineWidth = 1;
+  for (let y = 24; y < canvas.height; y += 34) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(canvas.width, y);
+    ctx.stroke();
+  }
+  ctx.fillStyle = "#8a765c";
+  ctx.font = "italic 13px Georgia";
+  ctx.textAlign = "left";
+  ctx.fillText("The Rusty Cleaver — a tavern that keeps score", 16, 26);
+}
+
+function drawZone(z) {
+  ctx.strokeStyle = "#4a3a24";
+  ctx.lineWidth = 1.5;
+  roundRect(z.x, z.y, z.w, z.h, 10);
+  ctx.stroke();
+  ctx.fillStyle = "rgba(217,164,65,0.05)";
+  roundRect(z.x, z.y, z.w, z.h, 10);
+  ctx.fill();
+  ctx.fillStyle = "#8a765c";
+  ctx.font = "11px Courier New";
+  ctx.textAlign = "left";
+  ctx.fillText(z.label.toUpperCase(), z.x + 8, z.y + 16);
+}
+
+function zoneMates(zone) {
+  return [...state.souls.entries()].filter(([, s]) => s.zone === zone).map(([n]) => n);
+}
+
+function positionOf(name) {
+  const soul = state.souls.get(name);
+  const z = ZONES[soul.zone] || ZONES.tavern;
+  const mates = zoneMates(soul.zone);
+  const idx = mates.indexOf(name);
+  const x = z.x + z.w / 2 + (idx - (mates.length - 1) / 2) * 52;
+  const y = z.y + z.h - 44;
+  return { x, y };
+}
+
+function drawSoul(name) {
+  const soul = state.souls.get(name);
+  const { x, y } = positionOf(name);
+  ctx.beginPath();
+  ctx.arc(x, y, 17, 0, Math.PI * 2);
+  ctx.fillStyle = soul.color;
+  ctx.fill();
+  ctx.lineWidth = soul.kind === "player" ? 3 : 1.5;
+  ctx.strokeStyle = soul.kind === "player" ? "#e8dcc5" : "#120d08";
+  ctx.stroke();
+  ctx.fillStyle = "#120d08";
+  ctx.font = "bold 13px Georgia";
+  ctx.textAlign = "center";
+  ctx.fillText(name[0], x, y + 4.5);
+  ctx.fillStyle = "#e8dcc5";
+  ctx.font = "12px Georgia";
+  ctx.fillText(name, x, y + 34);
+}
+
+function addBubble(name, text, fromPlayer) {
+  if (!name || !text) return;
+  state.bubbles = state.bubbles.filter((b) => b.name !== name); // one per speaker
+  state.bubbles.push({ name, text, born: performance.now(), fromPlayer });
+}
+
+function drawBubble(bubble, now) {
+  if (!state.souls.has(bubble.name)) return;
+  const { x, y } = positionOf(bubble.name);
+  const age = now - bubble.born;
+  const alpha = age < BUBBLE_MS - 900 ? 1 : Math.max(0, (BUBBLE_MS - age) / 900);
+  const lines = wrap(bubble.text, 30, 3);
+  const w = Math.min(230, Math.max(...lines.map((l) => l.length)) * 6.4 + 20);
+  const h = lines.length * 15 + 14;
+  let bx = Math.min(Math.max(x - w / 2, 6), canvas.width - w - 6);
+  let by = Math.max(y - 44 - h, 6);
+
+  ctx.globalAlpha = alpha;
+  ctx.fillStyle = bubble.fromPlayer ? "#3a4a5c" : "#efe3c8";
+  roundRect(bx, by, w, h, 8);
+  ctx.fill();
+  ctx.beginPath(); // tail
+  ctx.moveTo(x - 5, by + h);
+  ctx.lineTo(x + 5, by + h);
+  ctx.lineTo(x, by + h + 8);
+  ctx.fill();
+  ctx.fillStyle = bubble.fromPlayer ? "#e8dcc5" : "#241c12";
+  ctx.font = "12px Georgia";
+  ctx.textAlign = "left";
+  lines.forEach((line, i) => ctx.fillText(line, bx + 10, by + 18 + i * 15));
+  ctx.globalAlpha = 1;
+}
+
+function wrap(text, width, maxLines) {
+  const words = String(text).split(/\s+/);
+  const lines = [];
+  let line = "";
+  for (const word of words) {
+    if ((line + " " + word).trim().length > width) {
+      lines.push(line.trim());
+      line = word;
+      if (lines.length === maxLines) {
+        lines[maxLines - 1] += "…";
+        return lines;
+      }
+    } else {
+      line += " " + word;
+    }
+  }
+  if (line.trim()) lines.push(line.trim());
+  return lines.slice(0, maxLines);
+}
+
+function roundRect(x, y, w, h, r) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + w, y, x + w, y + h, r);
+  ctx.arcTo(x + w, y + h, x, y + h, r);
+  ctx.arcTo(x, y + h, x, y, r);
+  ctx.arcTo(x, y, x + w, y, r);
+  ctx.closePath();
+}
+
+// ---------------------------------------------------------------------------
+// HUD (right panel + top bar)
+// ---------------------------------------------------------------------------
+
+function renderCards() {
+  const box = document.getElementById("cards");
+  box.innerHTML = "";
+  const now = performance.now();
+  for (const [name, card] of state.cards) {
+    const el = document.createElement("div");
+    el.className = "card" + (card.flashUntil > now ? " flash" : "");
+    el.innerHTML =
+      `<div class="head"><span class="name">${name}</span>` +
+      `<span class="chip ${card.level}">${card.level}</span></div>` +
+      `<div class="bond">bond with Ragnar: <b>${card.bond.toFixed(1)}</b> / 100</div>` +
+      `<div class="grievance">${
+        card.lastGrievance ? "remembers: “" + escapeHtml(card.lastGrievance) + "”"
+                           : "no grievances yet"
+      }</div>`;
+    box.appendChild(el);
+  }
+  document.getElementById("cost").textContent = state.cost
+    ? `${state.cost.model}: ${state.cost.calls} calls (${state.cost.cached_calls} cached) — $${state.cost.total_cost.toFixed(4)}`
+    : "templated dialogue — $0";
+}
+
+function renderPhase() {
+  document.querySelectorAll("#phase-indicator .phase").forEach((el) => {
+    el.classList.toggle("active", el.dataset.phase === state.phase);
+  });
+}
+
+function escapeHtml(text) {
+  const div = document.createElement("div");
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+function setStatus(message) {
+  document.getElementById("status").textContent = message || "";
+}
+
+// ---------------------------------------------------------------------------
+// Controls
+// ---------------------------------------------------------------------------
+
+document.getElementById("controls").addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const input = document.getElementById("line");
+  const text = input.value.trim();
+  if (!text) return;
+  setStatus("");
+  const res = await fetch("/line", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      player: "Ragnar",
+      text,
+      kind: document.getElementById("kind").value,
+      npc: document.getElementById("npc").value,
+    }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    setStatus(err.error || `error ${res.status}`);
+    return;
+  }
+  input.value = "";
+});
+
+document.getElementById("reset").addEventListener("click", async () => {
+  await fetch("/reset", { method: "POST" });
+  state.cursor = 0;
+  state.bubbles = [];
+  state.cost = null;
+  setStatus("");
+  await seedFromSnapshot();
+});
+
+boot();

--- a/examples/butcher_remembers/app.js
+++ b/examples/butcher_remembers/app.js
@@ -5,6 +5,14 @@
 // floats fading speech bubbles on speech/beat events, and keeps the grudge
 // HUD (level chip, bond, last grievance) + director phase chip in sync.
 // No frameworks, no assets, no build step.
+// Updated: 2026-07-02 (BD-2, 90s demo) — bottom free-play bar: Send posts
+// /line WITHOUT a kind (the server's keyword classifier decides, echoed in
+// #free-status); Export bjorn.soul / ragnar.player.soul download the real
+// .soul files (Content-Disposition); Import soul posts raw bytes to
+// /import_soul and re-seeds from the returned snapshot; "Ask the innkeeper"
+// hits /reputation and floats Astrid's line as a long-lived amber SPECIAL
+// bubble + notoriety chip. Cost overlay (top-right, collapsible) polls /cost
+// after each send; hidden while /snapshot reports engine === "templated".
 
 "use strict";
 
@@ -22,14 +30,16 @@ const ZONES = {
 const SOUL_COLORS = { Bjorn: "#c1653f", Astrid: "#5f9e8f", Ragnar: "#7292c4" };
 const FALLBACK_COLORS = ["#a07ac0", "#b3a24c", "#c47292"];
 const BUBBLE_MS = 4200; // how long a speech bubble lives
+const SPECIAL_BUBBLE_MS = 9000; // the reputation gut-punch line lingers
 
 const state = {
   souls: new Map(), // name -> {kind:'npc'|'player', zone, color}
   cards: new Map(), // npc name -> {level, bond, lastGrievance, flashUntil}
-  bubbles: [], // {name, text, born, fromPlayer}
+  bubbles: [], // {name, text, born, fromPlayer, special}
   phase: "BUILD_UP",
   cost: null,
   cursor: 0,
+  engine: "templated", // from /snapshot — gates the cost overlay
 };
 
 // ---------------------------------------------------------------------------
@@ -58,6 +68,8 @@ async function seedFromSnapshot() {
   });
   snap.players.forEach((p) => ensureSoul(p.name, "player", p.zone));
   state.phase = snap.phase;
+  state.engine = snap.engine || "templated";
+  document.getElementById("cost-overlay").classList.toggle("hidden", state.engine === "templated");
   renderCards();
   renderPhase();
 }
@@ -119,12 +131,16 @@ function apply(e) {
 // Canvas rendering
 // ---------------------------------------------------------------------------
 
+function bubbleLife(bubble) {
+  return bubble.special ? SPECIAL_BUBBLE_MS : BUBBLE_MS;
+}
+
 function draw(now) {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   drawFloor();
   Object.values(ZONES).forEach(drawZone);
   for (const name of state.souls.keys()) drawSoul(name);
-  state.bubbles = state.bubbles.filter((b) => now - b.born < BUBBLE_MS);
+  state.bubbles = state.bubbles.filter((b) => now - b.born < bubbleLife(b));
   state.bubbles.forEach((b) => drawBubble(b, now));
   requestAnimationFrame(draw);
 }
@@ -193,25 +209,34 @@ function drawSoul(name) {
   ctx.fillText(name, x, y + 34);
 }
 
-function addBubble(name, text, fromPlayer) {
+function addBubble(name, text, fromPlayer, special) {
   if (!name || !text) return;
   state.bubbles = state.bubbles.filter((b) => b.name !== name); // one per speaker
-  state.bubbles.push({ name, text, born: performance.now(), fromPlayer });
+  state.bubbles.push({ name, text, born: performance.now(), fromPlayer, special: !!special });
 }
 
 function drawBubble(bubble, now) {
   if (!state.souls.has(bubble.name)) return;
   const { x, y } = positionOf(bubble.name);
   const age = now - bubble.born;
-  const alpha = age < BUBBLE_MS - 900 ? 1 : Math.max(0, (BUBBLE_MS - age) / 900);
-  const lines = wrap(bubble.text, 30, 3);
+  const life = bubbleLife(bubble);
+  const alpha = age < life - 900 ? 1 : Math.max(0, (life - age) / 900);
+  const maxLines = bubble.special ? 4 : 3;
+  const lines = wrap(bubble.text, 30, maxLines);
   const w = Math.min(230, Math.max(...lines.map((l) => l.length)) * 6.4 + 20);
   const h = lines.length * 15 + 14;
   let bx = Math.min(Math.max(x - w / 2, 6), canvas.width - w - 6);
   let by = Math.max(y - 44 - h, 6);
 
   ctx.globalAlpha = alpha;
-  ctx.fillStyle = bubble.fromPlayer ? "#3a4a5c" : "#efe3c8";
+  if (bubble.special) {
+    // The reputation gut-punch: amber, glowing, unmistakable.
+    ctx.shadowColor = "#d9a441";
+    ctx.shadowBlur = 14;
+    ctx.fillStyle = "#d9a441";
+  } else {
+    ctx.fillStyle = bubble.fromPlayer ? "#3a4a5c" : "#efe3c8";
+  }
   roundRect(bx, by, w, h, 8);
   ctx.fill();
   ctx.beginPath(); // tail
@@ -219,8 +244,9 @@ function drawBubble(bubble, now) {
   ctx.lineTo(x + 5, by + h);
   ctx.lineTo(x, by + h + 8);
   ctx.fill();
-  ctx.fillStyle = bubble.fromPlayer ? "#e8dcc5" : "#241c12";
-  ctx.font = "12px Georgia";
+  ctx.shadowBlur = 0;
+  ctx.fillStyle = bubble.special ? "#241c12" : bubble.fromPlayer ? "#e8dcc5" : "#241c12";
+  ctx.font = bubble.special ? "bold 12px Georgia" : "12px Georgia";
   ctx.textAlign = "left";
   lines.forEach((line, i) => ctx.fillText(line, bx + 10, by + 18 + i * 15));
   ctx.globalAlpha = 1;
@@ -299,8 +325,43 @@ function setStatus(message) {
 }
 
 // ---------------------------------------------------------------------------
-// Controls
+// Controls — right panel (explicit kind) + bottom free-play bar (auto kind)
 // ---------------------------------------------------------------------------
+
+function setFreeStatus(message) {
+  document.getElementById("free-status").textContent = message || "";
+}
+
+async function refreshCost() {
+  // Only meaningful when a metered LLM engine is active.
+  if (state.engine === "templated") return;
+  try {
+    const cost = await fetch("/cost").then((r) => r.json());
+    const cached = cost.cached_calls ? ` (+${cost.cached_calls} cached)` : "";
+    document.getElementById("cost-lines").textContent =
+      `${cost.calls} LLM line${cost.calls === 1 ? "" : "s"}${cached} — ${cost.model}`;
+    document.getElementById("cost-total").textContent =
+      `this session: $${cost.total_cost.toFixed(4)}`;
+    document.getElementById("cost-deepseek").textContent =
+      `would cost on DeepSeek: $${cost.projected_deepseek.toFixed(5)}`;
+    document.getElementById("cost-hour").textContent =
+      `per player-hour: $${cost.cost_per_player_hour.toFixed(4)}`;
+  } catch (err) {
+    /* cost readout is best-effort — never break play */
+  }
+}
+
+async function postLine(payload) {
+  const res = await fetch("/line", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error || `error ${res.status}`);
+  refreshCost();
+  return body;
+}
 
 document.getElementById("controls").addEventListener("submit", async (e) => {
   e.preventDefault();
@@ -308,22 +369,38 @@ document.getElementById("controls").addEventListener("submit", async (e) => {
   const text = input.value.trim();
   if (!text) return;
   setStatus("");
-  const res = await fetch("/line", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
+  try {
+    await postLine({
       player: "Ragnar",
       text,
       kind: document.getElementById("kind").value,
       npc: document.getElementById("npc").value,
-    }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({}));
-    setStatus(err.error || `error ${res.status}`);
-    return;
+    });
+    input.value = "";
+  } catch (err) {
+    setStatus(err.message);
   }
-  input.value = "";
+});
+
+// Free-play: no "kind" — the server's keyword classifier decides, and we echo
+// what it heard so the tone flip is legible on camera.
+document.getElementById("freeplay").addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const input = document.getElementById("free-line");
+  const text = input.value.trim();
+  if (!text) return;
+  setFreeStatus("");
+  try {
+    const summary = await postLine({
+      player: "Ragnar",
+      text,
+      npc: document.getElementById("npc").value,
+    });
+    input.value = "";
+    setFreeStatus(summary.kind === "neutral" ? "" : `heard as: ${summary.kind}`);
+  } catch (err) {
+    setFreeStatus(err.message);
+  }
 });
 
 document.getElementById("reset").addEventListener("click", async () => {
@@ -332,7 +409,85 @@ document.getElementById("reset").addEventListener("click", async () => {
   state.bubbles = [];
   state.cost = null;
   setStatus("");
+  setFreeStatus("");
+  document.getElementById("notoriety-chip").className = "chip hidden";
   await seedFromSnapshot();
+});
+
+// ---------------------------------------------------------------------------
+// Soul file actions — export / import / the reputation gut-punch
+// ---------------------------------------------------------------------------
+
+async function downloadSoul(url, payload, fallbackName) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload || {}),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    setFreeStatus(err.error || `error ${res.status}`);
+    return;
+  }
+  const blob = await res.blob();
+  const disposition = res.headers.get("Content-Disposition") || "";
+  const match = disposition.match(/filename="?([^";]+)"?/);
+  const name = match ? match[1] : fallbackName;
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = name;
+  a.click();
+  URL.revokeObjectURL(a.href);
+  setFreeStatus(`${name} saved — ${Math.round(blob.size / 1024)} KB of memory`);
+}
+
+document.getElementById("export-npc").addEventListener("click", () => {
+  downloadSoul("/export_soul", { npc: "Bjorn" }, "bjorn.soul");
+});
+
+document.getElementById("export-player").addEventListener("click", () => {
+  downloadSoul("/export_player", { player: "Ragnar" }, "ragnar.player.soul");
+});
+
+document.getElementById("import-btn").addEventListener("click", () => {
+  document.getElementById("soul-file").click();
+});
+
+document.getElementById("soul-file").addEventListener("change", async (e) => {
+  const file = e.target.files[0];
+  e.target.value = ""; // allow re-importing the same file
+  if (!file) return;
+  const bytes = await file.arrayBuffer();
+  const res = await fetch("/import_soul", {
+    method: "POST",
+    headers: { "Content-Type": "application/octet-stream" },
+    body: bytes,
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    setFreeStatus(body.error || `error ${res.status}`);
+    return;
+  }
+  state.bubbles = [];
+  await seedFromSnapshot(); // the imported grudge state, straight to the HUD
+  setFreeStatus(`${body.replaced} awakened from ${file.name} — they remember.`);
+});
+
+document.getElementById("ask-innkeeper").addEventListener("click", async () => {
+  const res = await fetch("/reputation?npc=Astrid&player=Ragnar");
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    setFreeStatus(body.error || `error ${res.status}`);
+    return;
+  }
+  addBubble(body.npc, body.line, false, true); // the gut-punch, in amber
+  const chip = document.getElementById("notoriety-chip");
+  chip.textContent = body.notoriety;
+  chip.className = `chip ${body.notoriety}`;
+});
+
+document.getElementById("cost-toggle").addEventListener("click", () => {
+  document.getElementById("cost-body").classList.toggle("hidden");
 });
 
 boot();

--- a/examples/butcher_remembers/index.html
+++ b/examples/butcher_remembers/index.html
@@ -2,7 +2,12 @@
      Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — canvas tavern
      (zones + soul circles + speech bubbles), right-panel grudge HUD, top-bar
      director phase indicator, and the talk controls. No frameworks, no CDN,
-     no build step — served whole by server.py. -->
+     no build step — served whole by server.py.
+     Updated: 2026-07-02 (BD-2, 90s demo) — bottom free-play bar (Speak as
+     Ragnar + Send, kind auto-classified server-side; export bjorn.soul /
+     import soul / export ragnar.player.soul; "Ask the innkeeper about me"
+     reputation gut-punch + notoriety chip) and the collapsible top-right
+     cost overlay (hidden on the templated engine). Still vanilla. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -22,6 +27,16 @@
     </div>
     <div id="cost">templated dialogue — $0</div>
   </header>
+
+  <div id="cost-overlay" class="hidden">
+    <button type="button" id="cost-toggle">$ cost</button>
+    <div id="cost-body">
+      <div id="cost-lines">0 LLM lines</div>
+      <div id="cost-total">this session: $0.0000</div>
+      <div id="cost-deepseek">would cost on DeepSeek: $0.00000</div>
+      <div id="cost-hour">per player-hour: $0.0000</div>
+    </div>
+  </div>
 
   <main>
     <canvas id="tavern" width="640" height="460"></canvas>
@@ -58,6 +73,28 @@
       </form>
     </aside>
   </main>
+
+  <footer id="bottombar">
+    <form id="freeplay">
+      <input id="free-line" type="text" autocomplete="off"
+             placeholder="Speak as Ragnar…" maxlength="200">
+      <button type="submit" id="send">Send</button>
+    </form>
+    <div id="soul-actions">
+      <button type="button" id="export-npc" title="Download Bjorn as a portable .soul file">
+        &#11015; Export bjorn.soul</button>
+      <button type="button" id="import-btn" title="Awaken an exported .soul — the NPC remembers">
+        &#11014; Import soul</button>
+      <input type="file" id="soul-file" accept=".soul" hidden>
+      <button type="button" id="export-player" title="Download Ragnar's portable reputation">
+        &#11015; Export ragnar.player.soul</button>
+      <button type="button" id="ask-innkeeper"
+              title="Astrid has never been wronged by you — she reads your player.soul">
+        &#127976; Ask the innkeeper about me</button>
+      <span id="notoriety-chip" class="chip hidden"></span>
+      <span id="free-status"></span>
+    </div>
+  </footer>
 
   <script src="/app.js"></script>
 </body>

--- a/examples/butcher_remembers/index.html
+++ b/examples/butcher_remembers/index.html
@@ -1,0 +1,64 @@
+<!-- index.html — "The Butcher Remembers" 2D client shell.
+     Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — canvas tavern
+     (zones + soul circles + speech bubbles), right-panel grudge HUD, top-bar
+     director phase indicator, and the talk controls. No frameworks, no CDN,
+     no build step — served whole by server.py. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>The Butcher Remembers</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <header id="topbar">
+    <h1>The Butcher <span>Remembers</span></h1>
+    <div id="phase-indicator" title="Pulse director phase">
+      <span class="phase" data-phase="BUILD_UP">BUILD_UP</span>
+      <span class="phase" data-phase="PEAK">PEAK</span>
+      <span class="phase" data-phase="FADE">FADE</span>
+      <span class="phase" data-phase="RELAX">RELAX</span>
+    </div>
+    <div id="cost">templated dialogue — $0</div>
+  </header>
+
+  <main>
+    <canvas id="tavern" width="640" height="460"></canvas>
+
+    <aside id="hud">
+      <h2>Grudge ledger</h2>
+      <div id="cards"></div>
+
+      <h2>Speak as Ragnar</h2>
+      <form id="controls">
+        <div class="row">
+          <label>to
+            <select id="npc">
+              <option value="Bjorn">Bjorn (butcher)</option>
+              <option value="Astrid">Astrid (innkeeper)</option>
+            </select>
+          </label>
+          <label>act
+            <select id="kind">
+              <option value="neutral">neutral</option>
+              <option value="insult">insult</option>
+              <option value="theft">theft</option>
+              <option value="betrayal">betrayal</option>
+            </select>
+          </label>
+        </div>
+        <input id="line" type="text" autocomplete="off"
+               placeholder="Say something to the butcher..." maxlength="200">
+        <div class="row">
+          <button type="submit" id="say">Say it</button>
+          <button type="button" id="reset">Reset world</button>
+        </div>
+        <div id="status"></div>
+      </form>
+    </aside>
+  </main>
+
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/examples/butcher_remembers/server.py
+++ b/examples/butcher_remembers/server.py
@@ -4,7 +4,7 @@
 # Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — Serves the 2D canvas
 #   client (index.html / app.js / style.css, same folder) and bridges HTTP onto
 #   the Game Profile's GameWorld. Stdlib only: http.server.ThreadingHTTPServer +
-#   json + urllib.parse — no frameworks, no build step, no npm.
+#   json + urllib — no frameworks, no build step, no npm.
 #
 #   Async bridge: GrudgeKernel/GameWorld APIs are async, HTTP handlers are
 #   threads. ONE background thread runs ONE asyncio event loop forever; every
@@ -12,18 +12,36 @@
 #   and blocks on the result. That serializes all world mutation on one loop —
 #   no per-request loops, no locks.
 #
+# Updated: 2026-07-02 (experiment/npc-soul-grudge-kernel, BD-2) — the 90-second
+#   demo script. Added: POST /export_soul + /export_player (.soul downloads —
+#   THE FILE beat), POST /import_soul (raw .soul bytes -> GrudgeKernel.awaken
+#   -> replace_npc swaps the NPC in place; GameWorld stays frozen, the swap +
+#   snapshot-cache refresh live HERE), GET /reputation (Astrid reads Ragnar's
+#   portable player.soul reputation — the gut-punch beat), GET /cost (CostMeter
+#   summary + deepseek-v3.2 projection + cost-per-player-hour; zeros when
+#   templated), --engine templated|claude|deepseek (LLMDialogueEngine over the
+#   local claude CLI or the DeepSeek chat API; missing DEEPSEEK_API_KEY falls
+#   back to templated with a warning), and classify_kind() — a deterministic
+#   keyword classifier so free-play POST /line needs no "kind" field.
+#
 #   Endpoints:
 #     GET  /            -> index.html (plus /app.js, /style.css — whitelisted)
-#     GET  /snapshot    -> GameWorld.snapshot() (zones, phase, per-NPC HUD state)
+#     GET  /snapshot    -> GameWorld.snapshot() + {"engine": ...} (HUD bootstrap)
 #     GET  /events?since=N -> world events with t > N (poll cursor)
+#     GET  /cost        -> cost meter summary (zeros when templated)
+#     GET  /reputation?npc=Astrid&player=Ragnar -> {line, notoriety}
 #     POST /line {player, text, kind?, npc?} -> world.beat(...) summary
+#                                               (kind absent -> classify_kind)
 #     POST /reset       -> rebuild the world fresh, return its snapshot
+#     POST /export_soul {npc?}      -> the NPC's .soul bytes as a download
+#     POST /export_player {player?} -> the player's .player.soul as a download
+#     POST /import_soul <raw .soul bytes> -> awaken + swap the same-named NPC
 #
 #   World: Bjorn (butcher, stall) + Astrid (innkeeper, tables) as GrudgeKernels,
 #   Ragnar as the PlayerSoul (door). TemplatedDialogueEngine by DEFAULT —
-#   deterministic and free; the LLM switch is BD-2's job. --scripted auto-plays
-#   the canonical arc (greet -> trade -> betrayal -> theft -> Astrid control ->
-#   return to Bjorn, who remembers) with a short delay between beats.
+#   deterministic and free. --scripted auto-plays the canonical arc (greet ->
+#   trade -> betrayal -> theft -> Astrid control -> return to Bjorn, who
+#   remembers) with a short delay between beats.
 #
 # Run:  uv run python examples/butcher_remembers/server.py --scripted
 # Then: open http://localhost:8777
@@ -33,13 +51,24 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
+import re
+import tempfile
 import threading
 import time
+import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
-from soul_protocol.profiles.game import GameWorld, GrudgeKernel, PlayerSoul
+from soul_protocol.profiles.game import (
+    CostMeter,
+    GameWorld,
+    GrudgeKernel,
+    LLMDialogueEngine,
+    PlayerSoul,
+    claude_cli_generate,
+)
 
 ROOT = Path(__file__).resolve().parent
 DEFAULT_PORT = 8777
@@ -70,11 +99,168 @@ SCRIPT: list[tuple[str, str, str]] = [
 ]
 
 
-async def build_world(session_path: str | None = None) -> GameWorld:
+# ---------------------------------------------------------------------------
+# Free-play machinery: kind auto-classifier, engine switch, cost meter, and
+# the .soul import/export helpers (BD-2).
+# ---------------------------------------------------------------------------
+
+# The bottom-bar input has no "kind" dropdown, so free-play lines are
+# classified with a tiny deterministic keyword map. First matching rule wins,
+# checked in this order — theft before betrayal so "I pocketed it while you
+# argued with the guard" reads as the theft it is. An explicit "kind" in the
+# POST body always overrides the classifier.
+_KIND_RULES: list[tuple[str, str]] = [
+    (
+        "theft",
+        r"\b(steal|stole|stolen|pocket\w*|rob|robbed|robbing|pilfer\w*|swipe[ds]?|thief|theft)\b",
+    ),
+    (
+        "betrayal",
+        r"\b(betray\w*|lie[ds]?|lying|frame[ds]?|framing|guard|snitch\w*|traitor|sold\s+you\s+out)\b",
+    ),
+    (
+        "insult",
+        r"\b(insult\w*|maggot\w*|fool|idiot|coward|stink\w*|reek\w*|ugly|worthless|scum|swine|pig|dog|liar|wretch\w*)\b",
+    ),
+]
+
+
+def classify_kind(text: str) -> str:
+    """Classify a free-play line into a transgression kind. Deterministic, no LLM."""
+    lowered = str(text).lower()
+    for kind, pattern in _KIND_RULES:
+        if re.search(pattern, lowered):
+            return kind
+    return "neutral"
+
+
+async def deepseek_generate(prompt: str) -> str:
+    """Generate a line via DeepSeek's OpenAI-compatible chat API (deepseek-chat).
+
+    Stdlib-only: urllib runs in a worker thread (asyncio.to_thread) so the world
+    loop never blocks on the network. Raises on missing key / HTTP / parse
+    errors — LLMDialogueEngine catches and falls back to the template.
+    """
+    api_key = os.environ.get("DEEPSEEK_API_KEY", "")
+    if not api_key:
+        raise RuntimeError("DEEPSEEK_API_KEY is not set")
+    payload = json.dumps(
+        {
+            "model": "deepseek-chat",
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 150,
+            "temperature": 0.8,
+        }
+    ).encode("utf-8")
+
+    def _call() -> str:
+        request = urllib.request.Request(
+            "https://api.deepseek.com/chat/completions",
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=60) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+        return body["choices"][0]["message"]["content"]
+
+    return (await asyncio.to_thread(_call)).strip()
+
+
+def build_engine(requested: str):
+    """Resolve --engine into (active_name, dialogue_engine | None, meter | None).
+
+    templated -> (None, None): kernels default to the free deterministic
+                 TemplatedDialogueEngine; /cost reports zeros.
+    claude    -> LLMDialogueEngine over the local `claude` CLI (no API key,
+                 ~20-40s per line), metered as the $0 "claude-cli" model so
+                 token counts still accrue for the DeepSeek projection.
+    deepseek  -> LLMDialogueEngine over the DeepSeek chat API, metered at
+                 deepseek-v3.2 rates. Missing DEEPSEEK_API_KEY: print a
+                 warning and fall back to templated — never crash the demo.
+    """
+    if requested == "claude":
+        meter = CostMeter(claude_cli_generate, model="claude-cli")
+        return "claude", LLMDialogueEngine(meter), meter
+    if requested == "deepseek":
+        if not os.environ.get("DEEPSEEK_API_KEY"):
+            print(
+                "[engine] DEEPSEEK_API_KEY is not set — falling back to the "
+                "templated engine (deterministic, $0).",
+                flush=True,
+            )
+            return "templated", None, None
+        meter = CostMeter(deepseek_generate, model="deepseek-v3.2")
+        return "deepseek", LLMDialogueEngine(meter), meter
+    return "templated", None, None
+
+
+def kernel_named(world: GameWorld, npc_name: str | None) -> GrudgeKernel:
+    """The named NPC kernel (case-insensitive), or the first when unnamed."""
+    if not npc_name:
+        return world.npcs[0]
+    for kernel in world.npcs:
+        if kernel.npc_name.lower() == str(npc_name).lower():
+            return kernel
+    known = sorted(k.npc_name for k in world.npcs)
+    raise LookupError(f"unknown npc {npc_name!r}; known: {known}")
+
+
+def player_named(world: GameWorld, player_name: str | None) -> PlayerSoul:
+    """The named player soul (case-insensitive), or the first when unnamed."""
+    if not player_name:
+        return world.players[0]
+    for player in world.players:
+        if player.name.lower() == str(player_name).lower():
+            return player
+    known = sorted(p.name for p in world.players)
+    raise LookupError(f"unknown player {player_name!r}; known: {known}")
+
+
+async def replace_npc(world: GameWorld, kernel: GrudgeKernel) -> str:
+    """Swap the same-named NPC for an awakened kernel — demo-side on purpose.
+
+    GameWorld (GP-5) stays frozen: the swap lives here, mutating world.npcs in
+    place (zones are keyed by name, so the zone sticks) and refreshing the two
+    private snapshot caches so the HUD immediately shows the IMPORTED grudge
+    state instead of the pre-import one. Emits nothing into the event stream —
+    the client re-bootstraps from /snapshot after an import.
+    """
+    for i, existing in enumerate(world.npcs):
+        if existing.npc_name == kernel.npc_name:
+            world.npcs[i] = kernel
+            break
+    else:
+        known = sorted(k.npc_name for k in world.npcs)
+        raise LookupError(f"imported soul {kernel.npc_name!r} matches no npc; known: {known}")
+
+    for player in world.players:
+        key = (kernel.npc_name, player.did)
+        world._grudge_levels[key] = await kernel.grudge_level(player.did)
+        grievances = await kernel.grievances(player.did)
+        if grievances:
+            # The HUD's "remembers: ..." line — cite the worst recovered wrong,
+            # stripped of the machine marker prefix.
+            worst = max(grievances, key=lambda g: g.severity)
+            world._last_grievance[key] = worst.content.split(" wronged me: ", 1)[-1]
+        else:
+            world._last_grievance.pop(key, None)
+    return kernel.npc_name
+
+
+async def build_world(session_path: str | None = None, dialogue_engine=None) -> GameWorld:
     """The Butcher world: two npc.souls + one player.soul, zoned for the canvas."""
-    bjorn = await GrudgeKernel.birth(name="Bjorn", archetype="The Butcher")
+    bjorn = await GrudgeKernel.birth(
+        name="Bjorn", archetype="The Butcher", dialogue_engine=dialogue_engine
+    )
     astrid = await GrudgeKernel.birth(
-        name="Astrid", archetype="The Innkeeper", persona=ASTRID_PERSONA
+        name="Astrid",
+        archetype="The Innkeeper",
+        persona=ASTRID_PERSONA,
+        dialogue_engine=dialogue_engine,
     )
     ragnar = await PlayerSoul.birth(name="Ragnar")
     world = GameWorld([bjorn, astrid], [ragnar], session_path=session_path)
@@ -91,8 +277,9 @@ class DemoState:
     onto the loop thread — HTTP handler threads never touch the world directly.
     """
 
-    def __init__(self, session_path: str | None = None) -> None:
+    def __init__(self, session_path: str | None = None, engine: str = "templated") -> None:
         self.session_path = session_path
+        self.engine_name, self.dialogue_engine, self.meter = build_engine(engine)
         self.loop = asyncio.new_event_loop()
         self._thread = threading.Thread(
             target=self.loop.run_forever, name="butcher-world-loop", daemon=True
@@ -111,12 +298,86 @@ class DemoState:
 
     # ---- coroutines (always executed on the world loop) -------------------
 
+    def _snapshot(self) -> dict:
+        """world.snapshot() stamped with the active engine (the client uses it
+        to decide whether the cost overlay is meaningful)."""
+        snap = self.world.snapshot()
+        snap["engine"] = self.engine_name
+        return snap
+
     async def reset(self) -> dict:
-        self.world = await build_world(self.session_path)
-        return self.world.snapshot()
+        self.world = await build_world(self.session_path, dialogue_engine=self.dialogue_engine)
+        if self.meter is not None:
+            self.world.attach_meter(self.meter)
+        return self._snapshot()
 
     async def snapshot(self) -> dict:
-        return self.world.snapshot()
+        return self._snapshot()
+
+    async def export_soul(self, npc_name: str | None) -> tuple[str, bytes]:
+        """Export one NPC to .soul bytes — THE artifact moment of the demo."""
+        kernel = kernel_named(self.world, npc_name)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "export.soul"
+            await kernel.export(str(path))
+            data = path.read_bytes()
+        return f"{kernel.npc_name.lower()}.soul", data
+
+    async def export_player(self, player_name: str | None) -> tuple[str, bytes]:
+        """Export a player.soul — the portable reputation the player OWNS."""
+        player = player_named(self.world, player_name)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "player.soul"
+            await player.export(str(path))
+            data = path.read_bytes()
+        return f"{player.name.lower()}.player.soul", data
+
+    async def import_soul(self, data: bytes) -> dict:
+        """Awaken a .soul from raw bytes and swap it in for the same-named NPC."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "import.soul"
+            path.write_bytes(data)
+            kernel = await GrudgeKernel.awaken(str(path), dialogue_engine=self.dialogue_engine)
+        if kernel.npc_name == "Astrid":
+            kernel.persona = ASTRID_PERSONA  # persona is not persisted in the .soul
+        replaced = await replace_npc(self.world, kernel)
+        return {"replaced": replaced, "snapshot": self._snapshot()}
+
+    async def reputation(self, npc_name: str, player_name: str) -> dict:
+        """THE gut-punch: a never-wronged NPC reads the player's portable
+        reputation off their player.soul and reacts to it."""
+        kernel = kernel_named(self.world, npc_name)
+        player = player_named(self.world, player_name)
+        line, notoriety = await kernel.react_to_reputation(player)
+        return {
+            "npc": kernel.npc_name,
+            "player": player.name,
+            "line": line,
+            "notoriety": notoriety,
+        }
+
+    async def cost(self) -> dict:
+        """The cost readout: meter summary + DeepSeek projection. Zeros/nulls
+        when the templated engine is active (no meter, nothing to meter)."""
+        if self.meter is None:
+            return {
+                "engine": self.engine_name,
+                "model": None,
+                "calls": 0,
+                "cached_calls": 0,
+                "tokens_in": 0,
+                "tokens_out": 0,
+                "total_cost": 0.0,
+                "avg_latency": 0.0,
+                "cost_per_100_lines": 0.0,
+                "projected_deepseek": 0.0,
+                "cost_per_player_hour": 0.0,
+            }
+        summary = self.meter.summary()
+        summary["engine"] = self.engine_name
+        summary["projected_deepseek"] = self.meter.project("deepseek-v3.2")
+        summary["cost_per_player_hour"] = self.meter.cost_per_player_hour()
+        return summary
 
     async def events_since(self, since: int) -> list[dict]:
         return [e for e in self.world.events() if e["t"] > since]
@@ -173,6 +434,20 @@ def make_handler(state: DemoState) -> type[BaseHTTPRequestHandler]:
                 raise ValueError("body must be a JSON object")
             return parsed
 
+        def _read_raw(self) -> bytes:
+            """The raw request body — /import_soul takes the .soul bytes as-is."""
+            length = int(self.headers.get("Content-Length") or 0)
+            return self.rfile.read(length) if length else b""
+
+        def _send_file(self, filename: str, data: bytes) -> None:
+            """Send bytes as a browser download (Content-Disposition attachment)."""
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Disposition", f'attachment; filename="{filename}"')
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
         # ---- routes --------------------------------------------------------
 
         def do_GET(self) -> None:  # noqa: N802 — stdlib naming
@@ -190,6 +465,16 @@ def make_handler(state: DemoState) -> type[BaseHTTPRequestHandler]:
                     self._send_json({"error": "since must be an integer"}, 400)
                     return
                 self._send_json(state.run(state.events_since(since)))
+            elif parsed.path == "/cost":
+                self._send_json(state.run(state.cost()))
+            elif parsed.path == "/reputation":
+                query = parse_qs(parsed.query)
+                npc = query.get("npc", ["Astrid"])[0]
+                player = query.get("player", ["Ragnar"])[0]
+                try:
+                    self._send_json(state.run(state.reputation(npc, player)))
+                except LookupError as exc:
+                    self._send_json({"error": str(exc)}, 400)
             else:
                 self._send_json({"error": f"no such route {parsed.path}"}, 404)
 
@@ -198,11 +483,15 @@ def make_handler(state: DemoState) -> type[BaseHTTPRequestHandler]:
             if parsed.path == "/line":
                 try:
                     body = self._read_body()
+                    text = str(body.get("text", ""))
+                    # Free-play lines carry no "kind": classify deterministically.
+                    # An explicit kind (the panel dropdown) always wins.
+                    kind = str(body.get("kind") or classify_kind(text))
                     summary = state.run(
                         state.beat(
                             str(body.get("player", "Ragnar")),
-                            str(body.get("text", "")),
-                            str(body.get("kind", "neutral")),
+                            text,
+                            kind,
                             body.get("npc"),
                         )
                     )
@@ -212,6 +501,36 @@ def make_handler(state: DemoState) -> type[BaseHTTPRequestHandler]:
                 self._send_json(summary)
             elif parsed.path == "/reset":
                 self._send_json(state.run(state.reset()))
+            elif parsed.path == "/export_soul":
+                try:
+                    body = self._read_body()
+                    filename, data = state.run(state.export_soul(body.get("npc")))
+                except (ValueError, LookupError) as exc:
+                    self._send_json({"error": str(exc)}, 400)
+                    return
+                self._send_file(filename, data)
+            elif parsed.path == "/export_player":
+                try:
+                    body = self._read_body()
+                    filename, data = state.run(state.export_player(body.get("player")))
+                except (ValueError, LookupError) as exc:
+                    self._send_json({"error": str(exc)}, 400)
+                    return
+                self._send_file(filename, data)
+            elif parsed.path == "/import_soul":
+                raw = self._read_raw()
+                if not raw.startswith(b"PK"):
+                    self._send_json({"error": "body must be raw .soul bytes (a zip archive)"}, 400)
+                    return
+                try:
+                    result = state.run(state.import_soul(raw))
+                except LookupError as exc:
+                    self._send_json({"error": str(exc)}, 400)
+                    return
+                except Exception as exc:  # corrupt archive, bad soul payload, ...
+                    self._send_json({"error": f"could not awaken soul: {exc}"}, 400)
+                    return
+                self._send_json(result)
             else:
                 self._send_json({"error": f"no such route {parsed.path}"}, 404)
 
@@ -219,10 +538,10 @@ def make_handler(state: DemoState) -> type[BaseHTTPRequestHandler]:
 
 
 def create_server(
-    port: int = DEFAULT_PORT, session_path: str | None = None
+    port: int = DEFAULT_PORT, session_path: str | None = None, engine: str = "templated"
 ) -> tuple[ThreadingHTTPServer, DemoState]:
     """Build the world + HTTP server (not yet serving). port=0 -> ephemeral."""
-    state = DemoState(session_path)
+    state = DemoState(session_path, engine=engine)
     httpd = ThreadingHTTPServer(("127.0.0.1", port), make_handler(state))
     return httpd, state
 
@@ -256,10 +575,24 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--session-log", default=None, help="optional path for the session.jsonl mirror"
     )
+    parser.add_argument(
+        "--engine",
+        choices=["templated", "claude", "deepseek"],
+        default="templated",
+        help=(
+            "dialogue backend: templated (deterministic, $0, default), "
+            "claude (local claude CLI, no key, ~20-40s/line), "
+            "deepseek (DeepSeek chat API, needs DEEPSEEK_API_KEY)"
+        ),
+    )
     args = parser.parse_args(argv)
 
-    httpd, state = create_server(args.port, args.session_log)
-    print(f"The Butcher Remembers — http://localhost:{args.port}  (Ctrl+C to stop)", flush=True)
+    httpd, state = create_server(args.port, args.session_log, engine=args.engine)
+    print(
+        f"The Butcher Remembers — http://localhost:{args.port}  "
+        f"[engine: {state.engine_name}]  (Ctrl+C to stop)",
+        flush=True,
+    )
     if args.scripted:
         threading.Thread(
             target=play_script, args=(state, args.delay), name="butcher-script", daemon=True

--- a/examples/butcher_remembers/server.py
+++ b/examples/butcher_remembers/server.py
@@ -1,0 +1,277 @@
+# server.py — "The Butcher Remembers": stdlib-only demo server that renders the
+#   scripted grudge arc in a browser.
+#
+# Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — Serves the 2D canvas
+#   client (index.html / app.js / style.css, same folder) and bridges HTTP onto
+#   the Game Profile's GameWorld. Stdlib only: http.server.ThreadingHTTPServer +
+#   json + urllib.parse — no frameworks, no build step, no npm.
+#
+#   Async bridge: GrudgeKernel/GameWorld APIs are async, HTTP handlers are
+#   threads. ONE background thread runs ONE asyncio event loop forever; every
+#   handler marshals its coroutine onto it via asyncio.run_coroutine_threadsafe
+#   and blocks on the result. That serializes all world mutation on one loop —
+#   no per-request loops, no locks.
+#
+#   Endpoints:
+#     GET  /            -> index.html (plus /app.js, /style.css — whitelisted)
+#     GET  /snapshot    -> GameWorld.snapshot() (zones, phase, per-NPC HUD state)
+#     GET  /events?since=N -> world events with t > N (poll cursor)
+#     POST /line {player, text, kind?, npc?} -> world.beat(...) summary
+#     POST /reset       -> rebuild the world fresh, return its snapshot
+#
+#   World: Bjorn (butcher, stall) + Astrid (innkeeper, tables) as GrudgeKernels,
+#   Ragnar as the PlayerSoul (door). TemplatedDialogueEngine by DEFAULT —
+#   deterministic and free; the LLM switch is BD-2's job. --scripted auto-plays
+#   the canonical arc (greet -> trade -> betrayal -> theft -> Astrid control ->
+#   return to Bjorn, who remembers) with a short delay between beats.
+#
+# Run:  uv run python examples/butcher_remembers/server.py --scripted
+# Then: open http://localhost:8777
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from soul_protocol.profiles.game import GameWorld, GrudgeKernel, PlayerSoul
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_PORT = 8777
+
+# Static whitelist: path -> (filename in this folder, content type). Nothing
+# else on disk is reachable — no directory traversal surface.
+STATIC: dict[str, tuple[str, str]] = {
+    "/": ("index.html", "text/html; charset=utf-8"),
+    "/index.html": ("index.html", "text/html; charset=utf-8"),
+    "/app.js": ("app.js", "text/javascript; charset=utf-8"),
+    "/style.css": ("style.css", "text/css; charset=utf-8"),
+}
+
+ASTRID_PERSONA = (
+    "I am Astrid, the sharp-eyed innkeeper. I pour honest ale, keep clean rooms, "
+    "and miss nothing that happens under my roof."
+)
+
+# The canonical scripted arc: (npc, kind, player line). Greet -> trade ->
+# betrayal -> theft -> Astrid control beat -> back to Bjorn, who remembers.
+SCRIPT: list[tuple[str, str, str]] = [
+    ("Bjorn", "neutral", "Good morning, Bjorn! Fine sausages you have today."),
+    ("Bjorn", "neutral", "I'll take the smoked ham. Here's your coin, fair and square."),
+    ("Bjorn", "betrayal", "I told the town guard you water down your salt pork. They believed me."),
+    ("Bjorn", "theft", "While you argued with the guard, I pocketed a string of sausages."),
+    ("Astrid", "neutral", "Evening, Astrid. A mug of ale and a warm bed, please."),
+    ("Bjorn", "neutral", "Bjorn, old friend! Surely you remember me kindly?"),
+]
+
+
+async def build_world(session_path: str | None = None) -> GameWorld:
+    """The Butcher world: two npc.souls + one player.soul, zoned for the canvas."""
+    bjorn = await GrudgeKernel.birth(name="Bjorn", archetype="The Butcher")
+    astrid = await GrudgeKernel.birth(
+        name="Astrid", archetype="The Innkeeper", persona=ASTRID_PERSONA
+    )
+    ragnar = await PlayerSoul.birth(name="Ragnar")
+    world = GameWorld([bjorn, astrid], [ragnar], session_path=session_path)
+    world.move("Bjorn", "stall")
+    world.move("Astrid", "tables")
+    world.move("Ragnar", "door")
+    return world
+
+
+class DemoState:
+    """Owns the ONE background asyncio loop and the current GameWorld.
+
+    Every world touch goes through :meth:`run`, which marshals the coroutine
+    onto the loop thread — HTTP handler threads never touch the world directly.
+    """
+
+    def __init__(self, session_path: str | None = None) -> None:
+        self.session_path = session_path
+        self.loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self.loop.run_forever, name="butcher-world-loop", daemon=True
+        )
+        self._thread.start()
+        self.world: GameWorld | None = None
+        self.run(self.reset())
+
+    def run(self, coro, timeout: float = 30.0):
+        """Run a coroutine on the world loop from any thread; return its result."""
+        return asyncio.run_coroutine_threadsafe(coro, self.loop).result(timeout)
+
+    def close(self) -> None:
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self._thread.join(timeout=2.0)
+
+    # ---- coroutines (always executed on the world loop) -------------------
+
+    async def reset(self) -> dict:
+        self.world = await build_world(self.session_path)
+        return self.world.snapshot()
+
+    async def snapshot(self) -> dict:
+        return self.world.snapshot()
+
+    async def events_since(self, since: int) -> list[dict]:
+        return [e for e in self.world.events() if e["t"] > since]
+
+    async def beat(self, player_name: str, text: str, kind: str, npc_name: str | None) -> dict:
+        player = next(
+            (p for p in self.world.players if p.name.lower() == player_name.lower()), None
+        )
+        if player is None:
+            known = sorted(p.name for p in self.world.players)
+            raise LookupError(f"unknown player {player_name!r}; known: {known}")
+        return await self.world.beat(player.did, player.name, text, kind=kind, npc_name=npc_name)
+
+
+def make_handler(state: DemoState) -> type[BaseHTTPRequestHandler]:
+    """The request handler class, closed over the shared DemoState."""
+
+    class Handler(BaseHTTPRequestHandler):
+        server_version = "ButcherRemembers/0.1"
+
+        def log_message(self, format: str, *args) -> None:  # noqa: A002 — stdlib signature
+            pass  # keep the demo console quiet (the script narrates instead)
+
+        # ---- plumbing ----------------------------------------------------
+
+        def _send_json(self, payload, status: int = 200) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _send_static(self, filename: str, content_type: str) -> None:
+            path = ROOT / filename
+            if not path.exists():
+                self._send_json({"error": f"missing static file {filename}"}, 404)
+                return
+            body = path.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _read_body(self) -> dict:
+            length = int(self.headers.get("Content-Length") or 0)
+            raw = self.rfile.read(length) if length else b"{}"
+            try:
+                parsed = json.loads(raw or b"{}")
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"body is not valid JSON: {exc}") from exc
+            if not isinstance(parsed, dict):
+                raise ValueError("body must be a JSON object")
+            return parsed
+
+        # ---- routes --------------------------------------------------------
+
+        def do_GET(self) -> None:  # noqa: N802 — stdlib naming
+            parsed = urlparse(self.path)
+            if parsed.path in STATIC:
+                filename, content_type = STATIC[parsed.path]
+                self._send_static(filename, content_type)
+            elif parsed.path == "/snapshot":
+                self._send_json(state.run(state.snapshot()))
+            elif parsed.path == "/events":
+                query = parse_qs(parsed.query)
+                try:
+                    since = int(query.get("since", ["0"])[0])
+                except ValueError:
+                    self._send_json({"error": "since must be an integer"}, 400)
+                    return
+                self._send_json(state.run(state.events_since(since)))
+            else:
+                self._send_json({"error": f"no such route {parsed.path}"}, 404)
+
+        def do_POST(self) -> None:  # noqa: N802 — stdlib naming
+            parsed = urlparse(self.path)
+            if parsed.path == "/line":
+                try:
+                    body = self._read_body()
+                    summary = state.run(
+                        state.beat(
+                            str(body.get("player", "Ragnar")),
+                            str(body.get("text", "")),
+                            str(body.get("kind", "neutral")),
+                            body.get("npc"),
+                        )
+                    )
+                except (ValueError, LookupError) as exc:
+                    self._send_json({"error": str(exc)}, 400)
+                    return
+                self._send_json(summary)
+            elif parsed.path == "/reset":
+                self._send_json(state.run(state.reset()))
+            else:
+                self._send_json({"error": f"no such route {parsed.path}"}, 404)
+
+    return Handler
+
+
+def create_server(
+    port: int = DEFAULT_PORT, session_path: str | None = None
+) -> tuple[ThreadingHTTPServer, DemoState]:
+    """Build the world + HTTP server (not yet serving). port=0 -> ephemeral."""
+    state = DemoState(session_path)
+    httpd = ThreadingHTTPServer(("127.0.0.1", port), make_handler(state))
+    return httpd, state
+
+
+def play_script(state: DemoState, delay: float = 1.4) -> None:
+    """Auto-play the canonical arc, one beat every ``delay`` seconds."""
+    for npc, kind, line in SCRIPT:
+        summary = state.run(state.beat("Ragnar", line, kind, npc))
+        print(f"[beat] Ragnar -> {npc} ({kind}): {line}", flush=True)
+        print(
+            f"[speech] {npc} ({summary['grudge_level']}, bond {summary['bond']:.0f}): "
+            f"{summary['reaction']}",
+            flush=True,
+        )
+        time.sleep(delay)
+    print(
+        "[script] arc complete — the butcher remembers. Keep talking from the browser.",
+        flush=True,
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="The Butcher Remembers — grudge kernel demo")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="HTTP port (default 8777)")
+    parser.add_argument(
+        "--scripted", action="store_true", help="auto-play the canonical 6-beat arc"
+    )
+    parser.add_argument(
+        "--delay", type=float, default=1.4, help="seconds between scripted beats (default 1.4)"
+    )
+    parser.add_argument(
+        "--session-log", default=None, help="optional path for the session.jsonl mirror"
+    )
+    args = parser.parse_args(argv)
+
+    httpd, state = create_server(args.port, args.session_log)
+    print(f"The Butcher Remembers — http://localhost:{args.port}  (Ctrl+C to stop)", flush=True)
+    if args.scripted:
+        threading.Thread(
+            target=play_script, args=(state, args.delay), name="butcher-script", daemon=True
+        ).start()
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\n[server] stopping.")
+    finally:
+        httpd.server_close()
+        state.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/butcher_remembers/style.css
+++ b/examples/butcher_remembers/style.css
@@ -1,0 +1,184 @@
+/* style.css — "The Butcher Remembers" dark-tavern look.
+   Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — layout (topbar /
+   canvas / HUD panel), grudge chips (NONE green, SLIGHTED amber, GRUDGING
+   red), phase indicator, and the talk controls. No external assets. */
+
+:root {
+  --bg: #14100c;
+  --panel: #1e1811;
+  --panel-edge: #3a2d1c;
+  --ink: #e8dcc5;
+  --muted: #9a8a70;
+  --amber: #d9a441;
+  --none: #4caf7d;
+  --slighted: #e0a53c;
+  --grudging: #d9534f;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: Georgia, "Times New Roman", serif;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+#topbar {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--panel-edge);
+  background: linear-gradient(#1a140e, var(--bg));
+}
+
+#topbar h1 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 1px;
+  color: var(--amber);
+}
+
+#topbar h1 span { color: var(--ink); font-style: italic; }
+
+#phase-indicator { display: flex; gap: 6px; margin-left: auto; }
+
+.phase {
+  font-family: "Courier New", monospace;
+  font-size: 11px;
+  padding: 3px 8px;
+  border: 1px solid var(--panel-edge);
+  border-radius: 10px;
+  color: var(--muted);
+  opacity: 0.55;
+}
+
+.phase.active {
+  color: #14100c;
+  background: var(--amber);
+  border-color: var(--amber);
+  opacity: 1;
+  font-weight: bold;
+}
+
+#cost { font-size: 12px; color: var(--muted); font-family: "Courier New", monospace; }
+
+main {
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+  align-items: flex-start;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+#tavern {
+  background: #241c12;
+  border: 1px solid var(--panel-edge);
+  border-radius: 8px;
+  box-shadow: 0 0 40px rgba(0, 0, 0, 0.6) inset;
+}
+
+#hud {
+  width: 300px;
+  background: var(--panel);
+  border: 1px solid var(--panel-edge);
+  border-radius: 8px;
+  padding: 14px;
+}
+
+#hud h2 {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: var(--muted);
+  margin: 4px 0 10px;
+}
+
+.card {
+  border: 1px solid var(--panel-edge);
+  border-radius: 6px;
+  padding: 10px;
+  margin-bottom: 10px;
+  background: #191309;
+  transition: box-shadow 0.4s;
+}
+
+.card.flash { box-shadow: 0 0 12px var(--grudging); }
+
+.card .head { display: flex; align-items: center; gap: 8px; }
+
+.card .name { font-weight: bold; font-size: 16px; }
+
+.chip {
+  font-family: "Courier New", monospace;
+  font-size: 11px;
+  font-weight: bold;
+  padding: 2px 8px;
+  border-radius: 10px;
+  color: #14100c;
+  margin-left: auto;
+}
+
+.chip.NONE { background: var(--none); }
+.chip.SLIGHTED { background: var(--slighted); }
+.chip.GRUDGING { background: var(--grudging); }
+
+.card .bond { font-size: 12px; color: var(--muted); margin-top: 6px; }
+.card .bond b { color: var(--ink); }
+
+.card .grievance {
+  font-style: italic;
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 6px;
+  border-left: 2px solid var(--panel-edge);
+  padding-left: 8px;
+}
+
+#controls { display: flex; flex-direction: column; gap: 8px; }
+
+#controls .row { display: flex; gap: 8px; }
+
+#controls label {
+  font-size: 11px;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1;
+}
+
+#controls select,
+#controls input {
+  background: #120d08;
+  color: var(--ink);
+  border: 1px solid var(--panel-edge);
+  border-radius: 4px;
+  padding: 7px 8px;
+  font-family: inherit;
+  font-size: 13px;
+  width: 100%;
+}
+
+#controls button {
+  flex: 1;
+  background: var(--amber);
+  color: #14100c;
+  font-weight: bold;
+  border: none;
+  border-radius: 4px;
+  padding: 8px 10px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+#controls button:hover { filter: brightness(1.1); }
+
+#controls #reset { background: transparent; color: var(--muted); border: 1px solid var(--panel-edge); }
+
+#status { font-size: 12px; color: var(--grudging); min-height: 16px; }

--- a/examples/butcher_remembers/style.css
+++ b/examples/butcher_remembers/style.css
@@ -1,7 +1,10 @@
 /* style.css — "The Butcher Remembers" dark-tavern look.
    Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — layout (topbar /
    canvas / HUD panel), grudge chips (NONE green, SLIGHTED amber, GRUDGING
-   red), phase indicator, and the talk controls. No external assets. */
+   red), phase indicator, and the talk controls. No external assets.
+   Updated: 2026-07-02 (BD-2, 90s demo) — bottom free-play bar (input + soul
+   export/import/reputation buttons + notoriety chip), and the collapsible
+   fixed top-right cost overlay (.hidden toggles both). */
 
 :root {
   --bg: #14100c;
@@ -182,3 +185,108 @@ main {
 #controls #reset { background: transparent; color: var(--muted); border: 1px solid var(--panel-edge); }
 
 #status { font-size: 12px; color: var(--grudging); min-height: 16px; }
+
+/* ---- bottom free-play bar (BD-2) ---------------------------------------- */
+
+#bottombar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 18px;
+  border-top: 1px solid var(--panel-edge);
+  background: var(--panel);
+}
+
+#freeplay { display: flex; gap: 8px; flex: 1 1 320px; }
+
+#freeplay input {
+  flex: 1;
+  background: #120d08;
+  color: var(--ink);
+  border: 1px solid var(--panel-edge);
+  border-radius: 4px;
+  padding: 8px 10px;
+  font-family: inherit;
+  font-size: 14px;
+}
+
+#freeplay button {
+  background: var(--amber);
+  color: #14100c;
+  font-weight: bold;
+  border: none;
+  border-radius: 4px;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+#soul-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+#soul-actions button {
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid var(--panel-edge);
+  border-radius: 4px;
+  padding: 7px 10px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+}
+
+#soul-actions button:hover { border-color: var(--amber); color: var(--amber); }
+
+#soul-actions #ask-innkeeper { border-color: var(--amber); color: var(--amber); }
+
+#free-status { font-size: 12px; color: var(--muted); font-family: "Courier New", monospace; }
+
+/* Notoriety chip — the player's portable reputation band. */
+.chip.UNKNOWN { background: var(--none); }
+.chip.KNOWN { background: var(--slighted); }
+.chip.NOTORIOUS { background: var(--grudging); }
+
+/* ---- cost overlay (BD-2) — fixed top-right, collapsible ------------------ */
+
+#cost-overlay {
+  position: fixed;
+  top: 52px;
+  right: 14px;
+  z-index: 10;
+  text-align: right;
+}
+
+#cost-overlay #cost-toggle {
+  background: var(--panel);
+  color: var(--amber);
+  border: 1px solid var(--panel-edge);
+  border-radius: 4px;
+  padding: 4px 10px;
+  cursor: pointer;
+  font-family: "Courier New", monospace;
+  font-size: 12px;
+}
+
+#cost-body {
+  margin-top: 6px;
+  background: var(--panel);
+  border: 1px solid var(--panel-edge);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-family: "Courier New", monospace;
+  font-size: 12px;
+  color: var(--ink);
+  text-align: left;
+  min-width: 230px;
+}
+
+#cost-body div { margin: 2px 0; }
+
+#cost-deepseek { color: var(--amber); }
+
+.hidden { display: none !important; }

--- a/tests/profiles/game/test_demo_server.py
+++ b/tests/profiles/game/test_demo_server.py
@@ -15,6 +15,23 @@
 #   The server module is imported straight from its file path (examples/ is
 #   not a package); each test gets a fresh server + world via the fixture.
 #
+# Updated: 2026-07-02 (experiment/npc-soul-grudge-kernel, BD-2) — Six more,
+#   all deterministic (templated engine, no network, no LLM):
+#     * test_export_soul_returns_zip_download — /export_soul streams real
+#       .soul bytes (zip magic PK) with a Content-Disposition attachment.
+#     * test_import_soul_round_trip_reverts_grudge — wrong Bjorn, export,
+#       wrong him more, import the EARLIER file: grudge level, bond, and the
+#       remembered grievance revert to the exported snapshot.
+#     * test_reputation_gut_punch — /reputation: clean record -> UNKNOWN and
+#       warm; after wronging Bjorn via /line (player_soul wired by
+#       world.beat, so deeds accrue on Ragnar), Astrid — never herself
+#       wronged — goes NOTORIOUS and cites the hearsay deeds.
+#     * test_classify_kind_unit — the keyword classifier's four kinds.
+#     * test_line_without_kind_auto_classifies — POST /line with no "kind":
+#       theft phrasing lands as a real theft beat (grudge SLIGHTED).
+#     * test_cost_endpoint_templated_zeros — /cost is all zeros / null model
+#       on the templated engine, and /snapshot reports engine=templated.
+#
 # Run:  uv run pytest tests/profiles/game/test_demo_server.py -v
 
 from __future__ import annotations
@@ -72,6 +89,30 @@ def _post(url: str, payload: dict):
         return json.loads(resp.read().decode("utf-8"))
 
 
+def _post_for_bytes(url: str, payload: dict) -> tuple[bytes, dict]:
+    """POST JSON, return (raw response bytes, headers) — for the .soul downloads."""
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as resp:
+        return resp.read(), dict(resp.headers)
+
+
+def _post_octets(url: str, data: bytes):
+    """POST raw bytes (the /import_soul body) and parse the JSON reply."""
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/octet-stream"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
 def test_snapshot_returns_zones_and_npcs(base_url: str) -> None:
     snap = _get(f"{base_url}/snapshot")
     assert snap["zones"] == {"Bjorn": "stall", "Astrid": "tables", "Ragnar": "door"}
@@ -123,3 +164,112 @@ def test_events_since_filters(base_url: str) -> None:
     assert "grudge_change" in types  # the insult tripped NONE -> SLIGHTED
 
     assert _get(f"{base_url}/events?since=1000000000") == []
+
+
+# ---------------------------------------------------------------------------
+# BD-2 — the 90-second demo endpoints (templated engine, fully deterministic)
+# ---------------------------------------------------------------------------
+
+
+def test_export_soul_returns_zip_download(base_url: str) -> None:
+    data, headers = _post_for_bytes(f"{base_url}/export_soul", {"npc": "Bjorn"})
+    assert data[:2] == b"PK", "a .soul is a zip archive — bytes must start with the PK magic"
+    assert headers.get("Content-Type") == "application/octet-stream"
+    assert 'attachment; filename="bjorn.soul"' in headers.get("Content-Disposition", "")
+
+    # The player.soul download works the same way.
+    pdata, pheaders = _post_for_bytes(f"{base_url}/export_player", {"player": "Ragnar"})
+    assert pdata[:2] == b"PK"
+    assert 'filename="ragnar.player.soul"' in pheaders.get("Content-Disposition", "")
+
+
+def test_import_soul_round_trip_reverts_grudge(base_url: str) -> None:
+    ragnar_did = _get(f"{base_url}/snapshot")["players"][0]["did"]
+
+    # Wrong Bjorn once -> SLIGHTED, then export him: the file IS his memory.
+    slighted = _post(
+        f"{base_url}/line",
+        {"player": "Ragnar", "text": "Your meat is maggoty.", "kind": "insult", "npc": "Bjorn"},
+    )
+    assert slighted["grudge_level"] == "SLIGHTED"
+    exported_bond = slighted["bond"]
+    soul_bytes, _ = _post_for_bytes(f"{base_url}/export_soul", {"npc": "Bjorn"})
+
+    # Wrong him more AFTER the export -> GRUDGING in the live world.
+    worse = _post(
+        f"{base_url}/line",
+        {"player": "Ragnar", "text": "And I stole your ham.", "kind": "theft", "npc": "Bjorn"},
+    )
+    assert worse["grudge_level"] == "GRUDGING"
+    assert worse["bond"] < exported_bond
+
+    # Import the EARLIER file: Bjorn reverts to the exported snapshot —
+    # SLIGHTED, the pre-theft bond, and only the insult remembered.
+    result = _post_octets(f"{base_url}/import_soul", soul_bytes)
+    assert result["replaced"] == "Bjorn"
+    snap = _get(f"{base_url}/snapshot")
+    bjorn = next(npc for npc in snap["npcs"] if npc["name"] == "Bjorn")
+    assert bjorn["players"][ragnar_did]["grudge"] == "SLIGHTED"
+    assert bjorn["players"][ragnar_did]["bond"] == pytest.approx(exported_bond)
+    assert bjorn["players"][ragnar_did]["last_grievance"] == "Your meat is maggoty."
+
+
+def test_reputation_gut_punch(base_url: str) -> None:
+    # Clean record: Astrid has heard nothing — warm welcome, UNKNOWN.
+    clean = _get(f"{base_url}/reputation?npc=Astrid&player=Ragnar")
+    assert clean["npc"] == "Astrid"
+    assert clean["notoriety"] == "UNKNOWN"
+    assert "Astrid" in clean["line"]
+
+    # Wrong BJORN twice; world.beat wires player_soul=Ragnar, so the deeds
+    # accrue on Ragnar's own player.soul (his portable reputation).
+    for kind, text in [
+        ("theft", "I pocketed a string of sausages."),
+        ("betrayal", "I told the guard your scales are rigged."),
+    ]:
+        _post(
+            f"{base_url}/line",
+            {"player": "Ragnar", "text": text, "kind": kind, "npc": "Bjorn"},
+        )
+
+    # THE gut-punch: Astrid was never wronged, but word travels.
+    punch = _get(f"{base_url}/reputation?npc=Astrid&player=Ragnar")
+    assert punch["notoriety"] == "NOTORIOUS"
+    assert "Word travels" in punch["line"]
+    assert "betrayed someone who trusted you" in punch["line"]  # worst deed cited
+
+
+def test_classify_kind_unit() -> None:
+    cases = {
+        "While you argued with the guard, I pocketed a string of sausages.": "theft",
+        "I stole your best ham, old man.": "theft",
+        "I told the town guard you water down your salt pork.": "betrayal",
+        "I lied to everyone about you.": "betrayal",
+        "You worthless maggot of a butcher.": "insult",
+        "You are a fool and a coward.": "insult",
+        "Good morning! Fine sausages you have today.": "neutral",
+        "": "neutral",
+    }
+    for text, expected in cases.items():
+        assert server_mod.classify_kind(text) == expected, text
+
+
+def test_line_without_kind_auto_classifies(base_url: str) -> None:
+    summary = _post(
+        f"{base_url}/line",
+        {"player": "Ragnar", "text": "I pocketed a string of sausages.", "npc": "Bjorn"},
+    )
+    assert summary["kind"] == "theft"  # the classifier heard the theft
+    assert summary["grudge_level"] == "SLIGHTED"  # and it landed as a real beat
+
+
+def test_cost_endpoint_templated_zeros(base_url: str) -> None:
+    assert _get(f"{base_url}/snapshot")["engine"] == "templated"
+    cost = _get(f"{base_url}/cost")
+    assert cost["engine"] == "templated"
+    assert cost["model"] is None
+    assert cost["calls"] == 0 and cost["cached_calls"] == 0
+    assert cost["tokens_in"] == 0 and cost["tokens_out"] == 0
+    assert cost["total_cost"] == 0.0
+    assert cost["projected_deepseek"] == 0.0
+    assert cost["cost_per_player_hour"] == 0.0

--- a/tests/profiles/game/test_demo_server.py
+++ b/tests/profiles/game/test_demo_server.py
@@ -1,0 +1,125 @@
+# test_demo_server.py — Smoke tests for the "Butcher Remembers" demo server
+#   (examples/butcher_remembers/server.py). No browser: a REAL server on an
+#   ephemeral port, driven with urllib.
+#
+# Created: 2026-07-02 (experiment/npc-soul-grudge-kernel) — Three tests:
+#     * test_snapshot_returns_zones_and_npcs — /snapshot carries the Butcher
+#       world: Bjorn at the stall, Astrid at the tables, Ragnar at the door,
+#       both NPC HUD entries, a director phase.
+#     * test_post_line_advances_events — POST /line runs a real world.beat:
+#       the summary carries the NPC's spoken reaction, and /events grows the
+#       beat + speech pair; a bogus kind is a clean 400.
+#     * test_events_since_filters — /events?since=N returns exactly the
+#       events with t > N (an insult beat shows its grudge_change), and a
+#       far-future cursor returns [].
+#   The server module is imported straight from its file path (examples/ is
+#   not a package); each test gets a fresh server + world via the fixture.
+#
+# Run:  uv run pytest tests/profiles/game/test_demo_server.py -v
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+_SERVER_PY = Path(__file__).resolve().parents[3] / "examples" / "butcher_remembers" / "server.py"
+
+
+def _load_server_module():
+    spec = importlib.util.spec_from_file_location("butcher_remembers_server", _SERVER_PY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+server_mod = _load_server_module()
+
+
+@pytest.fixture()
+def base_url():
+    """A live demo server on an ephemeral port, torn down after the test."""
+    httpd, state = server_mod.create_server(port=0)
+    thread = threading.Thread(target=httpd.serve_forever, name="butcher-http", daemon=True)
+    thread.start()
+    port = httpd.server_address[1]
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        state.close()
+
+
+def _get(url: str):
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _post(url: str, payload: dict):
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def test_snapshot_returns_zones_and_npcs(base_url: str) -> None:
+    snap = _get(f"{base_url}/snapshot")
+    assert snap["zones"] == {"Bjorn": "stall", "Astrid": "tables", "Ragnar": "door"}
+    assert [npc["name"] for npc in snap["npcs"]] == ["Bjorn", "Astrid"]
+    assert snap["phase"] == "BUILD_UP"
+    ragnar = snap["players"][0]
+    assert ragnar["name"] == "Ragnar"
+    # Fresh world: both NPCs hold nothing against Ragnar yet.
+    for npc in snap["npcs"]:
+        assert npc["players"][ragnar["did"]]["grudge"] == "NONE"
+
+
+def test_post_line_advances_events(base_url: str) -> None:
+    before = _get(f"{base_url}/events?since=0")  # the three build-time move events
+    assert {e["type"] for e in before} == {"move"}
+
+    summary = _post(
+        f"{base_url}/line",
+        {"player": "Ragnar", "text": "Morning, butcher.", "kind": "neutral", "npc": "Bjorn"},
+    )
+    assert summary["npc"] == "Bjorn"
+    assert summary["reaction"]  # the NPC actually spoke
+    assert summary["grudge_level"] == "NONE"
+
+    after = _get(f"{base_url}/events?since=0")
+    assert len(after) > len(before)
+    types = [e["type"] for e in after]
+    assert "beat" in types and "speech" in types
+
+    # A bogus kind is rejected cleanly, not a 500.
+    with pytest.raises(urllib.error.HTTPError) as excinfo:
+        _post(f"{base_url}/line", {"player": "Ragnar", "text": "x", "kind": "arson"})
+    assert excinfo.value.code == 400
+
+
+def test_events_since_filters(base_url: str) -> None:
+    _post(f"{base_url}/line", {"player": "Ragnar", "text": "Hello there.", "kind": "neutral"})
+    cursor = max(e["t"] for e in _get(f"{base_url}/events?since=0"))
+
+    _post(
+        f"{base_url}/line",
+        {"player": "Ragnar", "text": "Your meat is maggoty.", "kind": "insult", "npc": "Bjorn"},
+    )
+    fresh = _get(f"{base_url}/events?since={cursor}")
+    assert fresh, "the second beat must produce new events"
+    assert all(e["t"] > cursor for e in fresh)
+    types = [e["type"] for e in fresh]
+    assert "beat" in types and "speech" in types
+    assert "grudge_change" in types  # the insult tripped NONE -> SLIGHTED
+
+    assert _get(f"{base_url}/events?since=1000000000") == []


### PR DESCRIPTION
Top of the stack. The 90-second demo as a runnable local app: a browser client over the GameWorld event stream, with the soul-file and reputation moments wired as buttons.

## Run it

    uv run python examples/butcher_remembers/server.py --scripted
    # open http://localhost:8777

Engines: `--engine templated` (default, deterministic, free) · `--engine claude` (live LLM lines via claude -p, ~20-40s each) · `--engine deepseek` (needs DEEPSEEK_API_KEY; falls back to templated with a warning if missing).

## What's in here

- **Server + client** (`367a885`): stdlib-only HTTP server bridging the async GameWorld; canvas client with tavern zones, speech bubbles, a per-NPC grudge ledger (color-coded, shows the remembered grievance), and a director-phase chip.
- **The demo moments** (`f843f4b`): free-play input with a keyword kind-classifier; ⬇ Export bjorn.soul (a real zip downloads — the artifact moment) and ⬆ import to rewind him; "ask the innkeeper about me" — Astrid, who has never met Ragnar, reads his player.soul and reacts to his notoriety; a cost overlay (claude meters at $0 here, same traffic re-priced for DeepSeek).

## Review notes

- The scripted arc plays the canonical beats (befriend → betray → theft → return-still-hostile → clean-player control) and is what the demo video would record.
- Playtest verdicts (fun/feel) are explicitly the captain's — this PR delivers the machinery.

## Tests

46/46 in `tests/profiles/game/`, including: import-reverts-the-grudge round-trip, the reputation gut-punch (clean player warm, notorious player cited), classifier unit cases, and cost-endpoint shape. Smoke-verified live over HTTP.