### PR TITLE
ci: stop security-scan crashing on fork PRs; de-flake trust payload test

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -2,6 +2,9 @@
 # Added: 2026-03-05 — Quality gate + security scan for soul-protocol.
 # Updated: 2026-07-02 — Wrap label/comment writes so fork PRs (read-only
 #   token) report the verdict via the run summary instead of 403-crashing.
+# Updated: 2026-07-10 — security-scan: word-boundary the eval/exec patterns so
+#   they stop matching `retrieval(`, and guard its gh pr comment calls so a
+#   fork-PR 403 warns instead of failing the whole job under set -e.
 name: PR Quality Gate
 
 on:
@@ -236,8 +239,8 @@ jobs:
           REPORT=""
 
           PATTERNS=(
-            'eval\s*\('
-            'exec\s*\('
+            '\beval\s*\('
+            '\bexec\s*\('
             'os\.system\s*\('
             'subprocess\..*shell\s*=\s*True'
             '__import__\s*\('
@@ -278,7 +281,8 @@ jobs:
               --body "$COMMENT_BODY" \
               --edit-last 2>/dev/null || \
             gh pr comment ${{ github.event.pull_request.number }} \
-              --body "$COMMENT_BODY"
+              --body "$COMMENT_BODY" 2>/dev/null || \
+            echo "::warning::Could not post the security-scan comment (fork PRs get a read-only token); the flagged patterns are in this log."
 
             echo "::warning::Security patterns found. Review required."
           else
@@ -329,7 +333,8 @@ jobs:
 
           This PR diff appears to contain secrets or API keys. Please remove them immediately and rotate any exposed credentials.
 
-          If these are false positives (e.g., placeholder patterns in tests), a maintainer will verify."
+          If these are false positives (e.g., placeholder patterns in tests), a maintainer will verify." 2>/dev/null || \
+            echo "::warning::Could not post the secrets comment (fork PRs get a read-only token); see the ::error annotations above."
             exit 1
           fi
 

--- a/tests/test_trust_chain/test_chain_manager.py
+++ b/tests/test_trust_chain/test_chain_manager.py
@@ -142,13 +142,20 @@ def test_payload_is_hashed_not_stored():
     """The chain stores only payload_hash; original payload is NOT recoverable."""
     p = Ed25519SignatureProvider.from_seed(b"M" * 32)
     mgr = TrustChainManager(did="did:soul:test", provider=p)
-    secret_payload = {"secret": "do-not-leak", "tokens": ["t1", "t2"]}
+    # Use long, unique sentinels. Short tokens like "t1" give false failures:
+    # they collide by chance with the base64 signature / hex payload_hash that
+    # to_dict() serializes, which vary per run (the signature covers the
+    # timestamp). "do-not-leak-token-1" cannot appear in base64 or hex output.
+    secret_payload = {
+        "secret": "do-not-leak",
+        "tokens": ["do-not-leak-token-1", "do-not-leak-token-2"],
+    }
     e = mgr.append("memory.write", secret_payload)
 
     serialized = mgr.to_dict()
     raw = str(serialized)
     assert "do-not-leak" not in raw
-    assert "t1" not in raw
+    assert "do-not-leak-token-1" not in raw
     assert e.payload_hash  # but the hash is there
 
 


### PR DESCRIPTION
## What

Two CI failures were landing on contributor PRs, and neither was caused by the contributor's code. Both are fixed here.

### 1. `security-scan` fails on PRs from forks (#295, #296)

The dangerous-pattern scan grep used `eval\s*\(`, which matches `retrieval(` (and `set_retrieval_weight(`, ...) all over the memory modules. So an innocent diff touching `manager.py` or `soul.py` set `FOUND=1`, and the step then called `gh pr comment`. Fork PRs run with a read-only `GITHUB_TOKEN`, so the comment returns `GraphQL: Resource not accessible by integration (addComment)`, and under `set -e` that failed the whole `security-scan` job. It surfaced as a red security check on PRs that had no security issue.

Fixes:
- Word-boundary the `eval` / `exec` patterns (`\beval\s*\(`), so they match real `eval(` / `obj.eval(` calls but not `retrieval(`. Verified against a fixture.
- Guard both `gh pr comment` calls with a `|| echo "::warning::..."` fallback, so a fork-token 403 degrades to a log warning instead of crashing the job. This is the same fork-token fix #280 applied to the `check-quality` job, now extended to `security-scan`. Real-secret detection still exits non-zero.

### 2. Flaky trust test (#297)

`test_payload_is_hashed_not_stored` asserted `assert "t1" not in raw`, where `raw` is a serialized chain that includes the base64 Ed25519 signature. The signature covers a wall-clock timestamp, so it changes every run, and roughly 2% of the time the base64 happens to contain the 2-char substring `t1`. That is what failed #297's run (the signature was `...xfatt1Jo...`); the PR just rolled the unlucky 2%. The same suite passed on dev and on #295/#296 by luck.

Fix: use long hyphenated sentinels (`do-not-leak-token-1`) that cannot appear in base64 (no hyphen in the alphabet) or hex output. Ran the test 40x locally with zero failures; by construction it can no longer false-match.

## Why now

Sidhant's #295/#296/#297 (which fix #281/#282/#283) were blocked by red CI that had nothing to do with their changes. This unblocks them and every future fork PR.

## Testing

- YAML parses; all three `security-scan` shell blocks pass `bash -n`.
- `\beval\s*\(` matches `eval(code)` and `obj.eval(s)`, not `retrieval(q)` / `set_retrieval_weight(`.
- The de-flaked test passes 40/40 locally.
