### PR TITLE
fix(#305): preserve created_at in memory_journal round-trip

### DIFF
--- a/rfc/RFC-004-SOUL-FILE-FORMAT.md
+++ b/rfc/RFC-004-SOUL-FILE-FORMAT.md
@@ -167,7 +167,7 @@ And the `SoulContainer` class provides a high-level API:
 
 ```python
 soul = SoulContainer.create("Aria", traits={"role": "assistant"})
-soul.memory.store("episodic", MemoryEntry(content="Hello!"))
+soul.memory.store("episodic", MemoryEntry(content="Hello!", layer="episodic"))
 soul.save("aria.soul")
 
 soul = SoulContainer.open("aria.soul")

--- a/src/soul_protocol/spike/memory_journal.py
+++ b/src/soul_protocol/spike/memory_journal.py
@@ -153,6 +153,7 @@ class JournalBackedMemoryStore:
             "emotion": entry.metadata.get("emotion"),
             "tags": entry.metadata.get("tags", []),
             "source": entry.source,
+            "created_at": entry.created_at.isoformat(),
         }
         event = EventEntry(
             id=uuid4(),
@@ -352,7 +353,7 @@ class JournalBackedMemoryStore:
                 p.get("emotion"),
                 tags_json,
                 p.get("source", ""),
-                event.ts.isoformat(),
+                p.get("created_at") or event.ts.isoformat(),
                 event.seq or 0,
             ),
         )
@@ -414,7 +415,7 @@ class JournalBackedMemoryStore:
             source=source or "",
             layer=tier,
             visibility=MemoryVisibility.BONDED,
-            timestamp=datetime.fromisoformat(created_at),
+            created_at=datetime.fromisoformat(created_at),
             metadata={
                 "importance": importance,
                 "emotion": emotion,

--- a/tests/test_spike/test_memory_journal.py
+++ b/tests/test_spike/test_memory_journal.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import time
+from datetime import UTC
 from pathlib import Path
 
 import pytest
@@ -376,3 +377,25 @@ def test_realworld_search_latency_under_budget(
         store.search(topic, limit=5)
     elapsed = time.monotonic() - start
     assert elapsed < 1.0, f"search on 500 memories took {elapsed:.2f}s"
+
+
+def test_created_at_round_trip(store: JournalBackedMemoryStore):
+    """#305: entries reconstructed from the journal must keep their original
+    created_at, not silently fall back to now()."""
+    from datetime import datetime
+
+    past = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+    entry = MemoryEntry(
+        content="I remember this from 2025",
+        layer="episodic",
+        created_at=past,
+    )
+    store.store("episodic", entry)
+
+    recalled = store.recall("episodic", limit=1)
+    assert len(recalled) == 1
+    assert recalled[0].created_at == past, (
+        f"created_at was not preserved: expected {past}, got {recalled[0].created_at}"
+    )
+    # Also check through the backward-compat property
+    assert recalled[0].timestamp == past


### PR DESCRIPTION
Resolves #305.

## Problem

After #285/#300 turned `MemoryEntry.timestamp` into a read-only property, `spike/memory_journal.py:417` still constructs `MemoryEntry(..., timestamp=..., ...)`. Pydantic v2 silently ignores a kwarg that names a property, so `created_at` falls back to `now()`. Every entry reconstructed from the journal loses its stored creation time.

Additionally, `store()` never persisted the entry's `created_at` in the event payload — `_apply_remembered` used `event.ts` (always `now()`) as the SQLite `created_at`.

## Fix

1. `_row_to_entry` — `timestamp=` → `created_at=` (the actual Pydantic field)
2. `store` — persist `entry.created_at.isoformat()` in the event payload
3. `_apply_remembered` — use `p.get("created_at")` if available, fallback to `event.ts` for pre-fix events
4. `rfc/RFC-004-SOUL-FILE-FORMAT.md:170` — add `layer="episodic"` to `MemoryEntry` example (strict validator now requires `type` or `layer`)

## Testing

- Added `test_created_at_round_trip` — stores with past `created_at`, recalls, asserts timestamp survives
- All 24 existing journal tests pass
- Ruff check passed

