### PR TITLE
fix(memory): include archives tier in export and flat saves (fixes #283)

### DIFF
--- a/src/soul_protocol/runtime/export/pack.py
+++ b/src/soul_protocol/runtime/export/pack.py
@@ -117,6 +117,7 @@ async def pack_soul(
                 "graph",
                 "self_model",
                 "general_events",
+                "archives",  # v0.5.0 (#283) — consolidated memory summaries
             ]:
                 default = {} if tier_name in ("graph", "self_model") else []
                 tier_data = memory_data.get(tier_name, default)

--- a/src/soul_protocol/runtime/export/pack.py
+++ b/src/soul_protocol/runtime/export/pack.py
@@ -1,4 +1,6 @@
 # export/pack.py — Create .soul zip archives from a SoulConfig.
+# Updated: 2026-07-12 (#283) — Added "archives" to the pack tier list so
+#   consolidated conversation summaries survive export round-trips.
 # Updated: 2026-04-29 (#42) — Trust chain is written to ``trust_chain/chain.json``
 #   (canonical Pydantic-serialized form) plus ``trust_chain/entry_NNN.json`` for
 #   human inspection. Soul keys are persisted under ``keys/`` — public.key always,

--- a/src/soul_protocol/runtime/export/unpack.py
+++ b/src/soul_protocol/runtime/export/unpack.py
@@ -106,6 +106,7 @@ async def unpack_soul(
             "graph",
             "self_model",
             "general_events",
+            "archives",  # v0.5.0 (#283) — consolidated memory summaries
         ]:
             mem_path = f"memory/{tier_name}.json"
             exists = (f"{mem_path}.enc" in names) if is_encrypted else (mem_path in names)

--- a/src/soul_protocol/runtime/export/unpack.py
+++ b/src/soul_protocol/runtime/export/unpack.py
@@ -1,4 +1,6 @@
 # export/unpack.py — Load a SoulConfig from a .soul zip archive.
+# Updated: 2026-07-12 (#283) — Added "archives" to the unpack tier list so
+#   consolidated conversation summaries are restored from .soul archives.
 # Updated: 2026-04-29 (#42) — Read the trust chain (trust_chain/chain.json)
 #   and key files (keys/public.key, keys/private.key) when present. Both are
 #   optional — souls predating #42 just have an empty chain. Returns the

--- a/src/soul_protocol/runtime/storage/file.py
+++ b/src/soul_protocol/runtime/storage/file.py
@@ -159,6 +159,7 @@ _FLAT_TIERS: list[tuple[str, object]] = [
     ("graph", {}),
     ("self_model", {}),
     ("general_events", []),
+    ("archives", []),  # v0.5.0 (#283) — consolidated memory summaries
 ]
 
 _LAYER_TIERS = ("episodic", "semantic", "procedural", "social")

--- a/src/soul_protocol/runtime/storage/file.py
+++ b/src/soul_protocol/runtime/storage/file.py
@@ -1,4 +1,6 @@
 # storage/file.py — FileStorage backend persisting souls to the local filesystem.
+# Updated: 2026-07-12 (#283) — Added "archives" to _FLAT_TIERS so flat
+#   directory saves include consolidated conversation summaries.
 # Updated: 2026-04-29 (#42) — Trust chain + keystore land alongside the soul.
 #   ``trust_chain/chain.json`` and per-entry ``trust_chain/entry_NNN.json`` are
 #   written when the chain has any entries. ``keys/public.key`` is always

--- a/tests/test_memory/test_consolidation.py
+++ b/tests/test_memory/test_consolidation.py
@@ -525,3 +525,69 @@ class TestSoulGeneralEventsProperty:
         themes = [ge.theme for ge in soul.general_events]
         assert "coding" in themes
         assert "debugging" in themes
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #283 — archives tier persistence
+# ---------------------------------------------------------------------------
+
+
+class TestArchivesPersistence:
+    """Verify that the archives memory tier survives export and save."""
+
+    async def test_export_awaken_preserves_archives(self, tmp_path):
+        """Archives survive a .soul export/awaken round-trip (#283)."""
+        from datetime import datetime
+
+        from soul_protocol.runtime.memory.archival import ConversationArchive
+
+        soul = await Soul.birth("Aria")
+
+        # Manually seed an archive (normally created by archive_old_memories)
+        archive = ConversationArchive(
+            id="archive-001",
+            start_time=datetime(2026, 1, 1),
+            end_time=datetime(2026, 1, 2),
+            summary="Discussed Python best practices",
+            key_moments=["learned about type hints"],
+        )
+        soul._memory._archival.archive_conversation(archive)
+        assert len(soul._memory._archival.all_archives()) == 1
+
+        # Export and re-awaken
+        path = tmp_path / "aria.soul"
+        await soul.export(str(path))
+        restored = await Soul.awaken(str(path))
+
+        archives = restored._memory._archival.all_archives()
+        assert len(archives) == 1
+        assert archives[0].id == "archive-001"
+        assert archives[0].summary == "Discussed Python best practices"
+
+    async def test_save_load_preserves_archives(self, tmp_path):
+        """Archives survive a directory save/load round-trip (#283)."""
+        from datetime import datetime
+
+        from soul_protocol.runtime.memory.archival import ConversationArchive
+        from soul_protocol.runtime.storage.file import load_soul_full
+
+        soul = await Soul.birth("Aria")
+
+        archive = ConversationArchive(
+            id="archive-002",
+            start_time=datetime(2026, 6, 1),
+            end_time=datetime(2026, 6, 2),
+            summary="Debugging session on auth module",
+            key_moments=["found the root cause"],
+        )
+        soul._memory._archival.archive_conversation(archive)
+
+        await soul.save(tmp_path)
+
+        soul_dir = tmp_path / soul.did.replace(":", "_")
+        assert (soul_dir / "memory" / "archives.json").exists()
+
+        _, memory_data = await load_soul_full(soul_dir)
+        assert "archives" in memory_data
+        assert len(memory_data["archives"]) == 1
+        assert memory_data["archives"][0]["summary"] == "Debugging session on auth module"


### PR DESCRIPTION
## Description

Fixes #283 — Export and default saves silently drop the archives memory tier.

### The Bug

`pack_soul`'s tier list, `unpack_soul`'s tier list, and the flat on-disk layout (`_FLAT_TIERS`) all omitted `archives` (consolidated conversation summaries). Even though `MemoryManager.to_dict()` emits it and `from_dict()` would restore it, the data was never written to the `.soul` archive or the flat directory layout.

Exporting a soul and re-awakening it therefore loses all archival memory. Because source entries are already marked `archived=True`, the re-archival filter skips them — the lost archives **cannot be regenerated**.

### The Fix

One-line addition in each of three locations:

| File | Change |
|------|--------|
| `src/soul_protocol/runtime/export/pack.py:120` | Added `"archives"` to the pack tier list |
| `src/soul_protocol/runtime/export/unpack.py:110` | Added `"archives"` to the unpack tier list |
| `src/soul_protocol/runtime/storage/file.py:163` | Added `("archives", [])` to `_FLAT_TIERS` |

### Tests Added

- `test_export_awaken_preserves_archives` — seeds an archive, exports to `.soul`, awakens, verifies archive survived
- `test_save_load_preserves_archives` — saves to directory, verifies `archives.json` exists on disk, loads back and checks content

### Verification

