### PR TITLE
ci: run tests on dev PRs and stop the quality gate crashing on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,14 @@
-# CI — lint and test on every PR and push to main.
-# Updated: 2026-03-05 — Lint errors fixed, lint job now blocks PRs.
+# CI — lint and test on every PR and push to the mainline branches.
+# Updated: 2026-07-02 — Run on PRs and pushes targeting dev, not just main.
+#   dev is the working branch, so main-only triggers meant lint and the
+#   3.11/3.12/3.13 test matrix never ran on the PRs that actually merge.
 name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -1,5 +1,7 @@
 # PR quality gate — enforces contribution standards and security checks.
 # Added: 2026-03-05 — Quality gate + security scan for soul-protocol.
+# Updated: 2026-07-02 — Wrap label/comment writes so fork PRs (read-only
+#   token) report the verdict via the run summary instead of 403-crashing.
 name: PR Quality Gate
 
 on:
@@ -115,16 +117,32 @@ jobs:
               c => c.user.type === 'Bot' && c.body.includes(MARKER)
             );
 
+            // Fork PRs run with a read-only GITHUB_TOKEN, so labeling and
+            // commenting return 403 no matter what the permissions block says.
+            // Wrap every write so the gate still reports its verdict (via the
+            // run summary) instead of crashing the whole check.
+            async function tryWrite(desc, fn) {
+              try {
+                await fn();
+                return true;
+              } catch (e) {
+                core.warning(`Skipped ${desc}: ${e.message}. Expected on PRs from forks, whose token is read-only.`);
+                return false;
+              }
+            }
+
             if (issues.length > 0 || warnings.length > 0) {
               let message = `${MARKER}\n`;
 
               if (issues.length > 0) {
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr.number,
-                  labels: ['needs-work']
-                });
+                await tryWrite('adding the needs-work label', () =>
+                  github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    labels: ['needs-work']
+                  })
+                );
                 message += `### Issues (must fix)\n\n${issues.join('\n')}\n\n`;
               }
 
@@ -134,20 +152,32 @@ jobs:
 
               message += `Please update your PR to address these points.`;
 
-              if (botComment) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: botComment.id,
-                  body: message
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr.number,
-                  body: message
-                });
+              const posted = botComment
+                ? await tryWrite('updating the quality-gate comment', () =>
+                    github.rest.issues.updateComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      comment_id: botComment.id,
+                      body: message
+                    })
+                  )
+                : await tryWrite('posting the quality-gate comment', () =>
+                    github.rest.issues.createComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: pr.number,
+                      body: message
+                    })
+                  );
+
+              // Always surface the verdict in the run summary so it is visible
+              // even when the token cannot write to the PR.
+              await core.summary
+                .addHeading('PR quality gate', 2)
+                .addRaw(message.replace(MARKER, '').trim())
+                .write();
+              if (!posted) {
+                core.warning('Could not post quality-gate feedback to the PR; see the run summary above.');
               }
             } else {
               try {
@@ -157,15 +187,17 @@ jobs:
                   issue_number: pr.number,
                   name: 'needs-work'
                 });
-              } catch (e) { /* label wasn't present */ }
+              } catch (e) { /* label absent, or read-only fork token */ }
 
               if (botComment) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: botComment.id,
-                  body: `${MARKER}\nAll quality checks passed. Thanks for the clean PR!`
-                });
+                await tryWrite('updating the quality-gate comment', () =>
+                  github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: botComment.id,
+                    body: `${MARKER}\nAll quality checks passed. Thanks for the clean PR!`
+                  })
+                );
               }
             }
 

--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -1228,9 +1228,7 @@ def remember_cmd(path, text, importance, emotion, memory_type, domain):
     default=False,
     help="Skip contradiction detection on stored facts.",
 )
-def observe_cmd(
-    path, text, importance, emotion, memory_type, domain, no_dedup, no_contradictions
-):
+def note_cmd(path, text, importance, emotion, memory_type, domain, no_dedup, no_contradictions):
     """Note a fact in a Soul, with dedup against existing memories (#231).
 
     The brief for #231 originally specified ``soul observe`` for this
@@ -1299,14 +1297,10 @@ def observe_cmd(
             border = "cyan"
 
         sim_line = (
-            f"  Similarity  [yellow]{similarity:.2f}[/yellow]\n"
-            if similarity is not None
-            else ""
+            f"  Similarity  [yellow]{similarity:.2f}[/yellow]\n" if similarity is not None else ""
         )
         new_id_line = f"  New ID      [dim]{new_id}[/dim]\n" if new_id else ""
-        existing_line = (
-            f"  Existing ID [dim]{existing_id}[/dim]\n" if existing_id else ""
-        )
+        existing_line = f"  Existing ID [dim]{existing_id}[/dim]\n" if existing_id else ""
 
         console.print(
             Panel(

--- a/tests/cross_runtime/test_crewai.py
+++ b/tests/cross_runtime/test_crewai.py
@@ -36,9 +36,9 @@ class TestCrewAIRoundTrip:
                 assert len(results) > 0, f"No results for: {mem['content']}"
 
                 contents = [r.content for r in results]
-                assert any(
-                    mem["content"] in c for c in contents
-                ), f"Missing memory: {mem['content']}"
+                assert any(mem["content"] in c for c in contents), (
+                    f"Missing memory: {mem['content']}"
+                )
 
                 # CrewAI needs string content
                 for r in results:
@@ -47,9 +47,7 @@ class TestCrewAIRoundTrip:
 
         asyncio.get_event_loop().run_until_complete(_check())
 
-    def test_soul_identity_accessible_for_crewai_agent(
-        self, soul_path_semantic_only
-    ):
+    def test_soul_identity_accessible_for_crewai_agent(self, soul_path_semantic_only):
         """Soul identity fields are accessible for CrewAI agent backstory."""
 
         async def _check():

--- a/tests/cross_runtime/test_langchain.py
+++ b/tests/cross_runtime/test_langchain.py
@@ -37,9 +37,9 @@ class TestLangChainRoundTrip:
                 assert len(results) > 0, f"No results for: {mem['content']}"
 
                 contents = [r.content for r in results]
-                assert any(
-                    mem["content"] in c for c in contents
-                ), f"Missing memory: {mem['content']}"
+                assert any(mem["content"] in c for c in contents), (
+                    f"Missing memory: {mem['content']}"
+                )
 
                 # LangChain needs string content — verify it's available
                 for r in results:
@@ -48,9 +48,7 @@ class TestLangChainRoundTrip:
 
         asyncio.get_event_loop().run_until_complete(_check())
 
-    def test_soul_identity_accessible_for_langchain_system_prompt(
-        self, soul_path_semantic_only
-    ):
+    def test_soul_identity_accessible_for_langchain_system_prompt(self, soul_path_semantic_only):
         """Soul identity fields are accessible for LangChain system prompt."""
 
         async def _check():

--- a/tests/cross_runtime/test_pocketpaw.py
+++ b/tests/cross_runtime/test_pocketpaw.py
@@ -43,9 +43,9 @@ class TestPocketPawRoundTrip:
             for mem in SEMANTIC_MEMORIES:
                 results = await soul.recall(mem["content"])
                 contents = [r.content for r in results]
-                assert any(
-                    mem["content"] in c for c in contents
-                ), f"Missing semantic memory: {mem['content']}"
+                assert any(mem["content"] in c for c in contents), (
+                    f"Missing semantic memory: {mem['content']}"
+                )
 
         asyncio.get_event_loop().run_until_complete(_check())
 
@@ -63,9 +63,9 @@ class TestPocketPawRoundTrip:
 
             # Every episodic memory should be present
             for mem in EPISODIC_MEMORIES:
-                assert any(
-                    mem["content"] in c for c in contents
-                ), f"Missing episodic memory: {mem['content']}"
+                assert any(mem["content"] in c for c in contents), (
+                    f"Missing episodic memory: {mem['content']}"
+                )
 
         asyncio.get_event_loop().run_until_complete(_check())
 

--- a/tests/test_cli/test_note_cmd.py
+++ b/tests/test_cli/test_note_cmd.py
@@ -83,9 +83,7 @@ def test_e2e_merge_overlapping_content(tmp_path):
     first = runner.invoke(cli, ["note", str(soul_path), "Aria likes Python"])
     assert first.exit_code == 0, first.output
 
-    second = runner.invoke(
-        cli, ["note", str(soul_path), "Aria likes Python and async code"]
-    )
+    second = runner.invoke(cli, ["note", str(soul_path), "Aria likes Python and async code"])
 
     assert second.exit_code == 0, second.output
     out = second.output.lower()
@@ -100,12 +98,8 @@ def test_e2e_no_dedup_writes_both(tmp_path):
     _birth_soul_at(str(soul_path))
 
     runner = CliRunner()
-    first = runner.invoke(
-        cli, ["note", str(soul_path), "always store this raw", "--no-dedup"]
-    )
-    second = runner.invoke(
-        cli, ["note", str(soul_path), "always store this raw", "--no-dedup"]
-    )
+    first = runner.invoke(cli, ["note", str(soul_path), "always store this raw", "--no-dedup"])
+    second = runner.invoke(cli, ["note", str(soul_path), "always store this raw", "--no-dedup"])
 
     assert first.exit_code == 0, first.output
     assert second.exit_code == 0, second.output

--- a/tests/test_note/test_soul_note.py
+++ b/tests/test_note/test_soul_note.py
@@ -13,7 +13,6 @@ import pytest
 from soul_protocol.runtime.soul import Soul
 from soul_protocol.runtime.types import MemoryType
 
-
 # --- Helpers -----------------------------------------------------------------
 
 
@@ -103,9 +102,7 @@ async def test_merge_path_supersedes_old_memory():
     assert second["id"] != old_id
     assert second["existing_id"] == old_id
     sim = second["similarity"]
-    assert sim is not None and 0.6 <= sim <= 0.85, (
-        f"Expected MERGE band similarity, got {sim}"
-    )
+    assert sim is not None and 0.6 <= sim <= 0.85, f"Expected MERGE band similarity, got {sim}"
 
     # The old memory should be marked as superseded by the new one.
     all_facts = soul._memory._semantic.facts(include_superseded=True)
@@ -193,12 +190,8 @@ async def test_procedural_tier_dedup_works():
     """Procedural store goes through the same SKIP path as semantic."""
     soul = await Soul.birth("Aria", archetype="t")
 
-    first = await soul.note(
-        "to deploy run make deploy and verify", type=MemoryType.PROCEDURAL
-    )
-    second = await soul.note(
-        "to deploy run make deploy and verify", type=MemoryType.PROCEDURAL
-    )
+    first = await soul.note("to deploy run make deploy and verify", type=MemoryType.PROCEDURAL)
+    second = await soul.note("to deploy run make deploy and verify", type=MemoryType.PROCEDURAL)
 
     assert first["action"] == "CREATE"
     assert second["action"] == "SKIP"
@@ -217,9 +210,7 @@ async def test_return_shape_complete_across_all_paths():
     create_result = await soul.note("Aria enjoys playing guitar")
     skip_result = await soul.note("Aria enjoys playing guitar")
     merge_result = await soul.note("Bob writes essays about typography")
-    merge_result_2 = await soul.note(
-        "Bob writes essays about typography and design"
-    )
+    merge_result_2 = await soul.note("Bob writes essays about typography and design")
 
     for result in (create_result, skip_result, merge_result, merge_result_2):
         assert set(result.keys()) == {"action", "id", "existing_id", "similarity"}


### PR DESCRIPTION
## What

Two fixes to the GitHub Actions setup, both surfaced while reviewing the open community PRs (#268, #274, #276).

**1. Run CI on PRs targeting `dev`.** `ci.yml` only triggered on pushes and PRs to `main`, but `dev` is the working branch. Every dev-targeted PR was merging without ruff or the 3.11/3.12/3.13 pytest matrix ever running, so a green tick on those PRs proved nothing. This adds `dev` to both the `push` and `pull_request` triggers.

**2. Stop the quality gate crashing on fork PRs.** PRs from forks run with a read-only `GITHUB_TOKEN` regardless of the workflow's `permissions:` block, so `issues.addLabels` returned 403 and the whole `check-quality` step failed for the wrong reason (it read as a real quality failure). The label and comment writes are now wrapped so a read-only token is handled gracefully: the gate still reports its verdict through the run summary and an annotation, and same-repo PR behavior is unchanged.

## Why now

Three fork PRs are open right now (Siddhant's #268/#274/#276). On each, the only checks that ran were this gate (which crashed) and the security scan. Lint and tests never ran at all. That is a blind spot at exactly the moment we're merging outside contributions.

## Testing

- YAML parses for both workflows.
- The embedded `github-script` JS passes `node --check`.
- The behavior change is scoped to trigger config and to try/catch around API writes; no job logic was altered.

CI on this PR is itself the live proof of fix 1: with `dev` added to the trigger, the lint and test matrix should now run on this dev-targeted PR (it would not have before).

## Not touched

The gate stays non-blocking (it comments and warns; it does not fail the check on hygiene issues). Whether it should hard-fail is a separate policy call, left out of this PR.

## Follow-on: pre-existing lint debt

Turning the gate on immediately surfaced ruff debt that had never been checked on `dev` (which is the whole point). A second commit clears it so the gate actually passes:

- `F811`: the `note` command's function was named `observe_cmd`, colliding with the `observe` command's function of the same name. Both commands register correctly (Click keys on the decorator, not the Python name), so this is a rename to `note_cmd` with no behavior change.
- `ruff format` / `I001`: import ordering and formatting on six test files.

No logic changes in that commit. Verified locally: `ruff check .` and `ruff format --check .` both clean, and the 3.11/3.12/3.13 test matrix passes.
