### PR TITLE
feat: add `--password` to `soul export` for AES-256-GCM encryption at rest

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -289,6 +289,9 @@ soul export aria.soul --output aria.yaml --format yaml
 
 # Export to human-readable Markdown (DNA only)
 soul export aria.soul --output aria.md --format md
+
+# Export with AES-256-GCM encryption
+soul export aria.soul -o encrypted.soul --password mysecretpass
 ```
 
 **Arguments:**
@@ -303,6 +306,7 @@ soul export aria.soul --output aria.md --format md
 |--------|-------|-------------|
 | `--output PATH` | `-o` | Output file path. **Required.** |
 | `--format FORMAT` | `-f` | Target format: `soul` (zip archive), `json`, `yaml`, `md` (markdown). Defaults to `soul`. |
+| `--password TEXT` | `-p` | Encrypt the `.soul` archive with AES-256-GCM using a scrypt-derived key. All files except `manifest.json` are encrypted (`.enc` extension). Only applies to `soul` format. |
 
 **Format details:**
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -290,8 +290,8 @@ soul export aria.soul --output aria.yaml --format yaml
 # Export to human-readable Markdown (DNA only)
 soul export aria.soul --output aria.md --format md
 
-# Export with AES-256-GCM encryption
-soul export aria.soul -o encrypted.soul --password mysecretpass
+# Export with AES-256-GCM encryption (prompts interactively for password)
+soul export aria.soul -o encrypted.soul --password
 ```
 
 **Arguments:**
@@ -306,7 +306,7 @@ soul export aria.soul -o encrypted.soul --password mysecretpass
 |--------|-------|-------------|
 | `--output PATH` | `-o` | Output file path. **Required.** |
 | `--format FORMAT` | `-f` | Target format: `soul` (zip archive), `json`, `yaml`, `md` (markdown). Defaults to `soul`. |
-| `--password TEXT` | `-p` | Encrypt the `.soul` archive with AES-256-GCM using a scrypt-derived key. All files except `manifest.json` are encrypted (`.enc` extension). Only applies to `soul` format. |
+| `--password / -p` | Encrypt the `.soul` archive with AES-256-GCM using a scrypt-derived key. All files except `manifest.json` are encrypted (`.enc` extension). Only applies to `soul` format. |
 
 **Format details:**
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -247,11 +247,24 @@ soul inspect ./souls/sage.yaml
 |----------|----------|-------------|
 | `PATH` | Yes | Path to a `.soul`, `.yaml`, `.json`, or `.md` file. |
 
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--password / -p` | Decrypt an encrypted `.soul` file (prompts interactively for password). |
+
 **Output:** A formatted table showing:
 
 - **Identity:** DID, archetype, born date, age in days, lifecycle stage
 - **State:** Mood, energy (%), focus, social battery (%)
 - **Personality (OCEAN):** Openness, Conscientiousness, Extraversion, Agreeableness, Neuroticism (each 0.00-1.00)
+
+**Example with encrypted soul:**
+
+```bash
+soul inspect encrypted.soul --password
+# Prompts: Decryption password: ****
+```
 
 ---
 

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -14,6 +14,12 @@ When you export with `--password`, the archive is encrypted using:
   `manifest.json`, which remains readable so tools can detect that the
   archive is encrypted without needing the password.
 
+> **Privacy note:** The manifest intentionally keeps the soul's **name**,
+> **DID**, and **role** in plaintext so that tooling can index and display
+> archives without decryption. If you are encrypting for privacy, be aware
+> that the soul's identity header is visible — only the memory tiers,
+> trust chain, and signing keys are protected by the password.
+
 The `cryptography` Python package is required:
 
 ```bash

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,0 +1,100 @@
+# Encryption
+
+Soul Protocol supports AES-256-GCM encryption for `.soul` archives,
+allowing you to protect a soul's data at rest with a password.
+
+## How It Works
+
+When you export with `--password`, the archive is encrypted using:
+
+- **Algorithm:** AES-256-GCM (authenticated encryption)
+- **Key derivation:** scrypt (N=2¹⁴, r=8, p=1) with a random 16-byte salt
+- **Nonce:** Random 12 bytes per file
+- **Scope:** All files inside the `.soul` archive are encrypted *except*
+  `manifest.json`, which remains readable so tools can detect that the
+  archive is encrypted without needing the password.
+
+The `cryptography` Python package is required:
+
+```bash
+pip install cryptography
+```
+
+## CLI Usage
+
+### Encrypting a soul
+
+```bash
+soul export aria.soul -o aria-secure.soul --password
+```
+
+You will be prompted to enter and confirm the password interactively.
+The password never appears in your shell history.
+
+### Reading an encrypted soul
+
+```bash
+# Inspect
+soul inspect aria-secure.soul --password
+
+# Unpack to directory
+soul unpack aria-secure.soul -d ./aria/ --password
+```
+
+### Error handling
+
+If you try to open an encrypted `.soul` file without `--password`,
+the CLI prints a friendly message:
+
+```
+Error: This .soul file is encrypted. Pass --password to decrypt it.
+```
+
+A wrong password produces:
+
+```
+Error: Wrong password — decryption failed. Check your password and try again.
+```
+
+## Python API
+
+```python
+from soul_protocol.runtime.soul import Soul
+
+# Export with encryption
+soul = await Soul.birth("Aria")
+await soul.export("aria.soul", password="my-secret")
+
+# Awaken with decryption
+soul = await Soul.awaken("aria.soul", password="my-secret")
+```
+
+### Exception handling
+
+```python
+from soul_protocol.runtime.exceptions import (
+    SoulEncryptedError,
+    SoulDecryptionError,
+)
+
+try:
+    soul = await Soul.awaken("aria.soul")
+except SoulEncryptedError:
+    print("This soul is encrypted — provide a password.")
+except SoulDecryptionError:
+    print("Wrong password.")
+```
+
+## Archive Format
+
+An encrypted `.soul` file is a standard ZIP archive containing:
+
+| File | Encrypted? | Description |
+|------|-----------|-------------|
+| `manifest.json` | No | Contains `"encrypted": true`, format version, soul name |
+| `soul.json.enc` | Yes | Soul configuration (identity, DNA, state) |
+| `memory.json.enc` | Yes | All memory tiers |
+| `trust_chain.json.enc` | Yes | Trust chain entries |
+| `keys.json.enc` | Yes | Signing keys (when `include_keys=True`) |
+
+Each `.enc` file stores: `salt (16B) || nonce (12B) || ciphertext+tag`.

--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -170,6 +170,40 @@ def cli():
     pass
 
 
+async def _awaken_or_fail(
+    path: str | Path,
+    password: str | None = None,
+    *,
+    engine=None,
+) -> Soul:  # noqa: F821
+    """Awaken a soul, catching encryption errors with a friendly CLI message.
+
+    All read commands should use this instead of ``Soul.awaken()`` directly
+    so that encrypted .soul files produce a helpful hint rather than a raw
+    traceback (#294).
+    """
+    from soul_protocol.runtime.exceptions import (
+        SoulDecryptionError,
+        SoulEncryptedError,
+    )
+    from soul_protocol.runtime.soul import Soul
+
+    try:
+        return await Soul.awaken(path, engine=engine, password=password)
+    except SoulEncryptedError:
+        console.print(
+            "[red]Error:[/red] This .soul file is encrypted. "
+            "Pass [cyan]--password[/cyan] to decrypt it."
+        )
+        sys.exit(1)
+    except SoulDecryptionError:
+        console.print(
+            "[red]Error:[/red] Wrong password — decryption failed. "
+            "Check your password and try again."
+        )
+        sys.exit(1)
+
+
 # Org + user subcommands (feat/paw-os-init — Workstream A slice 3, RFC #164)
 from soul_protocol.cli.org import org_group as _org_group  # noqa: E402
 from soul_protocol.cli.org import user_group as _user_group  # noqa: E402
@@ -293,7 +327,7 @@ def birth(
                 f"from config {config_file} ({soul.did})"
             )
         elif from_file:
-            soul = await Soul.awaken(from_file)
+            soul = await _awaken_or_fail(from_file)
             console.print(f"[green]Birthed[/green] {soul.name} from {from_file}")
         else:
             if not name:
@@ -390,7 +424,7 @@ def init(name, archetype, values, from_file, soul_dir, soul_format, setup_target
                     "[yellow]Warning:[/yellow] --from-file ignored; existing soul "
                     f"found at {soul_path}/. Remove the existing soul to replace it."
                 )
-            soul = await Soul.awaken(str(soul_path))
+            soul = await _awaken_or_fail(str(soul_path))
             console.print(
                 f"\n[green]Found[/green] existing soul [bold]{soul.name}[/bold] in {soul_path}/\n"
             )
@@ -402,7 +436,7 @@ def init(name, archetype, values, from_file, soul_dir, soul_format, setup_target
                     return
 
             if from_file:
-                soul = await Soul.awaken(from_file)
+                soul = await _awaken_or_fail(from_file)
                 console.print(f"[green]Loaded[/green] {soul.name} from {from_file}")
             else:
                 if not name:
@@ -473,13 +507,21 @@ def init(name, archetype, values, from_file, soul_dir, soul_format, setup_target
 
 @cli.command()
 @click.argument("path", type=click.Path(exists=True))
-def inspect(path):
+@click.option(
+    "--password",
+    "-p",
+    is_flag=True,
+    help="Decrypt an encrypted .soul file (prompts interactively for password).",
+)
+def inspect(path, password):
     """Inspect a Soul — identity, OCEAN, memory, state, self-model."""
 
-    async def _inspect():
-        from soul_protocol.runtime.soul import Soul
+    password_val = None
+    if password:
+        password_val = click.prompt("Decryption password", hide_input=True)
 
-        soul = await Soul.awaken(path)
+    async def _inspect():
+        soul = await _awaken_or_fail(path, password=password_val)
         age = (datetime.now() - soul.born).days
         p = soul.dna.personality
         mem = soul.memory
@@ -617,9 +659,7 @@ def status(path):
     """
 
     async def _status():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         soul.recompute_focus()
         mood = soul.state.mood.value
         energy = soul.state.energy
@@ -719,9 +759,7 @@ def export_cmd(source, output, fmt, password):
             )
 
     async def _export():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(source)
+        soul = await _awaken_or_fail(source)
         out = output or f"{_safe_name(soul.name)}.{fmt}"
 
         if fmt == "soul":
@@ -749,7 +787,13 @@ def export_cmd(source, output, fmt, password):
 @click.option(
     "--dir", "-d", "soul_dir", default=None, help="Target directory (default: .soul/<name>/)"
 )
-def unpack_cmd(source, soul_dir):
+@click.option(
+    "--password",
+    "-p",
+    is_flag=True,
+    help="Decrypt an encrypted .soul file (prompts interactively for password).",
+)
+def unpack_cmd(source, soul_dir, password):
     """Unpack a .soul file into a browsable directory.
 
     \b
@@ -762,10 +806,12 @@ def unpack_cmd(source, soul_dir):
       soul unpack guardian.soul -d guardian/  # → guardian/
     """
 
-    async def _unpack():
-        from soul_protocol.runtime.soul import Soul
+    password_val = None
+    if password:
+        password_val = click.prompt("Decryption password", hide_input=True)
 
-        soul = await Soul.awaken(source)
+    async def _unpack():
+        soul = await _awaken_or_fail(source, password=password_val)
         target = soul_dir or f".soul/{_safe_name(soul.name)}"
         await soul.save_local(target)
         console.print(f"[green]Unpacked[/green] {soul.name} → {target}/")
@@ -800,9 +846,7 @@ def retire(path, preserve_memories):
     """Retire a Soul with dignity."""
 
     async def _retire():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         name = soul.name
 
         if not click.confirm(f"Are you sure you want to retire {name}?"):
@@ -1017,9 +1061,8 @@ def archive(path, tiers):
             MockBlockchainProvider,
             MockIPFSProvider,
         )
-        from soul_protocol.runtime.soul import Soul
 
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         soul_data = Path(path).read_bytes()
 
         manager = EternalStorageManager()
@@ -1101,9 +1144,7 @@ def eternal_status(path):
     """Show eternal storage status for a .soul file."""
 
     async def _eternal_status():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
 
         # Read manifest from .soul archive
         eternal_data = {}
@@ -1218,9 +1259,7 @@ def remember_cmd(path, text, importance, emotion, memory_type, domain):
     tier = MemoryType(memory_type.lower())
 
     async def _remember():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         memory_id = await soul.remember(
             text,
             type=tier,
@@ -1327,9 +1366,7 @@ def note_cmd(path, text, importance, emotion, memory_type, domain, no_dedup, no_
     tier = MemoryType(memory_type.lower())
 
     async def _observe():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         result = await soul.note(
             text,
             type=tier,
@@ -1481,9 +1518,7 @@ def recall_cmd(
     """
 
     async def _recall():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
 
         if recent is not None:
             # Show N most recent memories across all stores. Apply --user
@@ -1624,9 +1659,7 @@ def layers_cmd(path, as_json):
     """
 
     async def _layers():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         layer_names = soul.memory.known_layers()
         layout: dict[str, dict[str, int]] = {}
         for layer_name in layer_names:
@@ -1793,9 +1826,8 @@ def export_soulspec_cmd(source, output):
 
     async def _export():
         from soul_protocol.runtime.importers.soulspec import SoulSpecImporter
-        from soul_protocol.runtime.soul import Soul
 
-        soul = await Soul.awaken(source)
+        soul = await _awaken_or_fail(source)
         out = output or f"{_safe_name(soul.name)}-soulspec"
         result = await SoulSpecImporter.to_soulspec(soul, out)
         console.print(f"[green]Exported[/green] {soul.name} to SoulSpec directory -> {result}/")
@@ -1860,9 +1892,8 @@ def export_tavernai_cmd(source, output, png):
 
     async def _export():
         from soul_protocol.runtime.importers.tavernai import TavernAIImporter
-        from soul_protocol.runtime.soul import Soul
 
-        soul = await Soul.awaken(source)
+        soul = await _awaken_or_fail(source)
         card = await TavernAIImporter.to_character_card(soul)
 
         out = output or f"{_safe_name(soul.name)}-card.json"
@@ -1897,9 +1928,8 @@ def export_a2a_cmd(source, output, url):
 
     async def _export():
         from soul_protocol.runtime.bridges.a2a import A2AAgentCardBridge
-        from soul_protocol.runtime.soul import Soul
 
-        soul = await Soul.awaken(source)
+        soul = await _awaken_or_fail(source)
         card = A2AAgentCardBridge.soul_to_agent_card(soul, url=url)
         out = output or f"{_safe_name(soul.name)}-agent-card.json"
         Path(out).write_text(json.dumps(card, indent=2, default=str))
@@ -1978,10 +2008,9 @@ def observe_cmd(path, user_input, agent_output, channel, user_id):
     """
 
     async def _observe():
-        from soul_protocol.runtime.soul import Soul
         from soul_protocol.runtime.types import Interaction
 
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         interaction = Interaction(
             user_input=user_input,
             agent_output=agent_output,
@@ -2025,9 +2054,7 @@ def reflect_cmd(path, no_apply):
     """
 
     async def _reflect():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         result = await soul.reflect(apply=not no_apply)
 
         if result is None:
@@ -2113,9 +2140,7 @@ def dream_cmd(path, since, no_archive, no_synthesize, dry_run, as_json):
     """
 
     async def _dream():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         report = await soul.dream(
             since=since,
             archive=not no_archive,
@@ -2256,10 +2281,9 @@ def feel_cmd(path, mood, energy, focus):
     """
 
     async def _feel():
-        from soul_protocol.runtime.soul import Soul
         from soul_protocol.runtime.types import FOCUS_LEVELS, Mood
 
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
 
         kwargs = {}
         if mood is not None:
@@ -2321,9 +2345,7 @@ def prompt_cmd(path):
     """
 
     async def _prompt():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         click.echo(soul.to_system_prompt())
 
     asyncio.run(_prompt())
@@ -2374,9 +2396,7 @@ def forget_cmd(path, query, memory_id, entity, before, apply_changes, skip_confi
     """
 
     async def _forget():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         timestamp = None
 
         # Mutually-exclusive selector check — pick exactly one.
@@ -2550,9 +2570,7 @@ def supersede_cmd(path, new_content, old_id, reason, importance, emotion, memory
     tier_override = MemoryType(memory_type.lower()) if memory_type else None
 
     async def _supersede():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         result = await soul.supersede(
             old_id,
             new_content,
@@ -2615,9 +2633,7 @@ def confirm_cmd(path, memory_id, user_id):
     """
 
     async def _confirm():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         result = await soul.confirm(memory_id, user_id=user_id)
         if not result.get("found"):
             console.print(
@@ -2688,9 +2704,8 @@ def update_cmd(path, memory_id, patch_text, prediction_error, user_id):
             PredictionErrorOutOfBandError,
             ReconsolidationWindowClosedError,
         )
-        from soul_protocol.runtime.soul import Soul
 
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         # The window is per-process. Open it explicitly via recall against
         # the current content of the entry so the CLI is usable in a single
         # invocation (the alternative is a separate ``soul recall`` call
@@ -2773,9 +2788,7 @@ def purge_cmd(path, memory_id, apply_changes, user_id, skip_confirm):
     """
 
     async def _purge():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         if not apply_changes:
             entry, tier = await soul.memory.find_by_id(memory_id)
             if entry is None:
@@ -2836,9 +2849,7 @@ def reinstate_cmd(path, memory_id, user_id):
     """
 
     async def _reinstate():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         result = await soul.reinstate(memory_id, user_id=user_id)
         if not result.get("found"):
             console.print(
@@ -2899,13 +2910,11 @@ def upgrade_cmd(path, target_version, dry_run):
     """
 
     async def _upgrade():
-        from soul_protocol.runtime.soul import Soul
-
         if target_version != "0.5.0":
             console.print(f"[red]Unsupported target version: {target_version}[/red]")
             raise SystemExit(1)
 
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         # Walk every memory and derive the supersedes back-edge from the
         # existing superseded_by reverse map. Pydantic defaults already
         # handled retrieval_weight=1.0 and prediction_error=None at load
@@ -2973,9 +2982,7 @@ def edit_core_cmd(path, persona, human):
     """
 
     async def _edit_core():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
 
         if persona is None and human is None:
             console.print("[red]Provide at least --persona or --human[/red]")
@@ -3033,9 +3040,7 @@ def evolve_cmd(path, propose, trait, value, reason, approve_id, reject_id, list_
     """
 
     async def _evolve():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
 
         if propose:
             if not all([trait, value, reason]):
@@ -3130,10 +3135,9 @@ def evaluate_cmd(path, user_input, agent_output, domain):
     """
 
     async def _evaluate():
-        from soul_protocol.runtime.soul import Soul
         from soul_protocol.runtime.types import Interaction
 
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         interaction = Interaction(
             user_input=user_input,
             agent_output=agent_output,
@@ -3192,10 +3196,9 @@ def learn_cmd(path, user_input, agent_output, domain):
     """
 
     async def _learn():
-        from soul_protocol.runtime.soul import Soul
         from soul_protocol.runtime.types import Interaction
 
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         interaction = Interaction(
             user_input=user_input,
             agent_output=agent_output,
@@ -3245,9 +3248,7 @@ def skills_cmd(path):
     """
 
     async def _skills():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         registry = soul.skills
 
         if not registry.skills:
@@ -3291,9 +3292,7 @@ def bond_cmd(path, strengthen):
     """
 
     async def _bond():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         bond = soul.bond
 
         if strengthen is not None:
@@ -3334,9 +3333,7 @@ def events_cmd(path, recent):
     """
 
     async def _events():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         all_events = soul.general_events
 
         if not all_events:
@@ -3472,9 +3469,8 @@ def health_cmd(path):
 
     async def _health():
         from soul_protocol.runtime.memory.compression import MemoryCompressor
-        from soul_protocol.runtime.soul import Soul
 
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         mm = soul.memory
 
         episodic = mm.episodic_entries()
@@ -3609,9 +3605,8 @@ def cleanup_cmd(
 
     async def _cleanup():
         from soul_protocol.runtime.memory.compression import MemoryCompressor
-        from soul_protocol.runtime.soul import Soul
 
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         mm = soul.memory
         actions = []
 
@@ -3739,9 +3734,7 @@ def repair_cmd(
     """Repair a soul — reset state, rebuild graph, clear stale data."""
 
     async def _repair():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         changes = []
 
         if reset_energy:
@@ -3811,10 +3804,9 @@ def verify_cmd(path, as_json):
     """
 
     async def _verify():
-        from soul_protocol.runtime.soul import Soul
         from soul_protocol.spec.trust import chain_integrity_check
 
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         summary = chain_integrity_check(soul.trust_chain)
 
         # Compute time span (first → last entry)
@@ -3895,9 +3887,7 @@ def audit_cmd(path, action_prefix, limit, as_json, no_summary):
     """
 
     async def _audit():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         log = soul.audit_log(action_prefix=action_prefix, limit=limit)
 
         if as_json:
@@ -3957,9 +3947,7 @@ def graph_nodes(path, node_type, name_match, limit, as_json):
     """List nodes in the soul's knowledge graph."""
 
     async def _go():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         nodes = soul.graph.nodes(type=node_type, name_match=name_match, limit=limit)
         if as_json:
             console.print_json(
@@ -3995,9 +3983,7 @@ def graph_edges(path, source, target, relation, as_json):
     """List active edges in the soul's knowledge graph."""
 
     async def _go():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         edges = soul.graph.edges(source=source, target=target, relation=relation)
         if as_json:
             console.print_json(
@@ -4038,9 +4024,7 @@ def graph_neighbors(path, node_id, depth, types, as_json):
     """List nodes within ``depth`` hops of NODE_ID."""
 
     async def _go():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         type_list = [t.strip() for t in types.split(",")] if types else None
         nodes = soul.graph.neighbors(node_id, depth=depth, types=type_list)
         if as_json:
@@ -4081,9 +4065,7 @@ def graph_path(path, source_id, target_id, max_depth, as_json):
     """Find the shortest path of edges from SOURCE_ID to TARGET_ID."""
 
     async def _go():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         chain = soul.graph.path(source_id, target_id, max_depth=max_depth)
         if as_json:
             console.print_json(
@@ -4114,9 +4096,7 @@ def graph_mermaid(path):
     """Print the soul's full graph as a Mermaid ``graph LR`` block."""
 
     async def _go():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         console.print(soul.graph.to_mermaid())
 
     asyncio.run(_go())
@@ -4179,9 +4159,7 @@ def prune_chain_cmd(path, apply_changes, keep, reason, as_json):
     """
 
     async def _prune():
-        from soul_protocol.runtime.soul import Soul
-
-        soul = await Soul.awaken(path)
+        soul = await _awaken_or_fail(path)
         mgr = soul.trust_chain_manager
 
         # Resolve the keep threshold. CLI override wins; otherwise fall

--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -708,7 +708,7 @@ def export_cmd(source, output, fmt, password):
             except ImportError:
                 console.print(
                     "[red]Error:[/red] The 'cryptography' package is required for encryption.\n"
-                    "Install with: pip install soul-protocol[encryption]"
+                    "Install with: pip install cryptography"
                 )
                 sys.exit(1)
 

--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -682,8 +682,41 @@ def status(path):
     default="soul",
     help="Export format",
 )
-def export_cmd(source, output, fmt):
-    """Export a Soul to a different format."""
+@click.option(
+    "--password",
+    "-p",
+    is_flag=True,
+    help="Encrypt the .soul file with AES-256-GCM (prompts interactively for password).",
+)
+def export_cmd(source, output, fmt, password):
+    """Export a Soul to a different format.
+
+    When --password is provided, the exported .soul archive is encrypted
+    with AES-256-GCM using a scrypt-derived key. All contents except the
+    manifest are encrypted. Requires the `cryptography` package.
+    """
+    # Prompt for password interactively for security (no inline password args allowed)
+    password_val = None
+    if password:
+        if fmt != "soul":
+            console.print(
+                "[yellow]Warning:[/yellow] --password only applies to .soul format; ignoring."
+            )
+        else:
+            try:
+                from cryptography.hazmat.primitives.ciphers.aead import AESGCM  # noqa: F401
+            except ImportError:
+                console.print(
+                    "[red]Error:[/red] The 'cryptography' package is required for encryption.\n"
+                    "Install with: pip install soul-protocol[encryption]"
+                )
+                sys.exit(1)
+
+            password_val = click.prompt(
+                "Encryption password",
+                hide_input=True,
+                confirmation_prompt=True,
+            )
 
     async def _export():
         from soul_protocol.runtime.soul import Soul
@@ -692,7 +725,7 @@ def export_cmd(source, output, fmt):
         out = output or f"{_safe_name(soul.name)}.{fmt}"
 
         if fmt == "soul":
-            await soul.export(out, include_keys=True)
+            await soul.export(out, include_keys=True, password=password_val)
         elif fmt == "json":
             Path(out).write_text(soul.serialize().model_dump_json(indent=2))
         elif fmt == "yaml":
@@ -705,6 +738,8 @@ def export_cmd(source, output, fmt):
             Path(out).write_text(dna_to_markdown(soul.identity, soul.dna))
 
         console.print(f"[green]Exported[/green] {soul.name} to {out} ({fmt})")
+        if password_val and fmt == "soul":
+            console.print("[dim]File is encrypted with AES-256-GCM.[/dim]")
 
     asyncio.run(_export())
 

--- a/src/soul_protocol/cli/main.py
+++ b/src/soul_protocol/cli/main.py
@@ -1,4 +1,7 @@
 # cli/main.py — Click CLI for the Soul Protocol (org + user groups + runtime commands)
+# Updated: 2026-08-04 (#294) — Wires `--password` flag into `soul export`,
+#   `soul inspect`, and `soul unpack` for AES-256-GCM encryption at rest.
+#   Password is prompt-only (is_flag=True) so it never leaks into shell history.
 # Updated: 2026-07-17 (#286) — Catch unknown-tier ValueError in ``soul archive``;
 #   exit 1 so scripts can detect failure.
 # Updated: 2026-07-18 (#284) — Replaced ~45 private attribute accesses

--- a/tests/test_cli/test_export_password.py
+++ b/tests/test_cli/test_export_password.py
@@ -1,0 +1,178 @@
+# test_export_password.py — Tests for `soul export --password` (Phase 2).
+# Verifies AES-256-GCM encryption is correctly wired through the CLI,
+# and that passwords are securely prompted (not passed inline).
+
+from __future__ import annotations
+
+import json
+import os
+import zipfile
+
+import pytest
+from click.testing import CliRunner
+
+from soul_protocol.cli.main import cli
+
+
+def _birth(runner, tmp_path, name="EncryptTest"):
+    """Create a soul and return the .soul path."""
+    output_path = str(tmp_path / f"{name}.soul")
+    result = runner.invoke(cli, ["birth", name, "-o", output_path])
+    assert result.exit_code == 0, result.output
+    assert os.path.exists(output_path)
+    return output_path
+
+
+class TestExportPassword:
+    """Tests for the --password encryption option."""
+
+    def test_encrypted_export_creates_enc_files(self, tmp_path):
+        """Encrypted export should have .enc extension on files."""
+        runner = CliRunner()
+        soul_path = _birth(runner, tmp_path)
+
+        out_path = str(tmp_path / "encrypted.soul")
+        result = runner.invoke(
+            cli,
+            ["export", soul_path, "-o", out_path, "--password"],
+            input="testpass123\ntestpass123\n",
+        )
+        assert result.exit_code == 0
+
+        with zipfile.ZipFile(out_path) as zf:
+            names = zf.namelist()
+            # soul.json should be encrypted as soul.json.enc
+            assert any(n.endswith(".enc") for n in names), f"No encrypted files found: {names}"
+
+    def test_encrypted_export_manifest_unencrypted(self, tmp_path):
+        """Manifest should remain unencrypted and readable."""
+        runner = CliRunner()
+        soul_path = _birth(runner, tmp_path)
+
+        out_path = str(tmp_path / "encrypted.soul")
+        result = runner.invoke(
+            cli,
+            ["export", soul_path, "-o", out_path, "--password"],
+            input="testpass123\ntestpass123\n",
+        )
+        assert result.exit_code == 0
+
+        with zipfile.ZipFile(out_path) as zf:
+            names = zf.namelist()
+            # manifest.json should NOT have .enc
+            assert "manifest.json" in names, f"manifest.json missing: {names}"
+            assert "manifest.json.enc" not in names
+
+            # manifest should be valid JSON with encrypted=true
+            manifest = json.loads(zf.read("manifest.json"))
+            assert manifest["encrypted"] is True
+
+    def test_encrypted_export_shows_notice(self, tmp_path):
+        """Encrypted export should print encryption notice."""
+        runner = CliRunner()
+        soul_path = _birth(runner, tmp_path)
+
+        out_path = str(tmp_path / "encrypted.soul")
+        result = runner.invoke(
+            cli,
+            ["export", soul_path, "-o", out_path, "--password"],
+            input="testpass123\ntestpass123\n",
+        )
+        assert result.exit_code == 0
+        assert "AES-256-GCM" in result.output
+
+    def test_password_mismatched_confirmation(self, tmp_path):
+        """Export should fail if password and confirmation do not match."""
+        runner = CliRunner()
+        soul_path = _birth(runner, tmp_path)
+
+        out_path = str(tmp_path / "encrypted.soul")
+        result = runner.invoke(
+            cli,
+            ["export", soul_path, "-o", out_path, "--password"],
+            input="testpass123\nwrongpass\n",
+        )
+        assert result.exit_code != 0
+        assert "Error: The two entered values do not match." in result.output
+        assert not os.path.exists(out_path)
+
+    def test_unencrypted_export_no_enc_files(self, tmp_path):
+        """Export without --password should not have .enc files."""
+        runner = CliRunner()
+        soul_path = _birth(runner, tmp_path)
+
+        out_path = str(tmp_path / "plain.soul")
+        result = runner.invoke(cli, ["export", soul_path, "-o", out_path])
+        assert result.exit_code == 0
+
+        with zipfile.ZipFile(out_path) as zf:
+            names = zf.namelist()
+            assert not any(n.endswith(".enc") for n in names), (
+                f"Found .enc files in unencrypted export: {names}"
+            )
+
+    def test_unencrypted_manifest_not_encrypted(self, tmp_path):
+        """Unencrypted export manifest should have encrypted=false."""
+        runner = CliRunner()
+        soul_path = _birth(runner, tmp_path)
+
+        out_path = str(tmp_path / "plain.soul")
+        result = runner.invoke(cli, ["export", soul_path, "-o", out_path])
+        assert result.exit_code == 0
+
+        with zipfile.ZipFile(out_path) as zf:
+            manifest = json.loads(zf.read("manifest.json"))
+            assert manifest["encrypted"] is False
+
+    def test_password_ignored_for_non_soul_format(self, tmp_path):
+        """--password with --format json should show warning."""
+        runner = CliRunner()
+        soul_path = _birth(runner, tmp_path)
+
+        out_path = str(tmp_path / "output.json")
+        result = runner.invoke(
+            cli,
+            ["export", soul_path, "-o", out_path, "-f", "json", "--password"],
+            input="testpass123\ntestpass123\n",
+        )
+        assert result.exit_code == 0
+        assert "Warning" in result.output
+
+
+class TestExportPasswordRoundTrip:
+    """Tests for encrypted export/awaken round-trip."""
+
+    def test_awaken_with_correct_password(self, tmp_path):
+        """Soul exported with password can be awakened with same password."""
+        import asyncio
+
+        from soul_protocol.runtime.soul import Soul
+
+        async def _test():
+            soul = await Soul.birth("RoundTrip")
+            await soul.remember("Secret memory", importance=9)
+            path = str(tmp_path / "encrypted.soul")
+            await soul.export(path, password="mysecret")
+
+            # Awaken with correct password
+            restored = await Soul.awaken(path, password="mysecret")
+            assert restored.name == "RoundTrip"
+
+        asyncio.run(_test())
+
+    def test_awaken_with_wrong_password_fails(self, tmp_path):
+        """Soul exported with password fails with wrong password."""
+        import asyncio
+
+        from soul_protocol.runtime.exceptions import SoulDecryptionError
+        from soul_protocol.runtime.soul import Soul
+
+        async def _test():
+            soul = await Soul.birth("WrongPass")
+            path = str(tmp_path / "encrypted.soul")
+            await soul.export(path, password="correct")
+
+            with pytest.raises((SoulDecryptionError, ValueError)):
+                await Soul.awaken(path, password="wrong")
+
+        asyncio.run(_test())

--- a/tests/test_cli/test_export_password.py
+++ b/tests/test_cli/test_export_password.py
@@ -158,6 +158,16 @@ class TestExportPasswordRoundTrip:
             restored = await Soul.awaken(path, password="mysecret")
             assert restored.name == "RoundTrip"
 
+            # Assert encrypted memory tiers survived the round-trip (#294 review).
+            # The name lives in the plaintext manifest — this catches bugs that
+            # silently drop encrypted memory data during export or awaken.
+            facts = restored._memory._semantic.facts()
+            assert len(facts) > 0, (
+                "No semantic facts after encrypted round-trip — "
+                "encrypted memory tiers were likely dropped."
+            )
+            assert any("Secret memory" in f.content for f in facts)
+
         asyncio.run(_test())
 
     def test_awaken_with_wrong_password_fails(self, tmp_path):
@@ -208,6 +218,9 @@ class TestCLIRoundTrip:
         )
         assert result.exit_code == 0
         assert "CLIRoundTrip" in result.output
+        # Verify inspect shows memory counts survived encryption (#294 review).
+        # The inspect panel header is "Memory", and shows "Semantic      1".
+        assert "Semantic" in result.output and "1" in result.output
 
     def test_cli_export_unpack_roundtrip(self, tmp_path):
         """export --password → unpack --password should unpack successfully."""

--- a/tests/test_cli/test_export_password.py
+++ b/tests/test_cli/test_export_password.py
@@ -176,3 +176,103 @@ class TestExportPasswordRoundTrip:
                 await Soul.awaken(path, password="wrong")
 
         asyncio.run(_test())
+
+
+class TestCLIRoundTrip:
+    """CLI round-trip: export --password → inspect/unpack --password (#294 review)."""
+
+    def test_cli_export_inspect_roundtrip(self, tmp_path):
+        """export --password → inspect --password should display soul info."""
+        runner = CliRunner()
+        soul_path = _birth(runner, tmp_path, name="CLIRoundTrip")
+
+        # Add a memory via CLI
+        result = runner.invoke(cli, ["remember", soul_path, "The secret code is 42"])
+        assert result.exit_code == 0
+
+        # Export with password
+        enc_path = str(tmp_path / "encrypted.soul")
+        result = runner.invoke(
+            cli,
+            ["export", soul_path, "-o", enc_path, "--password"],
+            input="hunter2\nhunter2\n",
+        )
+        assert result.exit_code == 0
+        assert "AES-256-GCM" in result.output
+
+        # Inspect with correct password should work
+        result = runner.invoke(
+            cli,
+            ["inspect", enc_path, "--password"],
+            input="hunter2\n",
+        )
+        assert result.exit_code == 0
+        assert "CLIRoundTrip" in result.output
+
+    def test_cli_export_unpack_roundtrip(self, tmp_path):
+        """export --password → unpack --password should unpack successfully."""
+        runner = CliRunner()
+        soul_path = _birth(runner, tmp_path, name="UnpackRound")
+
+        # Export with password
+        enc_path = str(tmp_path / "encrypted.soul")
+        result = runner.invoke(
+            cli,
+            ["export", soul_path, "-o", enc_path, "--password"],
+            input="secret99\nsecret99\n",
+        )
+        assert result.exit_code == 0
+
+        # Unpack with correct password should work
+        unpack_dir = str(tmp_path / "unpacked")
+        result = runner.invoke(
+            cli,
+            ["unpack", enc_path, "-d", unpack_dir, "--password"],
+            input="secret99\n",
+        )
+        assert result.exit_code == 0
+        assert "Unpacked" in result.output
+
+    def test_cli_inspect_encrypted_without_password_shows_hint(self, tmp_path):
+        """inspect on encrypted file without --password → friendly error, not traceback."""
+        runner = CliRunner()
+        soul_path = _birth(runner, tmp_path, name="NoPass")
+
+        enc_path = str(tmp_path / "encrypted.soul")
+        result = runner.invoke(
+            cli,
+            ["export", soul_path, "-o", enc_path, "--password"],
+            input="pass123\npass123\n",
+        )
+        assert result.exit_code == 0
+
+        # Inspect WITHOUT --password should give a friendly error
+        result = runner.invoke(cli, ["inspect", enc_path])
+        assert result.exit_code != 0
+        assert "encrypted" in result.output.lower()
+        assert "--password" in result.output
+        # Should NOT contain a Python traceback
+        assert "Traceback" not in result.output
+
+    def test_cli_inspect_wrong_password_shows_error(self, tmp_path):
+        """inspect --password with wrong password → friendly decryption error."""
+        runner = CliRunner()
+        soul_path = _birth(runner, tmp_path, name="WrongPW")
+
+        enc_path = str(tmp_path / "encrypted.soul")
+        result = runner.invoke(
+            cli,
+            ["export", soul_path, "-o", enc_path, "--password"],
+            input="correct\ncorrect\n",
+        )
+        assert result.exit_code == 0
+
+        # Inspect with WRONG password should give a friendly error
+        result = runner.invoke(
+            cli,
+            ["inspect", enc_path, "--password"],
+            input="wrong\n",
+        )
+        assert result.exit_code != 0
+        assert "Wrong password" in result.output or "decryption failed" in result.output.lower()
+        assert "Traceback" not in result.output


### PR DESCRIPTION
## Description

This PR implements Phase 2 of the encryption feature by wiring the `--password` flag through the `soul export` CLI command. The underlying AES-256-GCM encryption and scrypt key derivation logic was already implemented in the `runtime/export/crypto.py` layer; this PR surfaces it securely to the user.

### Key Changes
- **Secure Interactive Prompts**: The `--password` option is implemented as a prompt-only flag (`is_flag=True`). This prevents users from passing passwords inline (e.g. `--password mysecret`), ensuring passwords do not leak into shell history or process listings.
- **Dependency Guard**: Added a user-friendly error message if the `cryptography` package is missing.
- **Manifest Readability**: The `manifest.json` file remains unencrypted so readers can inspect metadata and see the `"encrypted": true` flag without needing the password.
- **Documentation**: Updated `docs/cli-reference.md` with the new option and an example of its interactive usage.
- **Testing**: Added `tests/test_cli/test_export_password.py` with 9 tests covering archive structure, interactive prompt simulation, mismatched confirmation handling, format warnings, and async encryption/decryption round-trips.

## Verification
- `ruff check` and `ruff format --check` pass.
- 9/9 tests pass in `tests/test_cli/test_export_password.py`.

