### PR TITLE
Fix/graph recall rebind 281

### DIFF
--- a/src/soul_protocol/runtime/memory/manager.py
+++ b/src/soul_protocol/runtime/memory/manager.py
@@ -1,4 +1,8 @@
 # memory/manager.py — MemoryManager facade orchestrating all memory subsystems.
+# Updated: 2026-07-11 (#281) — Rewire recall engine graph reference after
+#   from_dict(). The RecallEngine held a stale reference to the pre-restore
+#   empty KnowledgeGraph, so graph-augmented recall returned nothing after
+#   awaken/reincarnate.
 # Updated: 2026-06-16 (feat/soul-skills-procedural) — adds
 #   consolidate_agent_procedures(): a curator pass over PROCEDURAL memories that
 #   only ever considers AGENT-authored entries (provenance == AGENT). It finds
@@ -2409,8 +2413,8 @@ class MemoryManager:
         graph_data = data.get("graph", {})
         if graph_data:
             manager._graph = KnowledgeGraph.from_dict(graph_data)
-            # Re-wire the recall engine to point to the restored graph
-            manager._recall_engine._graph = manager._graph
+            # Re-wire the recall engine to point to the restored graph (#281)
+            manager._recall_engine.rebind_graph(manager._graph)
 
         self_model_data = data.get("self_model", {})
         if self_model_data:

--- a/src/soul_protocol/runtime/memory/manager.py
+++ b/src/soul_protocol/runtime/memory/manager.py
@@ -2409,6 +2409,8 @@ class MemoryManager:
         graph_data = data.get("graph", {})
         if graph_data:
             manager._graph = KnowledgeGraph.from_dict(graph_data)
+            # Re-wire the recall engine to point to the restored graph
+            manager._recall_engine._graph = manager._graph
 
         self_model_data = data.get("self_model", {})
         if self_model_data:

--- a/src/soul_protocol/runtime/memory/recall.py
+++ b/src/soul_protocol/runtime/memory/recall.py
@@ -1,4 +1,7 @@
 # memory/recall.py — RecallEngine for cross-store memory retrieval.
+# Updated: 2026-07-11 (#281) — Added rebind_graph() so from_dict() can
+#   re-point the engine at the restored KnowledgeGraph without reaching
+#   into _graph directly.
 # Updated: 2026-03-29 — Added progressive parameter to recall(). When progressive=True,
 #   returns up to limit*2 entries: primary (full content) + overflow (abstract-only copies).
 #   Overflow entries with no abstract keep their original content unchanged.
@@ -108,6 +111,15 @@ class RecallEngine:
         self._procedural = procedural
         self._strategy = strategy if strategy is not None else BM25SearchStrategy()
         self._personality = personality
+        self._graph = graph
+
+    def rebind_graph(self, graph: KnowledgeGraph | None) -> None:
+        """Replace the graph reference used for graph-augmented recall.
+
+        Called by ``MemoryManager.from_dict()`` after deserializing a new
+        KnowledgeGraph so that subsequent recall queries see the restored
+        entities instead of the old, empty graph (#281).
+        """
         self._graph = graph
 
     async def recall(

--- a/tests/test_memory/test_memory.py
+++ b/tests/test_memory/test_memory.py
@@ -422,3 +422,26 @@ class TestSignificanceShortCircuit:
         # assess_significance scored low
         mgr._cognitive.extract_entities.assert_called_once()
         mgr._cognitive.update_self_model.assert_called_once()
+
+def test_from_dict_rewires_recall_engine_graph(manager: MemoryManager):
+    """Regression test for Issue #281: from_dict rebinds the recall engine's graph reference."""
+    import asyncio
+    
+    async def _test():
+        # 1. Mutate the graph on the fresh manager
+        manager._graph.add_entity("Alice", "person")
+        manager._graph.add_entity("Bob", "person")
+        manager._graph.add_relationship("Alice", "Bob", "likes")
+        
+        # 2. Serialize and Deserialize
+        state = manager.to_dict()
+        restored = MemoryManager.from_dict(state, MemorySettings())
+        
+        # 3. Verify the engine graph reference matches the restored manager graph reference
+        assert restored._recall_engine._graph is restored._graph
+        
+        # 4. Verify the graph actually contains the data
+        assert "Alice" in restored._graph._entities
+        assert "Bob" in restored._graph._entities
+        
+    asyncio.run(_test())

--- a/tests/test_memory/test_memory.py
+++ b/tests/test_memory/test_memory.py
@@ -423,25 +423,26 @@ class TestSignificanceShortCircuit:
         mgr._cognitive.extract_entities.assert_called_once()
         mgr._cognitive.update_self_model.assert_called_once()
 
+
 def test_from_dict_rewires_recall_engine_graph(manager: MemoryManager):
     """Regression test for Issue #281: from_dict rebinds the recall engine's graph reference."""
     import asyncio
-    
+
     async def _test():
         # 1. Mutate the graph on the fresh manager
         manager._graph.add_entity("Alice", "person")
         manager._graph.add_entity("Bob", "person")
         manager._graph.add_relationship("Alice", "Bob", "likes")
-        
+
         # 2. Serialize and Deserialize
         state = manager.to_dict()
         restored = MemoryManager.from_dict(state, MemorySettings())
-        
+
         # 3. Verify the engine graph reference matches the restored manager graph reference
         assert restored._recall_engine._graph is restored._graph
-        
+
         # 4. Verify the graph actually contains the data
         assert "Alice" in restored._graph._entities
         assert "Bob" in restored._graph._entities
-        
+
     asyncio.run(_test())

--- a/tests/test_memory/test_memory.py
+++ b/tests/test_memory/test_memory.py
@@ -425,24 +425,56 @@ class TestSignificanceShortCircuit:
 
 
 def test_from_dict_rewires_recall_engine_graph(manager: MemoryManager):
-    """Regression test for Issue #281: from_dict rebinds the recall engine's graph reference."""
+    """Regression test for Issue #281: graph-augmented recall works after from_dict.
+
+    The original bug: from_dict() rebuilt the KnowledgeGraph but the RecallEngine
+    kept a stale reference to the old, empty graph.  This test exercises the
+    actual symptom — recall returning no graph-augmented results after a
+    serialize/deserialize round-trip.
+    """
     import asyncio
 
     async def _test():
-        # 1. Mutate the graph on the fresh manager
+        # 1. Seed graph entities + a relationship
         manager._graph.add_entity("Alice", "person")
         manager._graph.add_entity("Bob", "person")
-        manager._graph.add_relationship("Alice", "Bob", "likes")
+        manager._graph.add_relationship("Alice", "Bob", "friend_of")
 
-        # 2. Serialize and Deserialize
+        # 2. Store a semantic memory mentioning "Bob"
+        bob_entry = MemoryEntry(
+            content="Bob helped me with the Python project yesterday",
+            type=MemoryType.SEMANTIC,
+            importance=8,
+        )
+        await manager.add(bob_entry)
+
+        # 3. Serialize → deserialize (simulates awaken / reincarnate)
         state = manager.to_dict()
         restored = MemoryManager.from_dict(state, MemorySettings())
 
-        # 3. Verify the engine graph reference matches the restored manager graph reference
-        assert restored._recall_engine._graph is restored._graph
+        # 4. Use the recall engine directly with use_graph=True to
+        #    verify graph augmentation works after restore.
+        #    Query "Alice" — graph should traverse Alice→Bob and
+        #    search for "Bob"-related memories.
+        results = await restored._recall_engine.recall(
+            "Alice",
+            use_graph=True,
+            limit=10,
+        )
 
-        # 4. Verify the graph actually contains the data
-        assert "Alice" in restored._graph._entities
-        assert "Bob" in restored._graph._entities
+        # Without the fix, restored._recall_engine._graph pointed at
+        # the old empty graph, so graph augmentation found zero entities
+        # and this returned nothing.
+        assert len(results) > 0, (
+            "Graph-augmented recall returned no results after from_dict — "
+            "the recall engine is still pointing at the old, empty graph."
+        )
+
+        # At least one result should mention Bob (surfaced via graph edge)
+        bob_mentioned = any("Bob" in r.content for r in results)
+        assert bob_mentioned, (
+            f"Expected a Bob-related memory via graph traversal, "
+            f"got: {[r.content[:60] for r in results]}"
+        )
 
     asyncio.run(_test())


### PR DESCRIPTION
## Description
This PR resolves Issue #281 where graph-augmented recall silently degraded after a Soul was restored from its state.

### The Bug
During initialization (`MemoryManager.__init__`), the `RecallEngine` was instantiated with a reference to an empty `KnowledgeGraph`. 
When `MemoryManager.from_dict()` restored a state, it completely rebuilt the graph and rebounded `manager._graph`, but the `manager._recall_engine` continued holding onto the old, empty graph. Because of this stale reference, graph-augmented recall returned empty results for restored souls, even while new observations mutated the new graph correctly.

### The Fix
- Rewired the graph reference inside `from_dict()` immediately after the `KnowledgeGraph` is restored: `manager._recall_engine._graph = manager._graph`.
- Confirmed that this is the lowest-risk approach for deserialization (other built-in stores like episodic/semantic are updated in-place via `.model_validate` so they do not suffer from this rebinding hazard).

### Testing Added
- Added a regression test `test_from_dict_rewires_recall_engine_graph` to `tests/test_memory/test_memory.py`.
- The test explicitly mutates a graph, serializes it, and asserts that `restored._recall_engine._graph is restored._graph` after calling `from_dict`.

Fixes #281
